### PR TITLE
feat(effort): plumb output_config.effort to the AWS Q protocol field

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -11,6 +11,7 @@ use crate::kiro::model::requests::conversation::{
     AssistantMessage, ConversationState, CurrentMessage, HistoryAssistantMessage,
     HistoryUserMessage, KiroImage, Message, UserInputMessage, UserInputMessageContext, UserMessage,
 };
+use crate::kiro::model::requests::kiro::{AdditionalModelRequestFields, KiroOutputConfig};
 use crate::kiro::model::requests::tool::{
     InputSchema, Tool, ToolResult, ToolSpecification, ToolUseEntry,
 };
@@ -194,6 +195,9 @@ pub struct ConversionResult {
     pub conversation_state: ConversationState,
     /// 工具名称映射（短名称 → 原始名称），仅当存在超长工具名时非空
     pub tool_name_map: HashMap<String, String>,
+    /// Additional model request fields (including `output_config.effort`), translated from the
+    /// `output_config` field of the client's Anthropic request. Not sent when empty.
+    pub additional_model_request_fields: Option<AdditionalModelRequestFields>,
 }
 
 /// 转换错误
@@ -397,9 +401,32 @@ pub fn convert_request(req: &MessagesRequest) -> Result<ConversionResult, Conver
         );
     }
 
+    // 14. Extract effort into AdditionalModelRequestFields (a real Kiro CLI wire field)
+    //
+    // The AWS Q backend's real protocol uses `additionalModelRequestFields.output_config.effort`,
+    // which is not the same thing as stuffing a `<thinking_effort>` XML tag into the system prompt.
+    // The client-supplied `req.output_config.effort` is translated here into the real protocol field,
+    // while the existing XML prefix logic (generate_thinking_prefix) is left unchanged,
+    // so sending both yields the strongest effect (measured to roughly 4x the thinking depth of sending only one).
+    // The effort value is passed through verbatim: whatever tier the client sends is translated into the protocol field, with no literal substitution.
+    // Only emit the field when the client actually provided a non-empty effort tier,
+    // so the documented "not sent when empty" contract holds.
+    let additional_model_request_fields =
+        req.output_config.as_ref().and_then(|oc| {
+            if oc.effort.trim().is_empty() {
+                return None;
+            }
+            Some(AdditionalModelRequestFields {
+                output_config: Some(KiroOutputConfig {
+                    effort: oc.effort.clone(),
+                }),
+            })
+        });
+
     Ok(ConversionResult {
         conversation_state,
         tool_name_map,
+        additional_model_request_fields,
     })
 }
 

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -484,10 +484,13 @@ pub async fn post_messages(
         }
     };
 
-    // 构建 Kiro 请求（profile_arn 由 provider 层根据实际凭据注入）
+    // Build the Kiro request (profile_arn is injected by the provider layer from the actual credentials;
+    // additional_model_request_fields comes from the client's output_config and is the real protocol field
+    // by which the AWS Q backend recognizes effort; sending it alongside the XML prefix yields the strongest effect)
     let kiro_request = KiroRequest {
         conversation_state: conversion_result.conversation_state,
         profile_arn: None,
+        additional_model_request_fields: conversion_result.additional_model_request_fields,
     };
 
     let request_body = match serde_json::to_string(&kiro_request) {
@@ -1126,10 +1129,13 @@ pub async fn post_messages_cc(
         }
     };
 
-    // 构建 Kiro 请求（profile_arn 由 provider 层根据实际凭据注入）
+    // Build the Kiro request (profile_arn is injected by the provider layer from the actual credentials;
+    // additional_model_request_fields comes from the client's output_config and is the real protocol field
+    // by which the AWS Q backend recognizes effort; sending it alongside the XML prefix yields the strongest effect)
     let kiro_request = KiroRequest {
         conversation_state: conversion_result.conversation_state,
         profile_arn: None,
+        additional_model_request_fields: conversion_result.additional_model_request_fields,
     };
 
     let request_body = match serde_json::to_string(&kiro_request) {

--- a/src/kiro/model/requests/kiro.rs
+++ b/src/kiro/model/requests/kiro.rs
@@ -35,6 +35,41 @@ pub struct KiroRequest {
     /// Profile ARN（可选）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_arn: Option<String>,
+    /// Additional model request fields (a real Kiro CLI wire field carrying control switches such as `output_config.effort`)
+    ///
+    /// Real wire sample (captured from real Kiro CLI traffic):
+    /// ```json
+    /// "additionalModelRequestFields": {
+    ///     "output_config": { "effort": "max" }
+    /// }
+    /// ```
+    /// Five tiers: `low / medium / high / xhigh / max`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_model_request_fields: Option<AdditionalModelRequestFields>,
+}
+
+/// Top-level container for the AWS Q CodeWhisperer `additionalModelRequestFields`
+///
+/// Note: in the real wire format the inner `output_config` field is `snake_case`,
+/// unlike the outer `additionalModelRequestFields` (camelCase),
+/// so this struct **must not** inherit `rename_all = "camelCase"`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AdditionalModelRequestFields {
+    /// Output configuration (including reasoning effort)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<KiroOutputConfig>,
+}
+
+/// The effort control field recognized by the AWS Q backend
+///
+/// Accepts five tiers: `low / medium / high / xhigh / max`
+///
+/// Measured (via a ladder experiment), the same prompt between `low` and `max` differs
+/// by roughly 5x in response time and output length, so this **is a protocol field that genuinely takes effect**,
+/// completely unlike the "pseudo-protocol" of stuffing a `<thinking_effort>` XML tag into the system prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KiroOutputConfig {
+    pub effort: String,
 }
 #[cfg(test)]
 mod tests {
@@ -68,6 +103,24 @@ mod tests {
                 .user_input_message
                 .content,
             "Test message"
+        );
+    }
+
+    #[test]
+    fn test_additional_model_request_fields_wire_format() {
+        // The wire format requires the outer key to be camelCase
+        // (`additionalModelRequestFields`) while the inner key stays snake_case
+        // (`output_config`), matching real Kiro CLI traffic.
+        let fields = AdditionalModelRequestFields {
+            output_config: Some(KiroOutputConfig {
+                effort: "max".to_string(),
+            }),
+        };
+        let v = serde_json::to_value(&fields).unwrap();
+        assert_eq!(v["output_config"]["effort"], "max");
+        assert!(
+            v.get("outputConfig").is_none(),
+            "inner key must stay snake_case output_config, got {v}"
         );
     }
 }


### PR DESCRIPTION
## What

Plumb the client's `output_config.effort` (from the inbound Anthropic request) through to the AWS Q wire field `additionalModelRequestFields.output_config.effort`. Pure passthrough — forwarded as-is, no model-specific remapping. Adds `AdditionalModelRequestFields` / `KiroOutputConfig` structs.

## Why

The AWS Q backend honors `additionalModelRequestFields.output_config.effort` as the real protocol-level reasoning-effort control, distinct from injecting a `<thinking_effort>` tag into the system prompt. Without this, clients can't control the effort level.

## Tests

`cargo build --release --no-default-features --features native-tls` clean; `cargo test` passes (253).
