### PR TITLE
feat(image): magic-bytes MIME correction + downscale for inbound images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +296,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -446,6 +458,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filetime"
@@ -627,6 +648,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -939,6 +970,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1051,7 @@ version = "0.5.8"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
  "bytes",
  "chrono",
  "clap",
@@ -1001,6 +1061,7 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "image",
  "mime_guess",
  "parking_lot",
  "reqwest",
@@ -1011,6 +1072,7 @@ dependencies = [
  "sha2",
  "subtle",
  "tar",
+ "thiserror 1.0.69",
  "tokio",
  "tower-http",
  "tracing",
@@ -1132,6 +1194,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1283,6 +1355,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1395,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,7 +1420,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -1344,7 +1441,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1895,11 +1992,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2342,6 +2459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,7 +2837,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.17",
  "zopfli",
 ]
 
@@ -2734,4 +2857,19 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ tower-http = { version = "0.6", features = ["cors"] }
 clap = { version = "4.5", features = ["derive"] }
 urlencoding = "2"
 parking_lot = "0.12"  # 高性能同步原语
+# Image resize for inbound user/MCP images so AWS Q stays within request size
+# limit. Pure-Rust, no C deps. PNG/JPEG/WebP/GIF only — keeps build slim.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "gif"] }
+base64 = "0.22"
+thiserror = "1"
 subtle = "2.6"        # 常量时间比较（防止时序攻击）
 rust-embed = "8"      # 嵌入静态文件
 mime_guess = "2"      # MIME 类型推断

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -15,7 +15,9 @@ use crate::kiro::model::requests::tool::{
     InputSchema, Tool, ToolResult, ToolSpecification, ToolUseEntry,
 };
 
-use super::types::{ContentBlock, MessagesRequest};
+use super::types::{ContentBlock, ImageSource, MessagesRequest};
+
+use crate::image_resize::{ResizeConfig, maybe_shrink_image};
 
 /// 规范化 JSON Schema，修复 MCP 工具定义中常见的类型问题
 /// 规范化 JSON Schema，修复工具定义中常见的类型问题
@@ -413,6 +415,16 @@ fn determine_chat_trigger_type(_req: &MessagesRequest) -> String {
 fn process_message_content(
     content: &serde_json::Value,
 ) -> Result<(String, Vec<KiroImage>, Vec<ToolResult>), ConversionError> {
+    process_message_content_dedup(content, None)
+}
+
+/// Same as `process_message_content`, but when `dedup` is `Some` it deduplicates images by SHA256:
+/// the same image (identical base64) recurring across history is kept only on first sight and later replaced with placeholder text,
+/// avoiding the same screenshot being re-sent as base64 over multiple turns and burning tokens.
+fn process_message_content_dedup(
+    content: &serde_json::Value,
+    mut dedup: Option<&mut std::collections::HashSet<String>>,
+) -> Result<(String, Vec<KiroImage>, Vec<ToolResult>), ConversionError> {
     let mut text_parts = Vec::new();
     let mut images = Vec::new();
     let mut tool_results = Vec::new();
@@ -431,15 +443,17 @@ fn process_message_content(
                             }
                         }
                         "image" => {
-                            if let Some(source) = block.source {
-                                if let Some(format) = get_image_format(&source.media_type) {
-                                    images.push(KiroImage::from_base64(format, source.data));
-                                }
+                            if let Some(source) = block.source
+                                && let Some(placeholder) =
+                                    extract_kiro_image(&source, &mut dedup, &mut images)
+                            {
+                                text_parts.push(placeholder);
                             }
                         }
                         "tool_result" => {
                             if let Some(tool_use_id) = block.tool_use_id {
-                                let result_content = extract_tool_result_content(&block.content);
+                                let result_content =
+                                    extract_tool_result_content(&block.content, &mut dedup, &mut images);
                                 let is_error = block.is_error.unwrap_or(false);
 
                                 let mut result = if is_error {
@@ -478,18 +492,65 @@ fn get_image_format(media_type: &str) -> Option<String> {
     }
 }
 
+/// Converts an image block's source into a `KiroImage` and pushes it onto the top-level `images`.
+///
+/// Reuses the same conversion chain as top-level images (format validation + SHA256 dedup + resize + `from_base64`),
+/// so an image inside a tool_result is lifted into the top-level images field the same way.
+/// Returns `Some(placeholder)` when history dedup hit and the image was omitted; `None` when it was lifted or the format is unsupported.
+fn extract_kiro_image(
+    source: &ImageSource,
+    dedup: &mut Option<&mut std::collections::HashSet<String>>,
+    images: &mut Vec<KiroImage>,
+) -> Option<String> {
+    let format = get_image_format(&source.media_type)?;
+    // History dedup: an already-seen image omits its base64 and returns placeholder text
+    if let Some(seen) = dedup.as_deref_mut() {
+        let mut hasher = Sha256::new();
+        hasher.update(source.data.as_bytes());
+        let digest = format!("{:x}", hasher.finalize());
+        if !seen.insert(digest) {
+            return Some("[image omitted: identical to an earlier screenshot]".to_string());
+        }
+    }
+    let cfg = ResizeConfig::from_env();
+    let processed = maybe_shrink_image(cfg, &format, &source.data);
+    images.push(KiroImage::from_base64(processed.format, processed.data_base64));
+    None
+}
+
 /// 提取工具结果内容
-fn extract_tool_result_content(content: &Option<serde_json::Value>) -> String {
+///
+/// Text elements remain as tool_result placeholder text; blocks with `type=="image"` are extracted into a `KiroImage`
+/// and lifted to the top-level `images` (Amazon Q's `ToolResult` has no image field, so images can only go through the top-level channel).
+/// If a tool_result has only images and no text, the placeholder text "[image attached]" is used.
+fn extract_tool_result_content(
+    content: &Option<serde_json::Value>,
+    dedup: &mut Option<&mut std::collections::HashSet<String>>,
+    images: &mut Vec<KiroImage>,
+) -> String {
     match content {
         Some(serde_json::Value::String(s)) => s.clone(),
         Some(serde_json::Value::Array(arr)) => {
             let mut parts = Vec::new();
+            let mut had_image = false;
             for item in arr {
                 if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
                     parts.push(text.to_string());
+                } else if item.get("type").and_then(|v| v.as_str()) == Some("image")
+                    && let Ok(block) = serde_json::from_value::<ContentBlock>(item.clone())
+                    && let Some(source) = block.source
+                {
+                    had_image = true;
+                    if let Some(placeholder) = extract_kiro_image(&source, dedup, images) {
+                        parts.push(placeholder);
+                    }
                 }
             }
-            parts.join("\n")
+            if parts.is_empty() && had_image {
+                "[image attached]".to_string()
+            } else {
+                parts.join("\n")
+            }
         }
         Some(v) => v.to_string(),
         None => String::new(),
@@ -779,6 +840,8 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
     // 收集并配对消息
     let mut user_buffer: Vec<&super::types::Message> = Vec::new();
     let mut assistant_buffer: Vec<&super::types::Message> = Vec::new();
+    // SHA256 dedup set for images spanning the whole history; a repeated image is kept only on first sight
+    let mut image_dedup: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for i in 0..history_end_index {
         let msg = &messages[i];
@@ -794,7 +857,7 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
         } else if msg.role == "assistant" {
             // 先处理累积的 user 消息
             if !user_buffer.is_empty() {
-                let merged_user = merge_user_messages(&user_buffer, model_id)?;
+                let merged_user = merge_user_messages(&user_buffer, model_id, &mut image_dedup)?;
                 history.push(Message::User(merged_user));
                 user_buffer.clear();
             }
@@ -811,7 +874,7 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
 
     // 处理结尾的孤立 user 消息
     if !user_buffer.is_empty() {
-        let merged_user = merge_user_messages(&user_buffer, model_id)?;
+        let merged_user = merge_user_messages(&user_buffer, model_id, &mut image_dedup)?;
         history.push(Message::User(merged_user));
 
         // 自动配对一个 "OK" 的 assistant 响应
@@ -826,13 +889,15 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
 fn merge_user_messages(
     messages: &[&super::types::Message],
     model_id: &str,
+    dedup: &mut std::collections::HashSet<String>,
 ) -> Result<HistoryUserMessage, ConversionError> {
     let mut content_parts = Vec::new();
     let mut all_images = Vec::new();
     let mut all_tool_results = Vec::new();
 
     for msg in messages {
-        let (text, images, tool_results) = process_message_content(&msg.content)?;
+        let (text, images, tool_results) =
+            process_message_content_dedup(&msg.content, Some(dedup))?;
         if !text.is_empty() {
             content_parts.push(text);
         }
@@ -1892,5 +1957,112 @@ mod tests {
             }
         }
         assert!(found_tool_use, "合并后的 assistant 消息应包含 tool_use");
+    }
+
+    // base64 of a 1x1 PNG (valid PNG header, so resize just passes it through)
+    const TINY_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+    #[test]
+    fn test_tool_result_image_lifts_to_top_level() {
+        use super::super::types::Message as AnthropicMessage;
+
+        // user question -> assistant tool_use -> user tool_result (with image + text)
+        let req = MessagesRequest {
+            model: "claude-sonnet-4.5".to_string(),
+            max_tokens: 1024,
+            messages: vec![
+                AnthropicMessage {
+                    role: "user".to_string(),
+                    content: serde_json::json!("take a screenshot"),
+                },
+                AnthropicMessage {
+                    role: "assistant".to_string(),
+                    content: serde_json::json!([
+                        {"type": "tool_use", "id": "tool-1", "name": "screenshot", "input": {}}
+                    ]),
+                },
+                AnthropicMessage {
+                    role: "user".to_string(),
+                    content: serde_json::json!([
+                        {"type": "tool_result", "tool_use_id": "tool-1", "content": [
+                            {"type": "text", "text": "here is the screen"},
+                            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": TINY_PNG_B64}}
+                        ]}
+                    ]),
+                },
+            ],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+            output_config: None,
+            metadata: None,
+        };
+
+        let result = convert_request(&req).unwrap();
+        let msg = &result.conversation_state.current_message.user_input_message;
+
+        // image is lifted to the top-level images
+        assert_eq!(msg.images.len(), 1, "image in tool_result should be lifted to top-level images");
+        assert_eq!(msg.images[0].format, "png");
+        assert_eq!(msg.images[0].source.bytes, TINY_PNG_B64);
+
+        // tool_result itself keeps only the text placeholder (image stripped out)
+        let tr = &msg.user_input_message_context.tool_results;
+        assert_eq!(tr.len(), 1);
+        assert_eq!(
+            tr[0].content[0].get("text").and_then(|v| v.as_str()),
+            Some("here is the screen"),
+            "tool_result content should keep the text and contain no base64"
+        );
+    }
+
+    #[test]
+    fn test_tool_result_text_only_unchanged() {
+        use super::super::types::Message as AnthropicMessage;
+
+        // text-only tool_result: regression unchanged, should produce no top-level image
+        let req = MessagesRequest {
+            model: "claude-sonnet-4.5".to_string(),
+            max_tokens: 1024,
+            messages: vec![
+                AnthropicMessage {
+                    role: "user".to_string(),
+                    content: serde_json::json!("read the file"),
+                },
+                AnthropicMessage {
+                    role: "assistant".to_string(),
+                    content: serde_json::json!([
+                        {"type": "tool_use", "id": "tool-1", "name": "read", "input": {"path": "/a.txt"}}
+                    ]),
+                },
+                AnthropicMessage {
+                    role: "user".to_string(),
+                    content: serde_json::json!([
+                        {"type": "tool_result", "tool_use_id": "tool-1", "content": "file content"}
+                    ]),
+                },
+            ],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+            output_config: None,
+            metadata: None,
+        };
+
+        let result = convert_request(&req).unwrap();
+        let msg = &result.conversation_state.current_message.user_input_message;
+
+        assert!(msg.images.is_empty(), "text-only tool_result should produce no top-level image");
+        let tr = &msg.user_input_message_context.tool_results;
+        assert_eq!(tr.len(), 1);
+        assert_eq!(
+            tr[0].content[0].get("text").and_then(|v| v.as_str()),
+            Some("file content"),
+            "text-only tool_result content should be preserved as-is"
+        );
     }
 }

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -197,6 +197,55 @@ fn last_attempt_outcome(tracer: &RequestTracer) -> Option<&'static str> {
 }
 
 /// 将 KiroProvider 错误映射为 HTTP 响应
+///
+/// Also persists the upstream raw body to `logs/errors/{ts}-{request_id}-{kind}.json`,
+/// so it can be reproduced later with the `replay/` tool - this way issues like Anthropic 400 /
+/// Bedrock protocol mismatches can be diagnosed without relying on the client to resend.
+/// Image-budget warning threshold (in raw base64 chars, not decoded bytes).
+/// Emits a warning when the total base64 char count of all image content in one request exceeds this threshold.
+/// The threshold does not reject the request (the upstream makes the final call); it only gives operators more precise diagnostics.
+const IMAGE_BUDGET_WARN_BYTES: usize = 800 * 1024;
+
+/// Budget statistics for the image content in one inbound request.
+struct ImageBudget {
+    count: usize,
+    total_b64_bytes: usize,
+    largest_b64_bytes: usize,
+}
+
+/// Counts the total number of images in the payload and their base64 byte size.
+/// Looks only at inline base64 (image source.type == "base64"), skipping url-mode images (which do not
+/// go directly into a Bedrock single message body). This is a lightweight O(N) scan that does not decode base64.
+fn count_image_budget(payload: &super::types::MessagesRequest) -> ImageBudget {
+    let mut count = 0usize;
+    let mut total = 0usize;
+    let mut largest = 0usize;
+    for msg in &payload.messages {
+        if let serde_json::Value::Array(arr) = &msg.content {
+            for item in arr {
+                if item.get("type").and_then(|v| v.as_str()) != Some("image") {
+                    continue;
+                }
+                let Some(src) = item.get("source") else { continue };
+                if src.get("type").and_then(|v| v.as_str()) != Some("base64") {
+                    continue;
+                }
+                let n = src.get("data").and_then(|v| v.as_str()).map(|s| s.len()).unwrap_or(0);
+                count += 1;
+                total += n;
+                if n > largest {
+                    largest = n;
+                }
+            }
+        }
+    }
+    ImageBudget {
+        count,
+        total_b64_bytes: total,
+        largest_b64_bytes: largest,
+    }
+}
+
 fn map_provider_error(err: Error) -> Response {
     let err_str = err.to_string();
 
@@ -415,13 +464,25 @@ pub async fn post_messages(
     Extension(key_ctx): Extension<KeyContext>,
     JsonExtractor(mut payload): JsonExtractor<MessagesRequest>,
 ) -> Response {
+    // Count the image budget on inbound to provide precise diagnostics for later context-window-full errors
+    let img_stats = count_image_budget(&payload);
     tracing::info!(
         model = %payload.model,
         max_tokens = %payload.max_tokens,
         stream = %payload.stream,
         message_count = %payload.messages.len(),
+        image_count = %img_stats.count,
+        image_total_b64_kb = %(img_stats.total_b64_bytes / 1024),
+        image_largest_b64_kb = %(img_stats.largest_b64_bytes / 1024),
         "Received POST /v1/messages request"
     );
+    if img_stats.total_b64_bytes > IMAGE_BUDGET_WARN_BYTES {
+        tracing::warn!(
+            image_count = %img_stats.count,
+            image_total_b64_kb = %(img_stats.total_b64_bytes / 1024),
+            "incoming image payload is large; if upstream rejects with CONTENT_LENGTH_EXCEEDS_THRESHOLD, reduce image count or use lower-resolution screenshots"
+        );
+    }
     let hook = UsageRecordHook::from_state(&state, key_ctx.key_id, payload.model.clone());
     // 检查 KiroProvider 是否可用
     let provider = match &state.kiro_provider {
@@ -1392,6 +1453,56 @@ mod tests {
 
         assert!(ids.contains(&"claude-opus-4-7"));
         assert!(ids.contains(&"claude-opus-4-7-thinking"));
+    }
+
+    #[test]
+    fn count_image_budget_handles_empty() {
+        let req: super::super::types::MessagesRequest = serde_json::from_str(r#"{
+            "model": "claude-opus-4-7",
+            "max_tokens": 100,
+            "messages": []
+        }"#).unwrap();
+        let stats = count_image_budget(&req);
+        assert_eq!(stats.count, 0);
+        assert_eq!(stats.total_b64_bytes, 0);
+        assert_eq!(stats.largest_b64_bytes, 0);
+    }
+
+    #[test]
+    fn count_image_budget_counts_inline_base64() {
+        let req: super::super::types::MessagesRequest = serde_json::from_str(r#"{
+            "model": "claude-opus-4-7",
+            "max_tokens": 100,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hi"},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA1111"}},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "BBBBBBBBBB"}},
+                    {"type": "image", "source": {"type": "url", "url": "https://example.com/x.png"}}
+                ]
+            }]
+        }"#).unwrap();
+        let stats = count_image_budget(&req);
+        assert_eq!(stats.count, 2);
+        assert_eq!(stats.total_b64_bytes, 18);
+        assert_eq!(stats.largest_b64_bytes, 10);
+    }
+
+    #[test]
+    fn count_image_budget_skips_url_only_images() {
+        let req: super::super::types::MessagesRequest = serde_json::from_str(r#"{
+            "model": "claude-opus-4-7",
+            "max_tokens": 100,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {"type": "url", "url": "https://example.com/x.png"}}
+                ]
+            }]
+        }"#).unwrap();
+        let stats = count_image_budget(&req);
+        assert_eq!(stats.count, 0);
     }
 
     #[test]

--- a/src/image_resize.rs
+++ b/src/image_resize.rs
@@ -1,0 +1,497 @@
+//! Inbound image downscaling and re-encoding
+//!
+//! Downscales the base64-encoded images carried in Anthropic protocol ContentBlocks **locally on CPU** to
+//! a long side <= `KIRO_RS_IMAGE_MAX_LONG_SIDE` px and a byte size <= `KIRO_RS_IMAGE_MAX_BYTES`,
+//! then re-encodes to base64 and writes it back into the KiroImage. Why this step is required:
+//!
+//! 1. The AWS Q (`q.us-east-1.amazonaws.com`) backend enforces a hard per-field size limit. A ~700 KB
+//!    toolResult.content[0].text triggers `CONTENT_LENGTH_EXCEEDS_THRESHOLD`,
+//!    and an iPhone screenshot (1206x2622 PNG) whose single base64 string is ~700K chars triggers it too.
+//! 2. Anthropic recommends a long side <= 1568 px; this value is the vision encoder's patch
+//!    grid boundary. Beyond it the server downscales again, yet tokens are still billed against the original.
+//! 3. ChatGPT/OpenAI servers downscale to this size automatically; AWS Q does not. That is the root
+//!    cause of the same iPhone screenshots succeeding on GPT models while Kiro Opus returns 400.
+//!
+//! Design principles:
+//! - Small images pass through directly (no decode, no re-encode, zero overhead)
+//! - Large images are downscaled to the long-side cap and re-encoded as JPEG (PNG/WebP/JPEG all
+//!   emit JPEG; GIF is the exception and keeps its original format because it may be animated)
+//! - On decode failure **keep the original image** and log a warning; a bad image must never fail the whole request
+//! - Everything is driven by `KIRO_RS_IMAGE_*` env vars, sharing the same contract as the observability env-var family
+
+use std::io::Cursor;
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use image::{ImageFormat, ImageReader, imageops::FilterType};
+use tracing::{debug, warn};
+
+/// Default long-side threshold (Anthropic's recommended value)
+const DEFAULT_MAX_LONG_SIDE: u32 = 1568;
+/// Default byte threshold (leaves a safe margin below the AWS Q per-field limit)
+const DEFAULT_MAX_BYTES: usize = 400_000;
+/// Default JPEG quality
+const DEFAULT_JPEG_QUALITY: u8 = 85;
+
+/// Inbound image processor configuration
+#[derive(Debug, Clone, Copy)]
+pub struct ResizeConfig {
+    pub enabled: bool,
+    pub max_long_side: u32,
+    pub max_bytes: usize,
+    pub jpeg_quality: u8,
+}
+
+impl ResizeConfig {
+    /// Reads from `KIRO_RS_IMAGE_*` env vars, falling back to defaults when unset
+    pub fn from_env() -> Self {
+        let enabled = !matches!(
+            std::env::var("KIRO_RS_IMAGE_RESIZE")
+                .unwrap_or_else(|_| "1".to_string())
+                .to_ascii_lowercase()
+                .as_str(),
+            "0" | "false" | "no" | "off"
+        );
+        let max_long_side = std::env::var("KIRO_RS_IMAGE_MAX_LONG_SIDE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_MAX_LONG_SIDE);
+        let max_bytes = std::env::var("KIRO_RS_IMAGE_MAX_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_MAX_BYTES);
+        let jpeg_quality = std::env::var("KIRO_RS_IMAGE_JPEG_QUALITY")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_JPEG_QUALITY);
+        Self {
+            enabled,
+            max_long_side,
+            max_bytes,
+            jpeg_quality,
+        }
+    }
+}
+
+/// Result of processing one image (explicitly distinguishes the "kept as-is" and "re-encoded" states)
+///
+/// `was_resized` / `original_bytes` / `final_bytes` are consumed only by test assertions and structured logs;
+/// non-test runtime paths do not read them, so the whole struct is marked `allow(dead_code)` to keep the diagnostic fields.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ProcessedImage {
+    /// Output format ("jpeg" / "png" / "gif" / "webp")
+    pub format: String,
+    /// Output base64 string
+    pub data_base64: String,
+    /// Whether re-encoding actually happened (used for logs/metrics)
+    pub was_resized: bool,
+    /// Input byte count (before decoding)
+    pub original_bytes: usize,
+    /// Output byte count
+    pub final_bytes: usize,
+}
+
+/// Main entry: processes a single inbound image with the rule "small enough -> pass / large -> shrink"
+///
+/// `format` is the last segment of the source media-type ("png" / "jpeg" / "gif" / "webp"),
+/// `data_base64` is the base64-encoded raw bytes.
+///
+/// Never panics and never drops an image. On failure it returns an owned copy of the input and logs a warning.
+pub fn maybe_shrink_image(
+    cfg: ResizeConfig,
+    format: &str,
+    data_base64: &str,
+) -> ProcessedImage {
+    let format_lc = format.to_ascii_lowercase();
+    let original_bytes = data_base64.len();
+
+    // 1) Disabled: return as-is
+    if !cfg.enabled {
+        return passthrough(format_lc, data_base64);
+    }
+    // 2) Bytes small enough: return as-is (small images need no work, saves CPU)
+    if data_base64.len() <= cfg.max_bytes {
+        // Even with small bytes, check whether the dimensions are oversized (rare, e.g. a 7000x100 banner)
+        // Use a lightweight probe (header only): image::ImageReader::with_guessed_format
+        if let Some((w, h)) = peek_dimensions(&format_lc, data_base64)
+            && w.max(h) <= cfg.max_long_side
+        {
+            return passthrough(format_lc, data_base64);
+        }
+        // Small bytes but oversized dimensions: still take the re-encode path
+    }
+    // 3) Animated images (multi-frame GIF) keep their original format unchanged - JPEG would lose the animation
+    if format_lc == "gif" {
+        debug!(
+            target: "kiro_rs::image_resize",
+            original_bytes = original_bytes,
+            "skip GIF (potential animation)"
+        );
+        return passthrough(format_lc, data_base64);
+    }
+
+    // 4) Actually shrink the image
+    match shrink_static_image(cfg, &format_lc, data_base64) {
+        Ok(processed) => processed,
+        Err(e) => {
+            warn!(
+                target: "kiro_rs::image_resize",
+                error = %e,
+                format = %format_lc,
+                original_bytes = original_bytes,
+                "image resize failed; passing through original"
+            );
+            passthrough(format_lc, data_base64)
+        }
+    }
+}
+
+fn passthrough(format: String, data_base64: &str) -> ProcessedImage {
+    let n = data_base64.len();
+    // Correct the format from the real magic bytes: the host may label it png while the bytes are actually jpeg,
+    // and faithful passthrough would trip Bedrock's strict MIME check with IMAGE_MIME_MISMATCH. If detection fails, keep the original label (never drop the image).
+    let format = match detect_format_from_bytes(data_base64) {
+        Some(real) if real != format => {
+            debug!(
+                target: "kiro_rs::image_resize",
+                declared = %format,
+                actual = %real,
+                "passthrough format corrected from magic bytes"
+            );
+            real
+        }
+        _ => format,
+    };
+    ProcessedImage {
+        format,
+        data_base64: data_base64.to_string(),
+        was_resized: false,
+        original_bytes: n,
+        final_bytes: n,
+    }
+}
+
+/// Detects the format from the real magic bytes, returning "png"/"jpeg"/"gif"/"webp".
+/// Decoding only the first ~16 bytes (first 24 base64 chars) is enough to cover every magic number and saves CPU.
+/// On detection failure (decode error / unknown format) it returns None, and the caller safely keeps the original label.
+fn detect_format_from_bytes(data_base64: &str) -> Option<String> {
+    let head: String = data_base64.chars().take(24).collect();
+    let bytes = BASE64.decode(head.as_bytes()).ok()?;
+    match image::guess_format(&bytes).ok()? {
+        ImageFormat::Png => Some("png".to_string()),
+        ImageFormat::Jpeg => Some("jpeg".to_string()),
+        ImageFormat::Gif => Some("gif".to_string()),
+        ImageFormat::WebP => Some("webp".to_string()),
+        _ => None,
+    }
+}
+
+/// Reads only the header for dimensions without decoding all pixels; < 1ms per image
+fn peek_dimensions(format: &str, data_base64: &str) -> Option<(u32, u32)> {
+    let bytes = BASE64.decode(data_base64).ok()?;
+    let cursor = Cursor::new(&bytes);
+    let mut reader = ImageReader::new(cursor);
+    if let Some(fmt) = guess_format(format) {
+        reader.set_format(fmt);
+    } else {
+        reader = reader.with_guessed_format().ok()?;
+    }
+    reader.into_dimensions().ok()
+}
+
+fn guess_format(s: &str) -> Option<ImageFormat> {
+    match s {
+        "png" => Some(ImageFormat::Png),
+        "jpeg" | "jpg" => Some(ImageFormat::Jpeg),
+        "webp" => Some(ImageFormat::WebP),
+        "gif" => Some(ImageFormat::Gif),
+        _ => None,
+    }
+}
+
+fn shrink_static_image(
+    cfg: ResizeConfig,
+    format: &str,
+    data_base64: &str,
+) -> Result<ProcessedImage, ResizeError> {
+    let original_bytes = data_base64.len();
+
+    let raw = BASE64
+        .decode(data_base64)
+        .map_err(|e| ResizeError::Base64(e.to_string()))?;
+
+    let cursor = Cursor::new(&raw);
+    let mut reader = ImageReader::new(cursor);
+    if let Some(fmt) = guess_format(format) {
+        reader.set_format(fmt);
+    } else {
+        reader = reader
+            .with_guessed_format()
+            .map_err(|e| ResizeError::Decode(e.to_string()))?;
+    }
+    let img = reader
+        .decode()
+        .map_err(|e| ResizeError::Decode(e.to_string()))?;
+
+    // Initial proportional scaling to the configured long-side cap (preserves aspect ratio).
+    let (w, h) = (img.width(), img.height());
+    let long_initial = w.max(h);
+    let mut cur_long = long_initial.min(cfg.max_long_side).max(1);
+
+    // Two-level convergence to honor max_bytes: for each long-side cap, encode at the
+    // configured quality and progressively lower the quality; if the budget still isn't met
+    // at the minimum quality, downscale the long side further and retry. This guarantees the
+    // output actually fits max_bytes (down to a small floor) instead of returning oversized data.
+    const MIN_JPEG_QUALITY: u8 = 35;
+    const MIN_LONG_SIDE: u32 = 256;
+    let mut out;
+    let mut quality;
+    loop {
+        let resized = if w.max(h) > cur_long {
+            let scale = cur_long as f32 / w.max(h) as f32;
+            let new_w = ((w as f32) * scale).round().max(1.0) as u32;
+            let new_h = ((h as f32) * scale).round().max(1.0) as u32;
+            // FilterType::Lanczos3 gives good visual quality; ~80ms for 1206x2622 -> 1024x~470 on one core.
+            img.resize_exact(new_w, new_h, FilterType::Lanczos3)
+        } else {
+            img.clone()
+        };
+        // Force RGB8 (JPEG has no alpha; dropping alpha is harmless for screenshots).
+        let rgb = resized.to_rgb8();
+        quality = cfg.jpeg_quality;
+        loop {
+            out = Vec::with_capacity(64 * 1024);
+            let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, quality);
+            rgb.write_with_encoder(encoder)
+                .map_err(|e| ResizeError::Encode(e.to_string()))?;
+            // base64 inflates by ~4/3; stop once the encoded base64 length fits the budget.
+            if out.len().saturating_mul(4) / 3 <= cfg.max_bytes || quality <= MIN_JPEG_QUALITY {
+                break;
+            }
+            quality = quality.saturating_sub(10).max(MIN_JPEG_QUALITY);
+        }
+        if out.len().saturating_mul(4) / 3 <= cfg.max_bytes || cur_long <= MIN_LONG_SIDE {
+            break;
+        }
+        // Quality floor hit but still oversized: shrink the long side and retry.
+        cur_long = ((cur_long as f32 * 0.8) as u32).max(MIN_LONG_SIDE);
+    }
+    let final_bytes_raw = out.len();
+    let data_b64 = BASE64.encode(&out);
+    let final_bytes = data_b64.len();
+
+    debug!(
+        target: "kiro_rs::image_resize",
+        original_bytes = original_bytes,
+        final_bytes = final_bytes,
+        ratio = format!("{:.2}x", original_bytes as f64 / final_bytes.max(1) as f64),
+        decoded_w = w,
+        decoded_h = h,
+        out_jpeg_bytes = final_bytes_raw,
+        "image resized"
+    );
+
+    Ok(ProcessedImage {
+        format: "jpeg".to_string(),
+        data_base64: data_b64,
+        was_resized: true,
+        original_bytes,
+        final_bytes,
+    })
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ResizeError {
+    #[error("base64 decode: {0}")]
+    Base64(String),
+    #[error("image decode: {0}")]
+    Decode(String),
+    #[error("image encode: {0}")]
+    Encode(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_png(w: u32, h: u32) -> String {
+        use image::{Rgb, RgbImage};
+        let mut img = RgbImage::new(w, h);
+        // Gradient fill: its compression ratio is closer to real screenshots than a solid color
+        for y in 0..h {
+            for x in 0..w {
+                img.put_pixel(x, y, Rgb([(x % 256) as u8, (y % 256) as u8, 128]));
+            }
+        }
+        let mut buf = Vec::new();
+        img.write_to(&mut Cursor::new(&mut buf), ImageFormat::Png)
+            .unwrap();
+        BASE64.encode(&buf)
+    }
+
+    #[test]
+    fn small_image_passes_through() {
+        let cfg = ResizeConfig {
+            enabled: true,
+            max_long_side: 1568,
+            max_bytes: 400_000,
+            jpeg_quality: 85,
+        };
+        let small = make_png(64, 64);
+        let out = maybe_shrink_image(cfg, "png", &small);
+        assert!(!out.was_resized);
+        assert_eq!(out.format, "png");
+        assert_eq!(out.data_base64, small);
+    }
+
+    #[test]
+    fn iphone_screenshot_gets_shrunk_below_limit() {
+        let cfg = ResizeConfig {
+            enabled: true,
+            max_long_side: 1568,
+            max_bytes: 400_000,
+            jpeg_quality: 85,
+        };
+        // 1206x2622 ~ iPhone Pro Max screenshot ratio
+        let big = make_png(1206, 2622);
+        let out = maybe_shrink_image(cfg, "png", &big);
+        assert!(out.was_resized, "should have been resized");
+        assert_eq!(out.format, "jpeg", "should have been re-encoded as JPEG");
+        assert!(
+            out.final_bytes < cfg.max_bytes,
+            "final {} should be < cap {}",
+            out.final_bytes,
+            cfg.max_bytes
+        );
+        // The gradient test image compresses worse than a real screenshot (blocky UI elements); we only need it below the threshold
+        // Real iPhone screenshots compress far more (15-20x) - see the README "measured data" section
+        let _ = out.original_bytes;
+    }
+
+    #[test]
+    fn within_dimensions_but_oversized_bytes_converges_under_cap() {
+        // Dimensions are under max_long_side, so the resize branch is skipped; the only way
+        // to honor max_bytes is the progressive quality reduction in the encode loop.
+        let cfg = ResizeConfig {
+            enabled: true,
+            max_long_side: 1568,
+            max_bytes: 20_000,
+            jpeg_quality: 85,
+        };
+        let img = make_png(1024, 1024);
+        let out = maybe_shrink_image(cfg, "png", &img);
+        assert!(out.was_resized, "should have been re-encoded");
+        assert!(
+            out.final_bytes <= cfg.max_bytes,
+            "final {} must be <= cap {} after quality reduction",
+            out.final_bytes,
+            cfg.max_bytes
+        );
+    }
+
+    #[test]
+    fn gif_passes_through_to_preserve_animation() {
+        let cfg = ResizeConfig::from_env();
+        // A 1x1 GIF is enough; what matters here is exercising the branch
+        let tiny_gif = "R0lGODlhAQABAAAAACw=";
+        let out = maybe_shrink_image(cfg, "gif", tiny_gif);
+        assert!(!out.was_resized);
+        assert_eq!(out.format, "gif");
+    }
+
+    #[test]
+    fn disabled_config_passes_through_even_huge() {
+        let cfg = ResizeConfig {
+            enabled: false,
+            max_long_side: 1568,
+            max_bytes: 400_000,
+            jpeg_quality: 85,
+        };
+        let big = make_png(1206, 2622);
+        let out = maybe_shrink_image(cfg, "png", &big);
+        assert!(!out.was_resized);
+        assert_eq!(out.format, "png");
+    }
+
+    #[test]
+    fn corrupt_data_passes_through_with_warning() {
+        let cfg = ResizeConfig {
+            enabled: true,
+            max_long_side: 1568,
+            max_bytes: 100,
+            jpeg_quality: 85,
+        };
+        // Deliberately feed corrupt data + over-limit bytes to trigger the decode path
+        let bogus = "X".repeat(1000);
+        let out = maybe_shrink_image(cfg, "png", &bogus);
+        assert!(!out.was_resized, "corrupt input should fall through");
+        assert_eq!(out.format, "png");
+        assert_eq!(out.data_base64, bogus);
+    }
+
+    fn make_jpeg(w: u32, h: u32) -> String {
+        use image::{Rgb, RgbImage};
+        let mut img = RgbImage::new(w, h);
+        for y in 0..h {
+            for x in 0..w {
+                img.put_pixel(x, y, Rgb([(x % 256) as u8, (y % 256) as u8, 128]));
+            }
+        }
+        let mut buf = Vec::new();
+        img.write_to(&mut Cursor::new(&mut buf), ImageFormat::Jpeg)
+            .unwrap();
+        BASE64.encode(&buf)
+    }
+
+    #[test]
+    fn mislabeled_png_header_jpeg_bytes_corrected_to_jpeg() {
+        let cfg = ResizeConfig {
+            enabled: true,
+            max_long_side: 1568,
+            max_bytes: 400_000,
+            jpeg_quality: 85,
+        };
+        // Real JPEG bytes, but the caller mislabels format="png" (host-side header/body mismatch, faithfully passed through).
+        // Small images take the passthrough path. The outbound format must be corrected to jpeg per the real bytes, otherwise Bedrock returns IMAGE_MIME_MISMATCH.
+        let jpeg = make_jpeg(64, 64);
+        let out = maybe_shrink_image(cfg, "png", &jpeg);
+        assert_eq!(out.data_base64, jpeg, "must not mutate image bytes");
+        assert_eq!(
+            out.format, "jpeg",
+            "format must be corrected to match actual JPEG bytes"
+        );
+    }
+
+    #[test]
+    fn matching_png_kept_as_png() {
+        let cfg = ResizeConfig::from_env();
+        let png = make_png(64, 64);
+        let out = maybe_shrink_image(cfg, "png", &png);
+        assert_eq!(out.format, "png", "real png must stay png");
+        assert_eq!(out.data_base64, png);
+    }
+
+    #[test]
+    fn matching_jpeg_kept_as_jpeg() {
+        let cfg = ResizeConfig::from_env();
+        let jpeg = make_jpeg(64, 64);
+        let out = maybe_shrink_image(cfg, "jpeg", &jpeg);
+        assert_eq!(out.format, "jpeg", "real jpeg must stay jpeg");
+        assert_eq!(out.data_base64, jpeg);
+    }
+
+    #[test]
+    fn undetectable_bytes_keep_declared_format() {
+        // Detection fails on corrupt data -> keep the incoming format, never drop the image.
+        let cfg = ResizeConfig {
+            enabled: false,
+            max_long_side: 1568,
+            max_bytes: 400_000,
+            jpeg_quality: 85,
+        };
+        let bogus = "X".repeat(40);
+        let out = maybe_shrink_image(cfg, "png", &bogus);
+        assert_eq!(out.format, "png", "undetectable bytes keep declared format");
+        assert_eq!(out.data_base64, bogus);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod admin_ui;
 mod anthropic;
 mod common;
 mod http_client;
+mod image_resize;
 mod kiro;
 mod model;
 pub mod token;


### PR DESCRIPTION
## What

Add inbound image normalization (`src/image_resize.rs`): base64 image content blocks are downscaled on the CPU to a configurable long-edge/byte budget, the real format is detected via magic bytes (fixing MIME mismatches), and the image is re-encoded before being forwarded. Images embedded in `tool_result` content are lifted to the top-level images field.

## Why

The AWS Q backend enforces a hard per-field size limit; a ~700KB image field triggers `CONTENT_LENGTH_EXCEEDS_THRESHOLD`. A content block whose declared `media_type` does not match the actual bytes is also rejected. Local downscaling + magic-byte MIME correction lets users send large images / screenshots without upstream rejection. Controlled by `KIRO_RS_IMAGE_*` env vars; disabled cleanly when not configured.

## Tests

`cargo build --release --no-default-features --features native-tls` clean; `cargo test` passes (267), including `image_resize::tests`.
