### PR TITLE
fix(websearch): only treat native Anthropic web_search tools as web_search

### DIFF
--- a/src/anthropic/websearch.rs
+++ b/src/anthropic/websearch.rs
@@ -102,24 +102,31 @@ pub struct WebSearchResult {
     pub public_domain: Option<bool>,
 }
 
+fn is_native_web_search_tool(t: &crate::anthropic::types::Tool) -> bool {
+    t.name == "web_search"
+        && t.tool_type
+            .as_deref()
+            .is_some_and(|typ| typ.starts_with("web_search_"))
+}
+
 /// 检查请求是否为纯 WebSearch 请求
 ///
-/// 条件：tools 有且只有一个，且 name 为 web_search
+/// 条件：tools 有且只有一个，且为 Anthropic 原生 web_search 工具。
 pub fn has_web_search_tool(req: &MessagesRequest) -> bool {
     req.tools.as_ref().is_some_and(|tools| {
-        tools.len() == 1 && tools.first().is_some_and(|t| t.name == "web_search")
+        tools.len() == 1 && tools.first().is_some_and(is_native_web_search_tool)
     })
 }
 
 /// Checks whether the request is a "mixed-tools set that contains web_search" case
 ///
 /// Mutually exclusive with [`has_web_search_tool`]: that one is the pure single-tool fast path, while this one detects
-/// the case where web_search coexists with other tools (exec, etc.) - such a request falls onto the normal chat path,
-/// where the upstream may return a tool_use with name=web_search, requiring the internal agentic loop.
+/// the case where native web_search coexists with other tools (exec, etc.) - such a request falls onto the normal chat
+/// path, where the upstream may return a tool_use with name=web_search, requiring the internal agentic loop.
 pub(crate) fn has_web_search_among_tools(req: &MessagesRequest) -> bool {
-    req.tools.as_ref().is_some_and(|tools| {
-        tools.len() > 1 && tools.iter().any(|t| t.name == "web_search")
-    })
+    req.tools
+        .as_ref()
+        .is_some_and(|tools| tools.len() > 1 && tools.iter().any(is_native_web_search_tool))
 }
 
 /// 从消息中提取搜索查询
@@ -630,6 +637,50 @@ mod tests {
 
         // 多个工具时不应该被识别为纯 websearch 请求
         assert!(!has_web_search_tool(&req));
+        assert!(has_web_search_among_tools(&req));
+    }
+
+    #[test]
+    fn test_regular_tool_named_web_search_does_not_trigger_native_websearch() {
+        use crate::anthropic::types::{Message, Tool};
+
+        let req = MessagesRequest {
+            model: "claude-sonnet-4".to_string(),
+            max_tokens: 1024,
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: serde_json::json!("test"),
+            }],
+            stream: true,
+            system: None,
+            tools: Some(vec![
+                Tool {
+                    tool_type: None,
+                    name: "web_search".to_string(),
+                    description: "Regular client-side search tool".to_string(),
+                    input_schema: Default::default(),
+                    max_uses: None,
+                    cache_control: None,
+                },
+                Tool {
+                    tool_type: None,
+                    name: "other_tool".to_string(),
+                    description: "Other tool".to_string(),
+                    input_schema: Default::default(),
+                    max_uses: None,
+                    cache_control: None,
+                },
+            ]),
+            tool_choice: None,
+            thinking: None,
+            output_config: None,
+            metadata: None,
+        };
+
+        // A regular client-defined tool can be named web_search, but only
+        // Anthropic's native web search tool has type=web_search_*.
+        assert!(!has_web_search_tool(&req));
+        assert!(!has_web_search_among_tools(&req));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`has_web_search_tool` and `has_web_search_among_tools` decide whether a request should be routed into the internal web_search agentic loop. They matched **any** tool whose `name == "web_search"`:

```rust
tools.len() == 1 && tools.first().is_some_and(|t| t.name == "web_search")           // pure
tools.len() > 1  && tools.iter().any(|t| t.name == "web_search")                    // mixed
```

The problem: `web_search` is not a reserved name. Anthropic's *native* server-side web search tool has a `type` field (`web_search_20250305`), but a regular client-defined tool can legitimately also be named `web_search` (some agent frameworks register an ordinary function tool by that name). When such a request arrives — especially the common "mixed tools" shape (`web_search` + other client tools) — kiro.rs diverts it into the web_search agentic loop instead of the normal chat path.

A visible side effect of that diversion: the request skips the normal chat path's cache metering, so `cache_creation`/`cache_read` come back as `0` even though the client sent `cache_control` markers. The log fingerprint is:

```
detected mixed tools containing web_search, entering the web_search agentic loop
```

## Fix

Only treat a tool as native Anthropic web_search when **both** conditions hold:

```rust
fn is_native_web_search_tool(t: &Tool) -> bool {
    t.name == "web_search"
        && t.tool_type
            .as_deref()
            .is_some_and(|typ| typ.starts_with("web_search_"))
}
```

`has_web_search_tool` and `has_web_search_among_tools` now use this helper. Native web_search (e.g. `type: "web_search_20250305"`) still enters the loop exactly as before; a plain client tool named `web_search` (no `type`) stays on the normal chat path.

## Test plan

- Added regression test `test_regular_tool_named_web_search_does_not_trigger_native_websearch`: a client tool named `web_search` with `tool_type: None` alongside another tool returns `false` for both the pure and mixed detectors.
- Strengthened `test_has_web_search_tool_multiple_tools` to also assert `has_web_search_among_tools` is `true` for a genuine native tool in a mixed set.

```
cargo test websearch   # 39 passed
cargo test             # 395 passed; 0 failed
```

No behavior change for native web_search requests; this only narrows the over-broad name match.
