### PR TITLE
fix(handlers): map Bedrock client-validation errors to 400 not 5xx

### DIFF
--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -225,6 +225,31 @@ fn map_provider_error(err: Error) -> Response {
         )
             .into_response();
     }
+
+    // Bedrock client-side validation errors (tool_use <-> tool_result mismatch, invalid message sequence, etc.)
+    // The root cause is the client's own messages array, not an upstream failure, so it must not map to 5xx
+    // otherwise it triggers an upstream cooldown that amplifies one client error into a 30+ burst of 503s
+    if err_str.contains("TOOL_USE_RESULT_MISMATCH")
+        || err_str.contains("ValidationException")
+        || err_str.contains("Expected toolResult blocks")
+    {
+        tracing::warn!(
+            error = %err,
+            "client messages array violates the protocol (Bedrock validation; mapped to 400 to avoid a false cooldown)"
+        );
+        // Return a stable, client-facing message and avoid echoing the raw upstream
+        // error string (which can carry request IDs or internal validation details).
+        // The full error is already logged above for diagnostics.
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "invalid_request_error",
+                "Invalid message sequence: tool_use and tool_result blocks must be correctly paired and ordered.".to_string(),
+            )),
+        )
+            .into_response();
+    }
+
     tracing::error!("Kiro API 调用失败: {}", err);
     (
         StatusCode::BAD_GATEWAY,


### PR DESCRIPTION
## What

Map Bedrock client-side validation errors (`TOOL_USE_RESULT_MISMATCH`, `ValidationException`, "Expected toolResult blocks") to HTTP **400** instead of 5xx.

## Why

These errors are caused by the client's own `messages` array, not an upstream outage. Treating them as 5xx triggers the upstream cooldown logic, amplifying one bad client request into a burst of 30+ `503`s. Returning `400` tells the caller their request was malformed and avoids the false cooldown.

## Tests

`cargo build --release --no-default-features --features native-tls` clean; `cargo test` passes (253).
