### PR TITLE
fix: Tool.input_schema 从 HashMap 改为 BTreeMap 以消除 prompt cache 序列化顺序不稳定

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -1180,7 +1180,7 @@ mod tests {
         let long_tool_name = "mcp__plugin_very_long_server_name__extremely_long_tool_name_exceeds_63";
         assert!(long_tool_name.len() > TOOL_NAME_MAX_LEN);
 
-        let mut schema = std::collections::HashMap::new();
+        let mut schema = std::collections::BTreeMap::new();
         schema.insert("type".to_string(), serde_json::json!("object"));
         schema.insert("properties".to_string(), serde_json::json!({}));
 
@@ -1231,7 +1231,7 @@ mod tests {
 
         let long_tool_name = "mcp__plugin_very_long_server_name__extremely_long_tool_name_exceeds_63";
 
-        let mut schema = std::collections::HashMap::new();
+        let mut schema = std::collections::BTreeMap::new();
         schema.insert("type".to_string(), serde_json::json!("object"));
         schema.insert("properties".to_string(), serde_json::json!({}));
 

--- a/src/anthropic/prompt_cache.rs
+++ b/src/anthropic/prompt_cache.rs
@@ -509,4 +509,77 @@ mod tests {
         };
         assert_eq!(compute_cache_usage(&cache, &req), (0, 0));
     }
+
+    /// 构造一个普通工具，input_schema 的顶层 key 按给定顺序插入。
+    /// 用于验证：无论插入顺序如何，tool_signature 都稳定（BTreeMap 保证）。
+    fn build_tool_with_schema_order(insert_required_first: bool) -> super::super::types::Tool {
+        use super::super::types::Tool;
+        let mut schema = std::collections::BTreeMap::new();
+        // 故意用不同的插入顺序，模拟上游 JSON 解析的不确定迭代序。
+        if insert_required_first {
+            schema.insert("required".to_string(), serde_json::json!([]));
+            schema.insert("properties".to_string(), serde_json::json!({}));
+            schema.insert("type".to_string(), serde_json::json!("object"));
+        } else {
+            schema.insert("type".to_string(), serde_json::json!("object"));
+            schema.insert("properties".to_string(), serde_json::json!({}));
+            schema.insert("required".to_string(), serde_json::json!([]));
+        }
+        Tool {
+            tool_type: None,
+            name: "my_tool".to_string(),
+            description: "desc".to_string(),
+            input_schema: schema,
+            max_uses: None,
+            cache_control: None,
+        }
+    }
+
+    #[test]
+    fn tool_signature_stable_across_insert_order() {
+        let a = build_tool_with_schema_order(true);
+        let b = build_tool_with_schema_order(false);
+        // 逻辑等价、插入顺序不同的 schema 必须产生相同签名，
+        // 否则 tools 段 hash 抖动会让后续 system/messages 断点连锁 miss。
+        assert_eq!(tool_signature(&a), tool_signature(&b));
+    }
+
+    #[test]
+    fn compute_cache_usage_tools_hit_regardless_of_schema_order() {
+        use super::super::types::{CacheControl, Message, MessagesRequest};
+
+        let make_req = |insert_required_first: bool| {
+            let mut tool = build_tool_with_schema_order(insert_required_first);
+            tool.cache_control = Some(CacheControl {
+                cache_type: "ephemeral".to_string(),
+                ttl: None,
+            });
+            MessagesRequest {
+                model: "claude-sonnet-4-5-20250929".to_string(),
+                max_tokens: 32,
+                messages: vec![Message {
+                    role: "user".to_string(),
+                    content: serde_json::Value::String("Hello".to_string()),
+                }],
+                stream: false,
+                system: None,
+                tools: Some(vec![tool]),
+                tool_choice: None,
+                thinking: None,
+                output_config: None,
+                metadata: None,
+            }
+        };
+
+        let cache = PromptCache::new(None);
+        // 第一次：用一种插入顺序，应写缓存。
+        let (cc1, cr1) = compute_cache_usage(&cache, &make_req(false));
+        assert!(cc1 > 0, "first call should write cache, cc={}", cc1);
+        assert_eq!(cr1, 0);
+
+        // 第二次：换一种插入顺序但逻辑等价，应命中缓存（不再反复 miss）。
+        let (cc2, cr2) = compute_cache_usage(&cache, &make_req(true));
+        assert_eq!(cc2, 0, "second call should hit, not re-create, got cc={}", cc2);
+        assert_eq!(cr2, cc1, "second read should equal first creation");
+    }
 }

--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -1,7 +1,7 @@
 //! Anthropic API 类型定义
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // === 错误响应 ===
 
@@ -232,8 +232,12 @@ pub struct Tool {
     #[serde(default)]
     pub description: String,
     /// 输入参数 schema（普通工具必需，WebSearch 工具无此字段）
+    ///
+    /// 使用 `BTreeMap` 而非 `HashMap`：key 按字典序稳定迭代，保证序列化
+    /// 输出可复现。这对 prompt cache 至关重要——tool 签名参与缓存前缀
+    /// 指纹，若顶层 key 顺序抖动会导致后续 system/messages 断点连锁失效。
     #[serde(default)]
-    pub input_schema: HashMap<String, serde_json::Value>,
+    pub input_schema: BTreeMap<String, serde_json::Value>,
     /// 最大使用次数（仅 WebSearch 工具）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_uses: Option<i32>,


### PR DESCRIPTION
HashMap 迭代顺序随 hash seed 变化，同一 schema 在不同请求中可能序列化
为不同 key 顺序，导致 tool_signature hash 抖动，tools 段之后的 system/messages 断点连锁失效，表现为带多 key input_schema 的请求反复 cache miss。

根因: std::collections::HashMap 的无序迭代 → prompt_cache tool_signature 不稳定。
修复: 将 Tool.input_schema 类型改为 BTreeMap，key 按字典序稳定迭代。

Closes #4