### PR TITLE
feat(admin): 账号分组管理 — 独立实体 + 调度隔离 + 全链路打通

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,13 @@
 /credentials.*
 /kiro_balance_cache.json
 /kiro_stats.json
-# 中转层 prompt cache 落盘（运行时产物，不入库）
+# 中转层缓存计量落盘（运行时产物，不入库）
+/cache_metering.json
 /prompt_cache.json
 # 客户端 Key 分发（含明文 csk_*，绝对不能提交）
 /client_api_keys.json
+# 账号分组注册表（运行时产物，不入库）
+/groups.json
 # 按天滚动的请求用量日志
 /usage_log.*.jsonl
 /usage_stats.json

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -4,7 +4,7 @@ import { LoginPage } from "@/components/login-page";
 import { Toaster } from "@/components/ui/sonner";
 import { ConfirmProvider } from "@/components/ui/confirm-dialog";
 import { Button } from "@/components/ui/button";
-import { Activity, KeyRound, Server, LogOut, Moon, Sun, ScrollText } from "lucide-react";
+import { Activity, KeyRound, Server, LogOut, Moon, Sun, ScrollText, FolderTree } from "lucide-react";
 import { TopbarTools } from "@/components/topbar-tools";
 
 function GithubIcon({ className }: { className?: string }) {
@@ -38,8 +38,13 @@ const TraceLogPage = lazy(() =>
     default: m.TraceLogPage,
   })),
 );
+const GroupsPage = lazy(() =>
+  import("@/components/groups-page").then((m) => ({
+    default: m.GroupsPage,
+  })),
+);
 
-type Tab = "overview" | "credentials" | "keys" | "traces";
+type Tab = "overview" | "credentials" | "keys" | "groups" | "traces";
 
 const TABS: {
   key: Tab;
@@ -66,6 +71,12 @@ const TABS: {
     icon: <KeyRound className="h-3.5 w-3.5" />,
   },
   {
+    key: "groups",
+    label: "分组管理",
+    mobileLabel: "分组",
+    icon: <FolderTree className="h-3.5 w-3.5" />,
+  },
+  {
     key: "traces",
     label: "请求日志",
     mobileLabel: "日志",
@@ -75,7 +86,13 @@ const TABS: {
 
 function readTabFromHash(): Tab {
   const h = window.location.hash.replace(/^#\/?/, "");
-  if (h === "credentials" || h === "keys" || h === "overview" || h === "traces")
+  if (
+    h === "credentials" ||
+    h === "keys" ||
+    h === "groups" ||
+    h === "overview" ||
+    h === "traces"
+  )
     return h;
   return "overview";
 }
@@ -359,6 +376,7 @@ function AppMain({ onLogout, tab }: { onLogout: () => void; tab: Tab }) {
         {tab === "overview" && <OverviewPage />}
         {tab === "credentials" && <Dashboard onLogout={onLogout} embedded />}
         {tab === "keys" && <ClientKeysPage />}
+        {tab === "groups" && <GroupsPage />}
         {tab === "traces" && <TraceLogPage />}
       </Suspense>
     </main>

--- a/admin-ui/src/api/client-keys.ts
+++ b/admin-ui/src/api/client-keys.ts
@@ -57,3 +57,8 @@ export async function resetClientKeyStats(id: number): Promise<SuccessResponse> 
   const { data } = await api.post<SuccessResponse>(`/client-keys/${id}/reset-stats`)
   return data
 }
+
+export async function rotateClientKey(id: number): Promise<CreateClientKeyResponse> {
+  const { data } = await api.post<CreateClientKeyResponse>(`/client-keys/${id}/rotate`)
+  return data
+}

--- a/admin-ui/src/api/groups.ts
+++ b/admin-ui/src/api/groups.ts
@@ -1,0 +1,47 @@
+import axios from 'axios'
+import { storage } from '@/lib/storage'
+import type {
+  GroupsResponse,
+  GroupItem,
+  CreateGroupRequest,
+  UpdateGroupRequest,
+  SuccessResponse,
+} from '@/types/api'
+
+const api = axios.create({
+  baseURL: '/api/admin',
+  timeout: 15000,
+  headers: { 'Content-Type': 'application/json' },
+})
+
+api.interceptors.request.use((config) => {
+  const apiKey = storage.getApiKey()
+  if (apiKey) config.headers['x-api-key'] = apiKey
+  return config
+})
+
+export async function listGroups(): Promise<GroupsResponse> {
+  const { data } = await api.get<GroupsResponse>('/groups')
+  return data
+}
+
+export async function createGroup(req: CreateGroupRequest): Promise<GroupItem> {
+  const { data } = await api.post<GroupItem>('/groups', req)
+  return data
+}
+
+export async function updateGroup(
+  name: string,
+  req: UpdateGroupRequest,
+): Promise<GroupItem> {
+  // path 中的分组名可能含中文/空格，必须 encodeURIComponent
+  const { data } = await api.patch<GroupItem>(`/groups/${encodeURIComponent(name)}`, req)
+  return data
+}
+
+/** 删除分组。`force=true` 时级联清理所有引用（凭据 groups + 客户端 Key.group）。 */
+export async function deleteGroup(name: string, force = false): Promise<SuccessResponse> {
+  const path = `/groups/${encodeURIComponent(name)}${force ? '?force=true' : ''}`
+  const { data } = await api.delete<SuccessResponse>(path)
+  return data
+}

--- a/admin-ui/src/api/stats.ts
+++ b/admin-ui/src/api/stats.ts
@@ -30,6 +30,7 @@ function statsParams(time: StatsTimeFilter, filter?: StatsFilter) {
   return {
     ...time,
     ...(filter?.keyId !== undefined ? { keyId: filter.keyId } : {}),
+    ...(filter?.group ? { group: filter.group } : {}),
   }
 }
 

--- a/admin-ui/src/api/traces.ts
+++ b/admin-ui/src/api/traces.ts
@@ -19,6 +19,7 @@ export async function getTraces(query: TraceQuery): Promise<TracePage> {
   if (query.status) params.status = query.status
   if (query.errorType) params.errorType = query.errorType
   if (query.credentialId != null) params.credentialId = String(query.credentialId)
+  if (query.keyId != null) params.keyId = String(query.keyId)
   if (query.failedAttemptCredentialId != null)
     params.failedAttemptCredentialId = String(query.failedAttemptCredentialId)
   if (query.model) params.model = query.model

--- a/admin-ui/src/components/add-credential-dialog.tsx
+++ b/admin-ui/src/components/add-credential-dialog.tsx
@@ -17,7 +17,9 @@ import {
   SelectItem,
 } from '@/components/ui/select'
 import { useAddCredential } from '@/hooks/use-credentials'
+import { useGroupOptions } from '@/hooks/use-groups'
 import { extractErrorMessage } from '@/lib/utils'
+import { GroupMultiSelect } from '@/components/group-select'
 
 interface AddCredentialDialogProps {
   open: boolean
@@ -39,6 +41,10 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
   const [proxyUsername, setProxyUsername] = useState('')
   const [proxyPassword, setProxyPassword] = useState('')
   const [endpoint, setEndpoint] = useState('')
+  const [groups, setGroups] = useState<string[]>([])
+  const [sourceChannel, setSourceChannel] = useState('')
+
+  const groupOptions = useGroupOptions()
 
   const { mutate, isPending } = useAddCredential()
 
@@ -55,6 +61,8 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
     setProxyUsername('')
     setProxyPassword('')
     setEndpoint('')
+    setGroups([])
+    setSourceChannel('')
   }
 
   const isApiKey = authMethod === 'api_key'
@@ -94,6 +102,8 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
         proxyUsername: proxyUsername.trim() || undefined,
         proxyPassword: proxyPassword.trim() || undefined,
         endpoint: endpoint.trim() || undefined,
+        groups: groups,
+        sourceChannel: sourceChannel.trim() || undefined,
       },
       {
         onSuccess: (data) => {
@@ -262,6 +272,37 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
               />
               <p className="text-xs text-muted-foreground">
                 可选。决定该凭据走哪套 Kiro API。留空使用全局 defaultEndpoint
+              </p>
+            </div>
+
+            {/* 账号分组 */}
+            <div className="space-y-2">
+              <label className="text-sm font-medium">账号分组</label>
+              <GroupMultiSelect
+                value={groups}
+                options={groupOptions}
+                onChange={setGroups}
+                disabled={isPending}
+              />
+              <p className="text-xs text-muted-foreground">
+                可选。绑定了某分组的客户端 Key 只会调度到含该分组的账号
+              </p>
+            </div>
+
+            {/* 账号来源渠道 */}
+            <div className="space-y-2">
+              <label htmlFor="sourceChannel" className="text-sm font-medium">
+                账号来源渠道（备注）
+              </label>
+              <Input
+                id="sourceChannel"
+                placeholder="例: 官方, 转售商A, 采购平台X"
+                value={sourceChannel}
+                onChange={(e) => setSourceChannel(e.target.value)}
+                disabled={isPending}
+              />
+              <p className="text-xs text-muted-foreground">
+                可选。纯备注，标记账号来源/渠道，便于追踪
               </p>
             </div>
 

--- a/admin-ui/src/components/batch-edit-credential-dialog.tsx
+++ b/admin-ui/src/components/batch-edit-credential-dialog.tsx
@@ -1,0 +1,183 @@
+import { useState, useEffect } from 'react'
+import { toast } from 'sonner'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
+import { GroupMultiSelect } from '@/components/group-select'
+import { updateCredential } from '@/api/credentials'
+import type { CredentialStatusItem } from '@/types/api'
+
+type GroupMode = 'replace' | 'add' | 'remove'
+
+interface BatchEditCredentialDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** 选中的账号对象（add/remove 模式需读各自当前 groups） */
+  credentials: CredentialStatusItem[]
+  /** 现有分组选项（去重聚合） */
+  groupOptions: string[]
+  /** 完成后回调（清空选择等） */
+  onDone: () => void
+}
+
+const MODE_LABELS: { value: GroupMode; label: string; desc: string }[] = [
+  { value: 'replace', label: '替换', desc: '用所选分组覆盖各账号原有分组（不选=清除分组）' },
+  { value: 'add', label: '追加', desc: '把所选分组并入各账号原有分组（去重）' },
+  { value: 'remove', label: '移除', desc: '从各账号分组里移除所选分组' },
+]
+
+export function BatchEditCredentialDialog({
+  open,
+  onOpenChange,
+  credentials,
+  groupOptions,
+  onDone,
+}: BatchEditCredentialDialogProps) {
+  const queryClient = useQueryClient()
+
+  const [editGroups, setEditGroups] = useState(false)
+  const [mode, setMode] = useState<GroupMode>('replace')
+  const [groups, setGroups] = useState<string[]>([])
+
+  const [editSource, setEditSource] = useState(false)
+  const [sourceChannel, setSourceChannel] = useState('')
+
+  const [running, setRunning] = useState(false)
+  const [progress, setProgress] = useState({ current: 0, total: 0 })
+
+  useEffect(() => {
+    if (open) {
+      setEditGroups(false)
+      setMode('replace')
+      setGroups([])
+      setEditSource(false)
+      setSourceChannel('')
+      setRunning(false)
+      setProgress({ current: 0, total: 0 })
+    }
+  }, [open])
+
+  const computeGroups = (current: string[]): string[] => {
+    if (mode === 'replace') return groups
+    if (mode === 'add') return Array.from(new Set([...current, ...groups]))
+    // remove
+    return current.filter((g) => !groups.includes(g))
+  }
+
+  const handleApply = async () => {
+    if (!editGroups && !editSource) {
+      toast.error('请至少开启一项要修改的字段')
+      return
+    }
+    setRunning(true)
+    setProgress({ current: 0, total: credentials.length })
+    let ok = 0
+    let fail = 0
+    for (let i = 0; i < credentials.length; i++) {
+      const c = credentials[i]
+      const req: Record<string, unknown> = {}
+      if (editGroups) req.groups = computeGroups(c.groups ?? [])
+      if (editSource) req.sourceChannel = sourceChannel.trim()
+      try {
+        await updateCredential(c.id, req)
+        ok++
+      } catch {
+        fail++
+      }
+      setProgress({ current: i + 1, total: credentials.length })
+    }
+    await queryClient.invalidateQueries({ queryKey: ['credentials'] })
+    setRunning(false)
+    if (fail === 0) toast.success(`已更新 ${ok} 个账号`)
+    else toast.warning(`成功 ${ok} 个，失败 ${fail} 个`)
+    onOpenChange(false)
+    onDone()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !running && onOpenChange(o)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>批量编辑（{credentials.length} 个账号）</DialogTitle>
+          <DialogDescription>
+            仅修改下方开启的字段，未开启的字段保持不变。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          {/* 分组区 */}
+          <div className="space-y-3 rounded-xl border border-border/60 p-3">
+            <label className="flex items-center justify-between">
+              <span className="text-sm font-medium">修改分组</span>
+              <Switch checked={editGroups} onCheckedChange={setEditGroups} disabled={running} />
+            </label>
+            {editGroups && (
+              <>
+                <div className="flex gap-2">
+                  {MODE_LABELS.map((m) => (
+                    <Button
+                      key={m.value}
+                      type="button"
+                      size="sm"
+                      variant={mode === m.value ? 'default' : 'outline'}
+                      onClick={() => setMode(m.value)}
+                      disabled={running}
+                    >
+                      {m.label}
+                    </Button>
+                  ))}
+                </div>
+                <p className="text-[11px] text-muted-foreground">
+                  {MODE_LABELS.find((m) => m.value === mode)?.desc}
+                </p>
+                <GroupMultiSelect
+                  value={groups}
+                  options={groupOptions}
+                  onChange={setGroups}
+                  disabled={running}
+                />
+              </>
+            )}
+          </div>
+
+          {/* 来源渠道区 */}
+          <div className="space-y-3 rounded-xl border border-border/60 p-3">
+            <label className="flex items-center justify-between">
+              <span className="text-sm font-medium">修改来源渠道</span>
+              <Switch checked={editSource} onCheckedChange={setEditSource} disabled={running} />
+            </label>
+            {editSource && (
+              <>
+                <Input
+                  placeholder="应用到所有选中账号（留空 = 清除）"
+                  value={sourceChannel}
+                  onChange={(e) => setSourceChannel(e.target.value)}
+                  disabled={running}
+                />
+                <p className="text-[11px] text-muted-foreground">纯备注，标记账号来源/渠道。</p>
+              </>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={running}>
+            取消
+          </Button>
+          <Button type="button" onClick={handleApply} disabled={running}>
+            {running ? `应用中… ${progress.current}/${progress.total}` : '应用'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/admin-ui/src/components/client-keys-page.tsx
+++ b/admin-ui/src/components/client-keys-page.tsx
@@ -1,19 +1,25 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import {
-  Plus, KeyRound, Trash2, Copy, Eye, EyeOff, Power, RotateCcw, Pencil,
+  Plus, KeyRound, Trash2, Copy, Eye, EyeOff, Power, RotateCcw, Pencil, RefreshCw,
 } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription,
 } from '@/components/ui/dialog'
 import {
   useClientKeys, useCreateClientKey, useDeleteClientKey,
   useSetClientKeyDisabled, useResetClientKeyStats, useUpdateClientKey,
+  useRotateClientKey,
 } from '@/hooks/use-client-keys'
+import { useGroupOptions } from '@/hooks/use-groups'
+import { GroupSingleSelect } from '@/components/group-select'
 import type { ClientKeyItem, CreateClientKeyResponse } from '@/types/api'
 import { extractErrorMessage } from '@/lib/utils'
 import { useConfirm } from '@/components/ui/confirm-dialog'
@@ -36,16 +42,20 @@ function formatRelative(ts?: string): string {
 
 export function ClientKeysPage() {
   const { data, isLoading } = useClientKeys()
+  // 已注册分组列表（来自 groups.json 注册表，与凭据的 groups 字段解耦）
+  const groupOptions = useGroupOptions()
   const createKey = useCreateClientKey()
   const deleteKey = useDeleteClientKey()
   const setDisabled = useSetClientKeyDisabled()
   const resetStats = useResetClientKeyStats()
   const updateKey = useUpdateClientKey()
+  const rotateKey = useRotateClientKey()
   const confirm = useConfirm()
 
   const [createOpen, setCreateOpen] = useState(false)
   const [createName, setCreateName] = useState('')
   const [createDesc, setCreateDesc] = useState('')
+  const [createGroup, setCreateGroup] = useState('')
   const [createdKey, setCreatedKey] = useState<CreateClientKeyResponse | null>(null)
   const [showCreatedPlain, setShowCreatedPlain] = useState(true)
 
@@ -53,6 +63,7 @@ export function ClientKeysPage() {
   const [editTarget, setEditTarget] = useState<ClientKeyItem | null>(null)
   const [editName, setEditName] = useState('')
   const [editDesc, setEditDesc] = useState('')
+  const [editGroup, setEditGroup] = useState('')
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -62,11 +73,16 @@ export function ClientKeysPage() {
       return
     }
     try {
-      const res = await createKey.mutateAsync({ name, description: createDesc.trim() || undefined })
+      const res = await createKey.mutateAsync({
+        name,
+        description: createDesc.trim() || undefined,
+        group: createGroup.trim() || undefined,
+      })
       setCreatedKey(res)
       setCreateOpen(false)
       setCreateName('')
       setCreateDesc('')
+      setCreateGroup('')
       setShowCreatedPlain(true)
     } catch (err) {
       toast.error('创建失败：' + extractErrorMessage(err))
@@ -117,10 +133,30 @@ export function ClientKeysPage() {
     }
   }
 
+  const handleRotate = async (item: ClientKeyItem) => {
+    if (
+      !(await confirm({
+        title: '重新生成 Key',
+        description: `重新生成 Key "${item.name}"？旧明文将立即失效，使用旧明文的下游需要换上新明文才能继续调用。Key 的名称、描述、绑定分组与累计统计保留不变。`,
+        confirmText: '重新生成',
+        destructive: true,
+      }))
+    )
+      return
+    try {
+      const res = await rotateKey.mutateAsync(item.id)
+      setCreatedKey(res)
+      setShowCreatedPlain(true)
+    } catch (err) {
+      toast.error('重新生成失败：' + extractErrorMessage(err))
+    }
+  }
+
   const startEdit = (item: ClientKeyItem) => {
     setEditTarget(item)
     setEditName(item.name)
     setEditDesc(item.description ?? '')
+    setEditGroup(item.group ?? '')
     setEditOpen(true)
   }
 
@@ -130,7 +166,7 @@ export function ClientKeysPage() {
     try {
       await updateKey.mutateAsync({
         id: editTarget.id,
-        req: { name: editName.trim(), description: editDesc.trim() },
+        req: { name: editName.trim(), description: editDesc.trim(), group: editGroup.trim() },
       })
       toast.success('已更新')
       setEditOpen(false)
@@ -185,6 +221,7 @@ export function ClientKeysPage() {
                 <tr className="whitespace-nowrap">
                   <th className="text-left font-medium px-4 py-3">名称</th>
                   <th className="text-left font-medium px-4 py-3">Key</th>
+                  <th className="text-left font-medium px-4 py-3">分组</th>
                   <th className="text-left font-medium px-4 py-3">状态</th>
                   <th className="text-right font-medium px-4 py-3">总调用</th>
                   <th className="text-right font-medium px-4 py-3">输入</th>
@@ -205,7 +242,30 @@ export function ClientKeysPage() {
                       )}
                     </td>
                     <td className="px-4 py-3">
-                      <code className="text-[12px] font-mono text-muted-foreground">{k.maskedKey}</code>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="rounded px-1 py-0.5 font-mono text-[12px] text-muted-foreground hover:bg-accent/60 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                            title="点击展开 Key 操作"
+                          >
+                            {k.maskedKey}
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="start">
+                          <DropdownMenuItem onSelect={() => handleRotate(k)}>
+                            <RefreshCw className="h-3.5 w-3.5" />
+                            重新生成 Key（旧 Key 立即失效）
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </td>
+                    <td className="px-4 py-3">
+                      {k.group ? (
+                        <Badge variant="outline">{k.group}</Badge>
+                      ) : (
+                        <span className="text-[12px] text-muted-foreground">全部账号</span>
+                      )}
                     </td>
                     <td className="px-4 py-3">
                       {k.disabled ? (
@@ -297,6 +357,19 @@ export function ClientKeysPage() {
                 disabled={createKey.isPending}
               />
             </div>
+            <div>
+              <label className="text-[12px] text-muted-foreground">绑定分组（可选）</label>
+              <GroupSingleSelect
+                value={createGroup}
+                options={groupOptions}
+                onChange={setCreateGroup}
+                disabled={createKey.isPending}
+                noneLabel="（不绑定，可用全部账号）"
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                绑定后该 Key 仅会使用含此分组的账号（严格隔离，分组内无可用账号时请求会失败）。
+              </p>
+            </div>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setCreateOpen(false)} disabled={createKey.isPending}>
                 取消
@@ -377,6 +450,19 @@ export function ClientKeysPage() {
             <div>
               <label className="text-[12px] text-muted-foreground">描述</label>
               <Input value={editDesc} onChange={(e) => setEditDesc(e.target.value)} />
+            </div>
+            <div>
+              <label className="text-[12px] text-muted-foreground">绑定分组</label>
+              <GroupSingleSelect
+                value={editGroup}
+                options={groupOptions}
+                onChange={setEditGroup}
+                disabled={updateKey.isPending}
+                noneLabel="（不绑定，可用全部账号）"
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                绑定后仅调度该分组内账号（严格隔离）。选「不绑定」表示解除绑定。
+              </p>
             </div>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setEditOpen(false)}>取消</Button>

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -464,6 +464,18 @@ export function CredentialCard({
                       .join(" · ")}
                   </Badge>
                 )}
+                {/* 账号所属分组 */}
+                {(credential.groups ?? []).map((g) => (
+                  <Badge key={g} variant="outline" title="账号分组">
+                    {g}
+                  </Badge>
+                ))}
+                {/* 账号来源渠道 */}
+                {credential.sourceChannel && (
+                  <Badge variant="outline" title="账号来源渠道">
+                    来源: {credential.sourceChannel}
+                  </Badge>
+                )}
               </div>
             </div>
             <Switch

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -28,6 +28,7 @@ import {
   Copy,
   Wand2,
   Zap,
+  Tags,
 } from "lucide-react";
 
 function GithubIcon({ className }: { className?: string }) {
@@ -68,6 +69,7 @@ import {
 import { CredentialCard } from "@/components/credential-card";
 import { AddCredentialDialog } from "@/components/add-credential-dialog";
 import { BatchImportDialog } from "@/components/batch-import-dialog";
+import { BatchEditCredentialDialog } from "@/components/batch-edit-credential-dialog";
 import { IdcLoginDialog } from "@/components/idc-login-dialog";
 import { SocialLoginDialog } from "@/components/social-login-dialog";
 import { KamImportDialog } from "@/components/kam-import-dialog";
@@ -89,7 +91,15 @@ import {
 } from "@/hooks/use-credentials";
 import { useUpdateCheck } from "@/hooks/use-update-check";
 import { useFailureStats } from "@/hooks/use-traces";
+import { useGroupOptions } from "@/hooks/use-groups";
 import { useRectSelect } from "@/hooks/use-rect-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   DndContext,
   PointerSensor,
@@ -131,6 +141,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const confirm = useConfirm();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [batchImportDialogOpen, setBatchImportDialogOpen] = useState(false);
+  const [batchEditDialogOpen, setBatchEditDialogOpen] = useState(false);
   const [idcLoginDialogOpen, setIdcLoginDialogOpen] = useState(false);
   const [enterpriseLoginDialogOpen, setEnterpriseLoginDialogOpen] = useState(false);
   const [socialLoginDialogOpen, setSocialLoginDialogOpen] = useState(false);
@@ -191,11 +202,30 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const setPriority = useSetPriority();
   const { data: updateCheck } = useUpdateCheck();
   const { data: failureStatsMap } = useFailureStats();
+  const groupOptions = useGroupOptions();
 
-  const totalPages = Math.ceil((data?.credentials.length || 0) / itemsPerPage);
+  // 分组筛选：'' = 全部；'__none__' = 仅显示未分组；其他 = 按分组名筛选
+  const [groupFilter, setGroupFilter] = useState<string>('');
+
+  // 应用分组筛选后的凭据全集（分页前先过滤，确保翻页粒度正确）
+  const filteredCredentials = (() => {
+    const all = data?.credentials ?? [];
+    if (!groupFilter) return all;
+    if (groupFilter === '__none__') {
+      return all.filter((c) => !c.groups || c.groups.length === 0);
+    }
+    return all.filter((c) => c.groups?.includes(groupFilter));
+  })();
+
+  // 切换分组筛选时复位到第 1 页，避免空页
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [groupFilter]);
+
+  const totalPages = Math.ceil(filteredCredentials.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
-  const serverPageCreds = data?.credentials.slice(startIndex, endIndex) || [];
+  const serverPageCreds = filteredCredentials.slice(startIndex, endIndex);
   // 拖拽排序的本地乐观顺序：仅当 id 集合与当前页一致时生效，否则回落到服务端顺序，
   // 避免翻页 / 数据变更后顺序错乱。
   const [pageOrder, setPageOrder] = useState<number[] | null>(null);
@@ -1094,7 +1124,24 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h2 className="text-lg font-semibold tracking-tight">凭据列表</h2>
             {data?.credentials && data.credentials.length > 0 && (
-              <Badge variant="secondary">{data.credentials.length}</Badge>
+              <Badge variant="secondary">
+                {groupFilter
+                  ? `${filteredCredentials.length} / ${data.credentials.length}`
+                  : data.credentials.length}
+              </Badge>
+            )}
+            {groupFilter && (
+              <Badge variant="outline" className="gap-1">
+                筛选：{groupFilter === '__none__' ? '未分组' : groupFilter}
+                <button
+                  type="button"
+                  className="ml-1 text-muted-foreground hover:text-foreground"
+                  onClick={() => setGroupFilter('')}
+                  title="清除筛选"
+                >
+                  ×
+                </button>
+              </Badge>
             )}
             {currentCredentials.length > 0 && (
               <Button
@@ -1169,6 +1216,15 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                   恢复异常
                 </Button>
                 <Button
+                  onClick={() => setBatchEditDialogOpen(true)}
+                  size="sm"
+                  variant="outline"
+                  title="批量编辑分组 / 来源渠道"
+                >
+                  <Tags className="h-3.5 w-3.5" />
+                  分组/来源
+                </Button>
+                <Button
                   onClick={handleExportKam}
                   size="sm"
                   variant="outline"
@@ -1192,6 +1248,25 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 <span className="mx-1 hidden h-5 w-px bg-border/70 sm:inline-block" />
               </>
             )}
+
+            {/* 分组筛选 */}
+            <Select value={groupFilter || 'all'} onValueChange={(v) => setGroupFilter(v === 'all' ? '' : v)}>
+              <SelectTrigger
+                className="h-8 w-full rounded-full border-border bg-card/60 px-3 backdrop-blur sm:w-[160px]"
+                title="按分组筛选凭据"
+              >
+                <SelectValue placeholder="全部分组" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectItem value="all">全部分组</SelectItem>
+                <SelectItem value="__none__">未分组</SelectItem>
+                {groupOptions.map((g) => (
+                  <SelectItem key={g} value={g}>
+                    {g}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
 
             {/* 刷新当前页余额 */}
             <Button
@@ -1449,6 +1524,13 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
       <BatchImportDialog
         open={batchImportDialogOpen}
         onOpenChange={setBatchImportDialogOpen}
+      />
+      <BatchEditCredentialDialog
+        open={batchEditDialogOpen}
+        onOpenChange={setBatchEditDialogOpen}
+        credentials={(data?.credentials ?? []).filter((c) => selectedIds.has(c.id))}
+        groupOptions={groupOptions}
+        onDone={deselectAll}
       />
       <SocialLoginDialog
         open={socialLoginDialogOpen}

--- a/admin-ui/src/components/edit-credential-dialog.tsx
+++ b/admin-ui/src/components/edit-credential-dialog.tsx
@@ -20,8 +20,10 @@ import {
 } from '@/components/ui/select'
 import { Input } from '@/components/ui/input'
 import { useUpdateCredential } from '@/hooks/use-credentials'
+import { useGroupOptions } from '@/hooks/use-groups'
 import { getProxyPool } from '@/api/credentials'
 import { extractErrorMessage, maskProxyUrl } from '@/lib/utils'
+import { GroupMultiSelect } from '@/components/group-select'
 import type { CredentialStatusItem } from '@/types/api'
 
 interface EditCredentialDialogProps {
@@ -39,7 +41,11 @@ export function EditCredentialDialog({
   const [proxyUrl, setProxyUrl] = useState(credential.proxyUrl ?? '')
   const [proxyUsername, setProxyUsername] = useState('')
   const [proxyPassword, setProxyPassword] = useState('')
+  const [groups, setGroups] = useState<string[]>(credential.groups ?? [])
+  const [sourceChannel, setSourceChannel] = useState(credential.sourceChannel ?? '')
   const [manualMode, setManualMode] = useState(false)
+
+  const groupOptions = useGroupOptions()
 
   const { data: proxyPool } = useQuery({
     queryKey: ['proxy-pool'],
@@ -54,6 +60,8 @@ export function EditCredentialDialog({
       setProxyUrl(credential.proxyUrl ?? '')
       setProxyUsername('')
       setProxyPassword('')
+      setGroups(credential.groups ?? [])
+      setSourceChannel(credential.sourceChannel ?? '')
       setManualMode(false)
     }
   }, [open, credential])
@@ -71,6 +79,8 @@ export function EditCredentialDialog({
           proxyUrl: proxyUrl,
           proxyUsername: proxyUsername || undefined,
           proxyPassword: proxyPassword || undefined,
+          groups: groups,
+          sourceChannel: sourceChannel,
         },
       },
       {
@@ -122,6 +132,37 @@ export function EditCredentialDialog({
               />
               <p className="text-xs text-muted-foreground">
                 留空则显示凭据 ID，清除请提交空值
+              </p>
+            </div>
+
+            {/* 账号分组 */}
+            <div className="space-y-2">
+              <label className="text-sm font-medium">账号分组</label>
+              <GroupMultiSelect
+                value={groups}
+                options={groupOptions}
+                onChange={setGroups}
+                disabled={isPending}
+              />
+              <p className="text-xs text-muted-foreground">
+                绑定了某分组的客户端 Key 只会调度到含该分组的账号。不选表示不属于任何分组。
+              </p>
+            </div>
+
+            {/* 账号来源渠道 */}
+            <div className="space-y-2">
+              <label htmlFor="sourceChannel" className="text-sm font-medium">
+                账号来源渠道（备注）
+              </label>
+              <Input
+                id="sourceChannel"
+                placeholder="例: 官方, 转售商A, 采购平台X"
+                value={sourceChannel}
+                onChange={(e) => setSourceChannel(e.target.value)}
+                disabled={isPending}
+              />
+              <p className="text-xs text-muted-foreground">
+                纯备注，标记此账号的购买来源/渠道，便于追踪。留空表示清除。
               </p>
             </div>
 

--- a/admin-ui/src/components/group-select.tsx
+++ b/admin-ui/src/components/group-select.tsx
@@ -1,0 +1,213 @@
+import { Checkbox } from '@/components/ui/checkbox'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ChevronDown, Check } from 'lucide-react'
+
+// 哨兵值：shadcn Select 不允许 SelectItem 用空字符串作 value，
+// 所以"不绑定"用一个 sentinel 占位，进出 onChange 时双向转换。
+const NONE_VALUE = '__none__'
+
+const NO_GROUPS_HINT_CLS =
+  'text-xs text-muted-foreground italic px-1 py-2 leading-relaxed'
+
+/** 提示用户去分组管理页注册新分组（取代旧版的"+ 新建分组"内联输入）。 */
+function ManageGroupsHint() {
+  return (
+    <p className={NO_GROUPS_HINT_CLS}>
+      还没有分组？前往
+      <a href="#/groups" className="text-primary underline mx-1">
+        分组管理
+      </a>
+      创建。分组名统一注册后才能在此选择，避免拼写漂移。
+    </p>
+  )
+}
+
+/** 单选分组：下拉选现有分组 / 不绑定。用于客户端 Key 绑定分组。
+ *
+ *  与改造前的差异：去掉"+ 新建分组"option（避免 typo 漂移）。
+ *  新建分组请去 #/groups 管理页。
+ */
+export function GroupSingleSelect({
+  value,
+  options,
+  onChange,
+  disabled,
+  noneLabel = '（不绑定）',
+}: {
+  value: string
+  options: string[]
+  onChange: (v: string) => void
+  disabled?: boolean
+  noneLabel?: string
+}) {
+  // 当前值不在已知选项里且非空 → "已删除分组的遗留引用"
+  const isOrphan = value !== '' && !options.includes(value)
+  // 与全站统一的 shadcn Select 用 NONE_VALUE 哨兵代替空字符串
+  const selectValue = value === '' ? NONE_VALUE : value
+
+  return (
+    <div className="space-y-2">
+      <Select
+        value={selectValue}
+        disabled={disabled}
+        onValueChange={(v) => onChange(v === NONE_VALUE ? '' : v)}
+      >
+        <SelectTrigger className="h-10 rounded-xl px-3.5">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NONE_VALUE}>{noneLabel}</SelectItem>
+          {options.map((g) => (
+            <SelectItem key={g} value={g}>
+              {g}
+            </SelectItem>
+          ))}
+          {isOrphan && (
+            <SelectItem value={value}>{value}（已注销）</SelectItem>
+          )}
+        </SelectContent>
+      </Select>
+      {options.length === 0 && <ManageGroupsHint />}
+      {isOrphan && (
+        <p className="text-xs text-amber-600">
+          当前绑定的分组 &quot;{value}&quot; 已不在注册表，请重新选择或前往
+          <a href="#/groups" className="text-primary underline mx-1">
+            分组管理
+          </a>
+          重建同名分组。
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** 多选分组：下拉菜单形式（点击展开 + 多选 checkbox）。用于账号(credential) groups 编辑。
+ *
+ *  与改造前的差异：
+ *  - 收起时只显示一个按钮，节省空间
+ *  - 多选能力保留（一个凭据可以同时属于多个分组）
+ *  - 去掉"+ 新建分组"输入框，新建分组请去 #/groups 管理页
+ */
+export function GroupMultiSelect({
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  value: string[]
+  options: string[]
+  onChange: (v: string[]) => void
+  disabled?: boolean
+}) {
+  // 选项 = 已注册 ∪ 当前已选（含可能已注销的旧分组，便于用户取消）
+  const allOptions = Array.from(new Set([...options, ...value])).sort()
+  const orphans = value.filter((g) => !options.includes(g))
+
+  const toggle = (g: string) => {
+    if (value.includes(g)) onChange(value.filter((x) => x !== g))
+    else onChange([...value, g])
+  }
+
+  // 触发器按钮的展示文案：未选 / 已选 N 个 / 单个分组直接显示名字
+  const triggerLabel = (() => {
+    if (value.length === 0) return '选择分组'
+    if (value.length === 1) return value[0]
+    return `已选 ${value.length} 个分组`
+  })()
+
+  return (
+    <div className="space-y-2">
+      {allOptions.length === 0 ? (
+        <ManageGroupsHint />
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={disabled}
+              className="w-full justify-between font-normal"
+            >
+              <span className={value.length === 0 ? 'text-muted-foreground' : ''}>
+                {triggerLabel}
+              </span>
+              <ChevronDown className="h-4 w-4 opacity-50" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            // 与触发器按钮等宽，避免菜单过窄或溢出
+            style={{ width: 'var(--radix-dropdown-menu-trigger-width)' }}
+            className="max-h-72 overflow-y-auto"
+          >
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              选择分组（可多选）
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {allOptions.map((g) => {
+              const orphan = !options.includes(g)
+              const checked = value.includes(g)
+              return (
+                <DropdownMenuItem
+                  key={g}
+                  // 阻止默认 close-on-select：分组管理是多选场景，选完一个还要继续选
+                  onSelect={(e) => {
+                    e.preventDefault()
+                    toggle(g)
+                  }}
+                  className="cursor-pointer gap-2"
+                >
+                  <Checkbox checked={checked} className="pointer-events-none" />
+                  <span className={`flex-1 ${orphan ? 'italic text-amber-600' : ''}`}>
+                    {g}
+                    {orphan && '（已注销）'}
+                  </span>
+                  {checked && <Check className="h-3.5 w-3.5 text-primary" />}
+                </DropdownMenuItem>
+              )
+            })}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="cursor-pointer text-xs text-muted-foreground"
+              onSelect={(e) => {
+                e.preventDefault()
+                window.location.hash = '#/groups'
+              }}
+            >
+              管理分组…
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {value.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          已选：{value.join('、')}
+        </p>
+      )}
+      {orphans.length > 0 && (
+        <p className="text-xs text-amber-600">
+          有 {orphans.length} 个分组已不在注册表，建议取消或前往
+          <a href="#/groups" className="text-primary underline mx-1">
+            分组管理
+          </a>
+          重建。
+        </p>
+      )}
+    </div>
+  )
+}

--- a/admin-ui/src/components/groups-page.tsx
+++ b/admin-ui/src/components/groups-page.tsx
@@ -1,0 +1,302 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import {
+  Plus, FolderTree, Trash2, Pencil, Users, KeyRound, RefreshCw,
+} from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription,
+} from '@/components/ui/dialog'
+import {
+  useGroups, useCreateGroup, useUpdateGroup, useDeleteGroup,
+} from '@/hooks/use-groups'
+import { useConfirm } from '@/components/ui/confirm-dialog'
+import { extractErrorMessage } from '@/lib/utils'
+import type { GroupItem } from '@/types/api'
+
+/**
+ * 分组管理页：CRUD 已注册分组。
+ *
+ * 设计要点：
+ * - 分组是独立实体，凭据 / 客户端 Key 通过名字引用
+ * - 改名走级联（后端自动同步所有引用）
+ * - 删除默认拒绝有引用的，二次确认才允许 force 级联清理
+ * - 列表展示每个分组当前被多少个凭据 / Key 引用，删除前清楚知道影响
+ */
+export function GroupsPage() {
+  const { data, isLoading, isFetching, refetch } = useGroups()
+  const createGroup = useCreateGroup()
+  const updateGroup = useUpdateGroup()
+  const deleteGroup = useDeleteGroup()
+  const confirm = useConfirm()
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [createName, setCreateName] = useState('')
+  const [createDesc, setCreateDesc] = useState('')
+
+  const [editOpen, setEditOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<GroupItem | null>(null)
+  const [editNewName, setEditNewName] = useState('')
+  const [editDesc, setEditDesc] = useState('')
+
+  const groups = data?.groups ?? []
+
+  const openCreate = () => {
+    setCreateName('')
+    setCreateDesc('')
+    setCreateOpen(true)
+  }
+
+  const handleCreate = async () => {
+    const name = createName.trim()
+    if (!name) {
+      toast.error('分组名不能为空')
+      return
+    }
+    try {
+      await createGroup.mutateAsync({
+        name,
+        description: createDesc.trim() || undefined,
+      })
+      toast.success(`已创建分组：${name}`)
+      setCreateOpen(false)
+    } catch (e) {
+      toast.error(extractErrorMessage(e))
+    }
+  }
+
+  const openEdit = (g: GroupItem) => {
+    setEditTarget(g)
+    setEditNewName(g.name)
+    setEditDesc(g.description ?? '')
+    setEditOpen(true)
+  }
+
+  const handleEdit = async () => {
+    if (!editTarget) return
+    const newName = editNewName.trim()
+    if (!newName) {
+      toast.error('分组名不能为空')
+      return
+    }
+    try {
+      await updateGroup.mutateAsync({
+        name: editTarget.name,
+        req: {
+          newName: newName !== editTarget.name ? newName : undefined,
+          description: editDesc, // 空字符串 → 后端清空
+        },
+      })
+      const renamed = newName !== editTarget.name
+      toast.success(renamed ? `已改名：${editTarget.name} → ${newName}` : '备注已更新')
+      setEditOpen(false)
+    } catch (e) {
+      toast.error(extractErrorMessage(e))
+    }
+  }
+
+  const handleDelete = async (g: GroupItem) => {
+    const refs = g.credentialCount + g.clientKeyCount
+    // 无引用：单层确认；有引用：二次确认 + force
+    if (refs === 0) {
+      const ok = await confirm({
+        title: `删除分组 ${g.name}？`,
+        description: '该分组当前无任何引用，可以安全删除。',
+        confirmText: '删除',
+        destructive: true,
+      })
+      if (!ok) return
+      try {
+        await deleteGroup.mutateAsync({ name: g.name })
+        toast.success(`分组 ${g.name} 已删除`)
+      } catch (e) {
+        toast.error(extractErrorMessage(e))
+      }
+    } else {
+      const ok = await confirm({
+        title: `强制删除分组 ${g.name}？`,
+        description: `该分组当前被 ${g.credentialCount} 个凭据 + ${g.clientKeyCount} 把客户端 Key 引用。继续将级联清理这些引用（凭据从 groups 列表移除该分组；客户端 Key 解除绑定）。此操作不可撤销。`,
+        confirmText: '强制删除',
+        destructive: true,
+      })
+      if (!ok) return
+      try {
+        await deleteGroup.mutateAsync({ name: g.name, force: true })
+        toast.success(`分组 ${g.name} 已删除，已清理 ${refs} 个引用`)
+      } catch (e) {
+        toast.error(extractErrorMessage(e))
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <FolderTree className="h-4 w-4" />
+            分组管理
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            分组是凭据 / 客户端 Key 共享的独立实体；改名 / 删除会级联同步。
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={() => refetch()} disabled={isFetching}>
+            <RefreshCw className={`h-3.5 w-3.5 ${isFetching ? 'animate-spin' : ''}`} />
+            刷新
+          </Button>
+          <Button size="sm" onClick={openCreate}>
+            <Plus className="h-3.5 w-3.5" />
+            新建分组
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <Card><CardContent className="py-8 text-sm text-center text-muted-foreground">加载中…</CardContent></Card>
+      ) : groups.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-sm text-center text-muted-foreground space-y-2">
+            <FolderTree className="h-8 w-8 mx-auto opacity-40" />
+            <p>暂无分组。点上方「新建分组」开始。</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {groups.map((g) => (
+            <Card key={g.name}>
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="font-medium truncate">{g.name}</div>
+                    {g.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{g.description}</p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => openEdit(g)} title="编辑">
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-7 w-7 text-destructive hover:text-destructive"
+                      onClick={() => handleDelete(g)}
+                      title="删除"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2 text-xs">
+                  <Badge variant="secondary" className="gap-1">
+                    <Users className="h-3 w-3" />
+                    {g.credentialCount} 凭据
+                  </Badge>
+                  <Badge variant="secondary" className="gap-1">
+                    <KeyRound className="h-3 w-3" />
+                    {g.clientKeyCount} Key
+                  </Badge>
+                </div>
+
+                <p className="text-[11px] text-muted-foreground">
+                  创建于 {new Date(g.createdAt).toLocaleString()}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* 新建分组弹框 */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>新建分组</DialogTitle>
+            <DialogDescription>
+              注册后即可在凭据 / 客户端 Key 中选择该分组。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-sm font-medium">分组名 *</label>
+              <Input
+                placeholder="例如：客户A、生产、备用池"
+                value={createName}
+                onChange={(e) => setCreateName(e.target.value)}
+                disabled={createGroup.isPending}
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">备注（可选）</label>
+              <Input
+                placeholder="用途说明，方便后续辨认"
+                value={createDesc}
+                onChange={(e) => setCreateDesc(e.target.value)}
+                disabled={createGroup.isPending}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)} disabled={createGroup.isPending}>
+              取消
+            </Button>
+            <Button onClick={handleCreate} disabled={createGroup.isPending || !createName.trim()}>
+              {createGroup.isPending ? '创建中…' : '创建'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 编辑分组弹框 */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>编辑分组：{editTarget?.name}</DialogTitle>
+            <DialogDescription>
+              改名会级联同步所有引用此分组的凭据与客户端 Key。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-sm font-medium">分组名</label>
+              <Input
+                value={editNewName}
+                onChange={(e) => setEditNewName(e.target.value)}
+                disabled={updateGroup.isPending}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">备注</label>
+              <Input
+                placeholder="（清空备注请留空）"
+                value={editDesc}
+                onChange={(e) => setEditDesc(e.target.value)}
+                disabled={updateGroup.isPending}
+              />
+            </div>
+            {editTarget && (editTarget.credentialCount > 0 || editTarget.clientKeyCount > 0) && (
+              <p className="text-xs text-amber-600">
+                当前被 {editTarget.credentialCount} 凭据 + {editTarget.clientKeyCount} 客户端 Key 引用，改名会自动同步。
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)} disabled={updateGroup.isPending}>
+              取消
+            </Button>
+            <Button onClick={handleEdit} disabled={updateGroup.isPending || !editNewName.trim()}>
+              {updateGroup.isPending ? '保存中…' : '保存'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/admin-ui/src/components/overview-page.tsx
+++ b/admin-ui/src/components/overview-page.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Activity, Calendar, Coins, Cpu, KeyRound, Server } from 'lucide-react'
 import { useByCredential, useByModel, useOverview, useTimeSeries } from '@/hooks/use-stats'
 import { useClientKeys } from '@/hooks/use-client-keys'
+import { useGroupOptions } from '@/hooks/use-groups'
 import type {
   ClientKeyItem,
   CredentialDistribution,
@@ -78,6 +79,7 @@ export function OverviewPage() {
   const filters = useOverviewFilters()
   const { data: overview } = useOverview()
   const { data: keysData } = useClientKeys()
+  const groupOptions = useGroupOptions()
   const { data: series } = useTimeSeries(filters.timeFilter, filters.statsFilter)
   const { data: byModel } = useByModel(filters.timeFilter, filters.statsFilter)
   const { data: byCred } = useByCredential(filters.timeFilter, filters.statsFilter)
@@ -86,6 +88,7 @@ export function OverviewPage() {
   const credData = useMemo(() => byCred ?? [], [byCred])
   const rangeStats = useMemo(() => aggregateSeries(seriesData), [seriesData])
   const selectedKeyLabel = selectedStatsKeyLabel(filters.keyFilter, keysData?.keys ?? [])
+  const groupFilterActive = filters.groupFilter !== 'all'
 
   return (
     <div>
@@ -101,6 +104,9 @@ export function OverviewPage() {
         keys={keysData?.keys ?? []}
         selectedLabel={selectedKeyLabel}
         onChange={filters.setKeyFilter}
+        groupFilter={filters.groupFilter}
+        groupOptions={groupOptions}
+        onGroupChange={filters.setGroupFilter}
       />
       <TrendCard
         customEndDate={filters.customEndDate}
@@ -120,6 +126,7 @@ export function OverviewPage() {
         byCred={credData}
         byModel={modelData}
         timeText={timeLabel(filters.timeFilter)}
+        groupFilterActive={groupFilterActive}
       />
     </div>
   )
@@ -135,10 +142,13 @@ function useOverviewFilters() {
   const [draftGranularity, setDraftGranularity] = useState<StatsGranularity>('hour')
   const [draftRange, setDraftRange] = useState<StatsRange | undefined>('24h')
   const [keyFilter, setKeyFilter] = useState('all')
+  const [groupFilter, setGroupFilter] = useState('all')
   const statsFilter = useMemo<StatsFilter>(() => {
-    if (keyFilter === 'all') return {}
-    return { keyId: Number(keyFilter) }
-  }, [keyFilter])
+    const f: StatsFilter = {}
+    if (keyFilter !== 'all') f.keyId = Number(keyFilter)
+    if (groupFilter !== 'all') f.group = groupFilter
+    return f
+  }, [keyFilter, groupFilter])
   const applyCustomRange = () => {
     setTimeFilter(customTimeFilter(customStartDate, customEndDate, draftGranularity))
   }
@@ -163,11 +173,13 @@ function useOverviewFilters() {
     draftGranularity,
     draftRange,
     keyFilter,
+    groupFilter,
     selectPresetRange,
     setCustomEndDate: updateCustomEndDate,
     setCustomStartDate: updateCustomStartDate,
     setDraftGranularity,
     setKeyFilter,
+    setGroupFilter,
     statsFilter,
     timeFilter,
   }
@@ -267,34 +279,60 @@ function KeyFilterCard({
   keys,
   onChange,
   selectedLabel,
+  groupFilter,
+  groupOptions,
+  onGroupChange,
 }: {
   keyFilter: string
   keys: ClientKeyItem[]
   onChange: (value: string) => void
   selectedLabel: string
+  groupFilter: string
+  groupOptions: string[]
+  onGroupChange: (value: string) => void
 }) {
   return (
     <Card className="mb-6">
       <CardContent className="p-4 sm:p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <div className="text-sm font-medium">统计入口</div>
-            <div className="truncate text-[12px] text-muted-foreground">{selectedLabel}</div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium">统计筛选</div>
+            <div className="truncate text-[12px] text-muted-foreground">
+              {selectedLabel}
+              {groupFilter !== 'all' && ` · 分组：${groupFilter}`}
+            </div>
           </div>
-          <Select value={keyFilter} onValueChange={onChange}>
-            <SelectTrigger className="h-8 w-full sm:w-[220px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent align="end">
-              <SelectItem value="all">全部入口 Key</SelectItem>
-              <SelectItem value="0">管理员API密钥</SelectItem>
-              {keys.map((key) => (
-                <SelectItem key={key.id} value={String(key.id)}>
-                  {key.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {/* 入口 Key 筛选 */}
+            <Select value={keyFilter} onValueChange={onChange}>
+              <SelectTrigger className="h-8 w-full sm:w-[180px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectItem value="all">全部入口 Key</SelectItem>
+                <SelectItem value="0">管理员API密钥</SelectItem>
+                {keys.map((key) => (
+                  <SelectItem key={key.id} value={String(key.id)}>
+                    {key.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {/* 账号分组筛选 */}
+            <Select value={groupFilter} onValueChange={onGroupChange}>
+              <SelectTrigger className="h-8 w-full sm:w-[180px]">
+                <SelectValue placeholder="全部分组" />
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectItem value="all">全部分组</SelectItem>
+                {groupOptions.map((g) => (
+                  <SelectItem key={g} value={g}>
+                    {g}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
       </CardContent>
     </Card>
@@ -498,20 +536,30 @@ function DistributionPanels({
   byCred,
   byModel,
   timeText,
+  groupFilterActive,
 }: {
   byCred: CredentialDistribution[]
   byModel: ModelDistribution[]
   timeText: string
+  groupFilterActive: boolean
 }) {
   return (
     <div className="mb-6 grid gap-4 lg:grid-cols-2">
-      <ModelPanel data={byModel} timeText={timeText} />
+      <ModelPanel data={byModel} timeText={timeText} groupFilterActive={groupFilterActive} />
       <CredentialPanel data={byCred} />
     </div>
   )
 }
 
-function ModelPanel({ data, timeText }: { data: ModelDistribution[]; timeText: string }) {
+function ModelPanel({
+  data,
+  timeText,
+  groupFilterActive,
+}: {
+  data: ModelDistribution[]
+  timeText: string
+  groupFilterActive: boolean
+}) {
   return (
     <Card>
       <CardContent className="p-4 sm:p-5">
@@ -519,6 +567,12 @@ function ModelPanel({ data, timeText }: { data: ModelDistribution[]; timeText: s
           <h2 className="text-base font-semibold tracking-tight">按模型分布</h2>
           <span className="text-[11px] text-muted-foreground">{timeText}</span>
         </div>
+        {groupFilterActive && (
+          <p className="mb-3 rounded-md bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-600">
+            当前已启用「分组筛选」。模型分布暂未细分到分组维度，本卡片显示的是
+            <strong className="mx-0.5">不区分分组</strong>的模型聚合结果。
+          </p>
+        )}
         <ModelPieChart data={data} />
         {data.length > 0 && <ModelTable data={data} />}
       </CardContent>

--- a/admin-ui/src/components/trace-log-page.tsx
+++ b/admin-ui/src/components/trace-log-page.tsx
@@ -36,6 +36,7 @@ import {
   SelectItem as UiSelectItem,
 } from '@/components/ui/select'
 import { useTraces } from '@/hooks/use-traces'
+import { useClientKeys } from '@/hooks/use-client-keys'
 import {
   useLogGovernanceConfig,
   useSetLogGovernanceConfig,
@@ -105,15 +106,15 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`
 }
 
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K'
+  return String(n)
+}
+
 /** 千位分隔的完整数值（用于明细悬浮框） */
 function formatTokenFull(n: number): string {
   return n.toLocaleString('en-US')
-}
-
-/** 紧凑数值：>=1000 显示为 K（用于表格列） */
-function formatTokenCompact(n: number): string {
-  if (n < 1000) return String(n)
-  return `${(n / 1000).toFixed(1)}K`
 }
 
 function credLabel(id: number, email?: string | null): string {
@@ -121,9 +122,10 @@ function credLabel(id: number, email?: string | null): string {
   return email ? email : `#${id}`
 }
 
-function keySourceLabel(rec: TraceRecord): string {
-  if (rec.keySource === 'clientKey') return rec.keyName ?? `#${rec.keyId}`
-  return '管理员API密钥'
+function keyLabel(keyId: number, keyName?: string | null): string {
+  if (keyName) return keyName
+  if (keyId === 0) return '管理员API密钥'
+  return `#${keyId}`
 }
 
 const STATUS_OPTIONS = [
@@ -144,58 +146,6 @@ const ERROR_TYPE_OPTIONS = [
   { value: 'stream_interrupted', label: '流中断' },
   { value: 'unknown', label: '未知' },
 ]
-
-/** Token 用量单元格：紧凑展示总量，hover 显示分项明细 */
-function TokenCell({ rec }: { rec: TraceRecord }) {
-  const total =
-    rec.totalTokens ??
-    rec.inputTokens + rec.outputTokens + rec.cacheCreationTokens + rec.cacheReadTokens
-  // 全 0（早期失败、未走到上游）时不显示明细，仅占位
-  if (total === 0) {
-    return <span className="text-muted-foreground">—</span>
-  }
-  const rows: Array<[string, number]> = [
-    ['输入 Token', rec.inputTokens],
-    ['输出 Token', rec.outputTokens],
-  ]
-  if (rec.cacheCreationTokens > 0) rows.push(['缓存创建 Token', rec.cacheCreationTokens])
-  if (rec.cacheReadTokens > 0) rows.push(['缓存读取 Token', rec.cacheReadTokens])
-  return (
-    <TooltipProvider delayDuration={150}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="inline-flex items-center gap-1 font-mono tabular-nums cursor-default border-b border-dotted border-muted-foreground/40">
-            <span className="text-emerald-600 dark:text-emerald-400">
-              ↓{formatTokenCompact(rec.inputTokens + rec.cacheCreationTokens + rec.cacheReadTokens)}
-            </span>
-            <span className="text-violet-600 dark:text-violet-400">
-              ↑{formatTokenCompact(rec.outputTokens)}
-            </span>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent className="p-0">
-          <div className="min-w-[180px] px-3 py-2">
-            <div className="mb-1.5 text-[13px] font-semibold">Token 明细</div>
-            <div className="space-y-1 text-[12px]">
-              {rows.map(([label, val]) => (
-                <div key={label} className="flex items-center justify-between gap-6">
-                  <span className="text-muted-foreground">{label}</span>
-                  <span className="font-mono tabular-nums">{formatTokenFull(val)}</span>
-                </div>
-              ))}
-              <div className="mt-1 flex items-center justify-between gap-6 border-t border-border/50 pt-1">
-                <span className="font-medium">总 Token</span>
-                <span className="font-mono font-semibold tabular-nums">
-                  {formatTokenFull(total)}
-                </span>
-              </div>
-            </div>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )
-}
 
 /** 单跳明细行 */
 function AttemptRow({ a }: { a: TraceAttempt }) {
@@ -224,6 +174,60 @@ function AttemptRow({ a }: { a: TraceAttempt }) {
 }
 
 /** 可展开的链路行 */
+/** Token 用量单元格：紧凑展示总量，hover 显示分项明细 */
+function TokenCell({ rec }: { rec: TraceRecord }) {
+  const input = rec.inputTokens ?? 0
+  const output = rec.outputTokens ?? 0
+  const cacheCreation = rec.cacheCreationTokens ?? 0
+  const cacheRead = rec.cacheReadTokens ?? 0
+  const total = rec.totalTokens ?? input + output + cacheCreation + cacheRead
+  // 全 0（早期失败、未走到上游）时不显示明细，仅占位
+  if (total === 0) {
+    return <span className="text-muted-foreground">—</span>
+  }
+  const rows: Array<[string, number]> = [
+    ['输入 Token', input],
+    ['输出 Token', output],
+  ]
+  if (cacheCreation > 0) rows.push(['缓存创建 Token', cacheCreation])
+  if (cacheRead > 0) rows.push(['缓存读取 Token', cacheRead])
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex items-center gap-1 font-mono tabular-nums cursor-default border-b border-dotted border-muted-foreground/40">
+            <span className="text-emerald-600 dark:text-emerald-400">
+              ↓{formatTokens(input + cacheCreation + cacheRead)}
+            </span>
+            <span className="text-violet-600 dark:text-violet-400">
+              ↑{formatTokens(output)}
+            </span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="p-0">
+          <div className="min-w-[180px] px-3 py-2">
+            <div className="mb-1.5 text-[13px] font-semibold">Token 明细</div>
+            <div className="space-y-1 text-[12px]">
+              {rows.map(([label, val]) => (
+                <div key={label} className="flex items-center justify-between gap-6">
+                  <span className="text-muted-foreground">{label}</span>
+                  <span className="font-mono tabular-nums">{formatTokenFull(val)}</span>
+                </div>
+              ))}
+              <div className="mt-1 flex items-center justify-between gap-6 border-t border-border/50 pt-1">
+                <span className="font-medium">总 Token</span>
+                <span className="font-mono font-semibold tabular-nums">
+                  {formatTokenFull(total)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
 function TraceRow({ rec }: { rec: TraceRecord }) {
   const [open, setOpen] = useState(false)
   const errStyle = rec.errorType ? outcomeStyle(rec.errorType) : null
@@ -247,21 +251,31 @@ function TraceRow({ rec }: { rec: TraceRecord }) {
           <span className="inline-block max-w-[220px] truncate align-middle">{rec.model}</span>
           {rec.isStream && <Badge variant="outline" className="ml-1.5">流式</Badge>}
         </td>
+        <td className="py-2.5 pr-3 text-[13px]">
+          {rec.keyId === 0 ? (
+            <span className="text-muted-foreground">{keyLabel(rec.keyId, rec.keyName)}</span>
+          ) : (
+            <Badge variant="outline">{keyLabel(rec.keyId, rec.keyName)}</Badge>
+          )}
+        </td>
         <td className="py-2.5 pr-3">
           <StatusBadge status={rec.finalStatus} />
         </td>
-        <td className="py-2.5 pr-3 text-[13px] whitespace-nowrap">
-          {keySourceLabel(rec)}
-        </td>
         <TraceCredentialCell rec={rec} />
+        <td className="py-2.5 pr-3 text-[12px] tabular-nums">
+          <TokenCell rec={rec} />
+        </td>
+        <td className="py-2.5 pr-3 text-[13px] tabular-nums">
+          {rec.credits != null && rec.credits > 0 ? rec.credits.toFixed(4) : '—'}
+        </td>
+        <td className="py-2.5 pr-3 text-[13px] tabular-nums text-muted-foreground">
+          {rec.firstTokenMs != null ? formatDuration(rec.firstTokenMs) : '—'}
+        </td>
         <td className="py-2.5 pr-3">
           {errStyle ? <Badge variant={errStyle.variant}>{errStyle.label}</Badge> : '—'}
         </td>
         <td className="py-2.5 pr-3 text-[13px] tabular-nums">
           {Math.max(0, rec.totalAttempts - 1)}
-        </td>
-        <td className="py-2.5 pr-3 text-[13px]">
-          <TokenCell rec={rec} />
         </td>
         <td className="py-2.5 pr-3 text-[13px] tabular-nums text-muted-foreground">
           {formatDuration(rec.durationMs)}
@@ -285,7 +299,7 @@ function TraceCredentialCell({ rec }: { rec: TraceRecord }) {
 function ExpandedTraceRow({ rec }: { rec: TraceRecord }) {
   return (
     <tr className="border-b border-border/40 bg-secondary/20">
-      <td colSpan={10} className="px-3 py-3">
+      <td colSpan={12} className="px-3 py-3">
         <ExpandedDetail rec={rec} />
       </td>
     </tr>
@@ -469,8 +483,16 @@ const PAGE_SIZE = 50
 export function TraceLogPage() {
   const [status, setStatus] = useState('')
   const [errorType, setErrorType] = useState('')
+  const [keyId, setKeyId] = useState('')
   const [onlyFailed, setOnlyFailed] = useState(false)
   const [page, setPage] = useState(0)
+
+  const { data: keysData } = useClientKeys()
+  const keyOptions = [
+    { value: '', label: '全部 Key' },
+    { value: '0', label: 'master' },
+    ...(keysData?.keys ?? []).map((k) => ({ value: String(k.id), label: k.name })),
+  ]
 
   // 筛选条件变化时回到第一页
   const resetTo = <T,>(setter: (v: T) => void) => (v: T) => {
@@ -481,6 +503,7 @@ export function TraceLogPage() {
   const query: TraceQuery = {
     status: status || undefined,
     errorType: errorType || undefined,
+    keyId: keyId ? Number(keyId) : undefined,
     onlyFailed: onlyFailed || undefined,
     limit: PAGE_SIZE,
     offset: page * PAGE_SIZE,
@@ -500,6 +523,7 @@ export function TraceLogPage() {
           {total > 0 && <Badge variant="secondary">{total}</Badge>}
         </div>
         <div className="ml-auto flex flex-wrap items-center gap-2">
+          <Select value={keyId} onChange={resetTo(setKeyId)} options={keyOptions} />
           <Select value={status} onChange={resetTo(setStatus)} options={STATUS_OPTIONS} />
           <Select
             value={errorType}
@@ -540,12 +564,14 @@ export function TraceLogPage() {
                     <th className="py-2 pl-3 pr-2 font-medium"></th>
                     <th className="py-2 pr-3 font-medium">时间</th>
                     <th className="py-2 pr-3 font-medium">模型</th>
+                    <th className="py-2 pr-3 font-medium">客户端 Key</th>
                     <th className="py-2 pr-3 font-medium">状态</th>
-                    <th className="py-2 pr-3 font-medium">入口 Key</th>
                     <th className="py-2 pr-3 font-medium">最终凭据</th>
+                    <th className="py-2 pr-3 font-medium">Token</th>
+                    <th className="py-2 pr-3 font-medium">费用</th>
+                    <th className="py-2 pr-3 font-medium">首Token</th>
                     <th className="py-2 pr-3 font-medium">错误类型</th>
                     <th className="py-2 pr-3 font-medium">重试</th>
-                    <th className="py-2 pr-3 font-medium">Token</th>
                     <th className="py-2 pr-3 font-medium">耗时</th>
                   </tr>
                 </thead>

--- a/admin-ui/src/hooks/use-client-keys.ts
+++ b/admin-ui/src/hooks/use-client-keys.ts
@@ -6,6 +6,7 @@ import {
   updateClientKey,
   setClientKeyDisabled,
   resetClientKeyStats,
+  rotateClientKey,
 } from '@/api/client-keys'
 import type { CreateClientKeyRequest, UpdateClientKeyRequest } from '@/types/api'
 
@@ -55,6 +56,14 @@ export function useResetClientKeyStats() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => resetClientKeyStats(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['client-keys'] }),
+  })
+}
+
+export function useRotateClientKey() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => rotateClientKey(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['client-keys'] }),
   })
 }

--- a/admin-ui/src/hooks/use-groups.ts
+++ b/admin-ui/src/hooks/use-groups.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  listGroups,
+  createGroup,
+  deleteGroup,
+  updateGroup,
+} from '@/api/groups'
+import type { CreateGroupRequest, UpdateGroupRequest } from '@/types/api'
+
+export function useGroups() {
+  return useQuery({
+    queryKey: ['groups'],
+    queryFn: listGroups,
+    // 分组变更频率低（人工操作），15s 自动刷新足够
+    refetchInterval: 15000,
+    staleTime: 5000,
+  })
+}
+
+/**
+ * 给所有 GroupSelect 用的"已注册分组名"字符串数组。
+ * 内部复用 useGroups 缓存，不会重复打接口。
+ */
+export function useGroupOptions(): string[] {
+  const { data } = useGroups()
+  return (data?.groups ?? []).map((g) => g.name)
+}
+
+export function useCreateGroup() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (req: CreateGroupRequest) => createGroup(req),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['groups'] }),
+  })
+}
+
+export function useUpdateGroup() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ name, req }: { name: string; req: UpdateGroupRequest }) =>
+      updateGroup(name, req),
+    onSuccess: () => {
+      // 改名 / 改备注会影响凭据 / Key 的展示，三处缓存全部失效
+      qc.invalidateQueries({ queryKey: ['groups'] })
+      qc.invalidateQueries({ queryKey: ['credentials'] })
+      qc.invalidateQueries({ queryKey: ['client-keys'] })
+    },
+  })
+}
+
+export function useDeleteGroup() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ name, force }: { name: string; force?: boolean }) =>
+      deleteGroup(name, !!force),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['groups'] })
+      qc.invalidateQueries({ queryKey: ['credentials'] })
+      qc.invalidateQueries({ queryKey: ['client-keys'] })
+    },
+  })
+}

--- a/admin-ui/src/hooks/use-stats.ts
+++ b/admin-ui/src/hooks/use-stats.ts
@@ -36,7 +36,7 @@ function timeKey(time: StatsTimeFilter) {
 
 export function useTimeSeries(time: StatsTimeFilter, filter?: StatsFilter) {
   return useQuery({
-    queryKey: ['stats', 'timeseries', ...timeKey(time), filter?.keyId ?? 'all'],
+    queryKey: ['stats', 'timeseries', ...timeKey(time), filter?.keyId ?? 'all', filter?.group ?? 'all'],
     queryFn: () => getTimeSeries(time, filter),
     ...COMMON,
   })
@@ -44,7 +44,7 @@ export function useTimeSeries(time: StatsTimeFilter, filter?: StatsFilter) {
 
 export function useByModel(time: StatsTimeFilter, filter?: StatsFilter) {
   return useQuery({
-    queryKey: ['stats', 'by-model', ...timeKey(time), filter?.keyId ?? 'all'],
+    queryKey: ['stats', 'by-model', ...timeKey(time), filter?.keyId ?? 'all', filter?.group ?? 'all'],
     queryFn: () => getByModel(time, filter),
     ...COMMON,
   })
@@ -52,7 +52,7 @@ export function useByModel(time: StatsTimeFilter, filter?: StatsFilter) {
 
 export function useByCredential(time: StatsTimeFilter, filter?: StatsFilter) {
   return useQuery({
-    queryKey: ['stats', 'by-credential', ...timeKey(time), filter?.keyId ?? 'all'],
+    queryKey: ['stats', 'by-credential', ...timeKey(time), filter?.keyId ?? 'all', filter?.group ?? 'all'],
     queryFn: () => getByCredential(time, filter),
     ...COMMON,
   })

--- a/admin-ui/src/lib/utils.ts
+++ b/admin-ui/src/lib/utils.ts
@@ -277,3 +277,4 @@ export function generateApiKey(prefix: string = 'sk-kiro-', randomLen: number = 
   }
   return prefix + out
 }
+

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -32,6 +32,10 @@ export interface CredentialStatusItem {
   /** 账号级风控冷却剩余秒数（>0 表示冷却中） */
   throttledRemainingSecs?: number
   endpoint: string
+  /** 账号所属分组（可属于多个分组） */
+  groups?: string[]
+  /** 账号来源渠道（纯备注） */
+  sourceChannel?: string
   /** 后端缓存的最近一次余额（5 分钟内） */
   balance?: BalanceResponse
   /** 余额缓存的更新时间（Unix 秒） */
@@ -113,6 +117,8 @@ export interface AddCredentialRequest {
   kiroApiKey?: string
   endpoint?: string
   email?: string
+  groups?: string[]
+  sourceChannel?: string
 }
 
 // 添加凭据响应
@@ -129,6 +135,10 @@ export interface UpdateCredentialRequest {
   proxyUrl?: string
   proxyUsername?: string
   proxyPassword?: string
+  /** 账号所属分组（undefined 表示不修改，数组表示整体替换） */
+  groups?: string[]
+  /** 账号来源渠道（undefined 表示不修改，空串表示清除） */
+  sourceChannel?: string
 }
 
 // 更新 refreshToken 请求
@@ -353,6 +363,8 @@ export interface ClientKeyItem {
   totalOutputTokens: number
   totalCacheCreationTokens: number
   totalCacheReadTokens: number
+  /** 绑定的账号分组（未绑定时为 undefined） */
+  group?: string
 }
 
 export interface ClientKeysResponse {
@@ -363,6 +375,7 @@ export interface ClientKeysResponse {
 export interface CreateClientKeyRequest {
   name: string
   description?: string
+  group?: string
 }
 
 /** 创建响应：明文 Key 仅在此处返回一次 */
@@ -376,6 +389,7 @@ export interface CreateClientKeyResponse {
 export interface UpdateClientKeyRequest {
   name?: string
   description?: string
+  group?: string
 }
 
 // ============ 用量统计 ============
@@ -393,6 +407,8 @@ export interface StatsTimeFilter {
 export interface StatsFilter {
   /** 不传 = 全部；0 = 管理员API密钥；其它值 = 创建的客户端 Key id */
   keyId?: number
+  /** 按账号分组筛选（仅影响 timeseries / by-credential，by-model 不支持） */
+  group?: string
 }
 
 export interface OverviewStats {
@@ -460,7 +476,7 @@ export interface TraceRecord {
   keyId: number
   /** masterApiKey = 管理员API密钥；clientKey = 创建的客户端 Key */
   keySource: 'masterApiKey' | 'clientKey'
-  /** 创建的客户端 Key 名称；管理员业务 Key 为 null */
+  /** 发起请求的客户端 Key 名称（master 表示主 apiKey；管理员业务 Key 可为 null） */
   keyName?: string | null
   model: string
   isStream: boolean
@@ -474,16 +490,20 @@ export interface TraceRecord {
   durationMs: number
   /** 流式中断时已发送字节数 */
   interruptedAfterBytes: number | null
-  /** 输入 token（互斥口径：未被缓存覆盖的部分） */
-  inputTokens: number
-  /** 输出 token（估算） */
-  outputTokens: number
+  /** 输入 token */
+  inputTokens?: number
+  /** 输出 token */
+  outputTokens?: number
   /** 缓存创建 token */
-  cacheCreationTokens: number
+  cacheCreationTokens?: number
   /** 缓存读取 token */
-  cacheReadTokens: number
+  cacheReadTokens?: number
   /** 总 token = input + output + cache_creation + cache_read */
-  totalTokens: number
+  totalTokens?: number
+  /** 费用（credits） */
+  credits?: number
+  /** 首 Token 延迟（毫秒，仅流式有值） */
+  firstTokenMs?: number | null
   attempts: TraceAttempt[]
 }
 
@@ -492,6 +512,8 @@ export interface TraceQuery {
   status?: string
   errorType?: string
   credentialId?: number
+  /** 按发起请求的客户端 Key 筛选（0 = master apiKey） */
+  keyId?: number
   /** 该凭据在某一跳失败过（即便 trace 最终成功）——用于凭据失败详情 */
   failedAttemptCredentialId?: number
   model?: string
@@ -515,3 +537,32 @@ export interface FailureStats {
 
 /** credentialId(字符串) → 失败分类计数 */
 export type FailureStatsMap = Record<string, FailureStats>
+
+// ============ 账号分组（独立实体）============
+
+export interface GroupItem {
+  name: string
+  description?: string
+  createdAt: string
+  /** 引用计数：有多少个凭据带这个分组 */
+  credentialCount: number
+  /** 引用计数：有多少把客户端 Key 绑定这个分组 */
+  clientKeyCount: number
+}
+
+export interface GroupsResponse {
+  total: number
+  groups: GroupItem[]
+}
+
+export interface CreateGroupRequest {
+  name: string
+  description?: string
+}
+
+export interface UpdateGroupRequest {
+  /** 新名字；不传或与原名一致则不改名 */
+  newName?: string
+  /** 新备注；空字符串清除；undefined 保留原值 */
+  description?: string
+}

--- a/src/admin/client_keys.rs
+++ b/src/admin/client_keys.rs
@@ -49,6 +49,12 @@ pub struct ClientKey {
     /// 累计 credit 计费量（meteringEvent.usage 累加）
     #[serde(default)]
     pub total_credits: f64,
+    /// 绑定的账号分组名（可选）
+    ///
+    /// 设置后，用该 Key 发起的请求只会调度到 groups 包含此分组名的上游账号（严格隔离）。
+    /// None 表示不绑定分组，可使用全部账号（与 master apiKey 行为一致）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
 }
 
 /// 客户端 Key 管理器
@@ -140,7 +146,7 @@ impl ClientKeyManager {
     }
 
     /// 创建新 Key（生成明文随机串），返回新建条目
-    pub fn create(&self, name: String, description: Option<String>) -> ClientKey {
+    pub fn create(&self, name: String, description: Option<String>, group: Option<String>) -> ClientKey {
         let key = generate_client_key();
         let mut inner = self.inner.write();
         let id = inner.next_id;
@@ -159,6 +165,7 @@ impl ClientKeyManager {
             total_cache_creation_tokens: 0,
             total_cache_read_tokens: 0,
             total_credits: 0.0,
+            group: group.filter(|g| !g.trim().is_empty()),
         };
         inner.by_key.insert(key, id);
         inner.entries.insert(id, entry.clone());
@@ -201,6 +208,7 @@ impl ClientKeyManager {
         id: u64,
         name: Option<String>,
         description: Option<Option<String>>,
+        group: Option<Option<String>>,
     ) -> bool {
         let mut inner = self.inner.write();
         let updated = match inner.entries.get_mut(&id) {
@@ -211,6 +219,9 @@ impl ClientKeyManager {
                 if let Some(d) = description {
                     e.description = d;
                 }
+                if let Some(g) = group {
+                    e.group = g.filter(|s| !s.trim().is_empty());
+                }
                 true
             }
             None => false,
@@ -219,6 +230,87 @@ impl ClientKeyManager {
             self.save_locked(&inner);
         }
         updated
+    }
+
+    /// 返回指定 Key 绑定的分组名（None 表示未绑定或 Key 不存在）
+    pub fn group_of(&self, id: u64) -> Option<String> {
+        self.inner.read().entries.get(&id).and_then(|e| e.group.clone())
+    }
+
+    /// 列出所有当前被引用的分组名（仅去重，不带计数）。
+    pub fn used_group_names(&self) -> Vec<String> {
+        let inner = self.inner.read();
+        let mut set: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for e in inner.entries.values() {
+            if let Some(g) = &e.group {
+                set.insert(g.clone());
+            }
+        }
+        let mut list: Vec<String> = set.into_iter().collect();
+        list.sort();
+        list
+    }
+
+    /// 统计指定分组被多少把 Key 绑定（用于分组管理页 / 删除前提示）。
+    pub fn count_with_group(&self, group: &str) -> usize {
+        self.inner
+            .read()
+            .entries
+            .values()
+            .filter(|e| e.group.as_deref() == Some(group))
+            .count()
+    }
+
+    /// 把所有引用 `old` 的 Key 的 group 字段改为 `new`（分组改名级联用）。
+    /// 返回受影响的 Key 数。
+    pub fn rename_group(&self, old: &str, new: &str) -> usize {
+        let mut inner = self.inner.write();
+        let mut affected = 0usize;
+        for entry in inner.entries.values_mut() {
+            if entry.group.as_deref() == Some(old) {
+                entry.group = Some(new.to_string());
+                affected += 1;
+            }
+        }
+        if affected > 0 {
+            self.save_locked(&inner);
+        }
+        affected
+    }
+
+    /// 把所有引用 `name` 的 Key 的 group 字段清空（强删分组级联用）。
+    /// 返回受影响的 Key 数。
+    pub fn clear_group(&self, name: &str) -> usize {
+        let mut inner = self.inner.write();
+        let mut affected = 0usize;
+        for entry in inner.entries.values_mut() {
+            if entry.group.as_deref() == Some(name) {
+                entry.group = None;
+                affected += 1;
+            }
+        }
+        if affected > 0 {
+            self.save_locked(&inner);
+        }
+        affected
+    }
+
+    /// 轮换 Key 值：旧 Key 立即失效，生成新明文，保留 id/name/description/group/统计/disabled。
+    /// 用于「明文遗失」「下游怀疑泄漏」场景，比删后重建更安全（不会丢统计与分组绑定）。
+    /// 命中且替换成功时返回新条目（含新明文）；id 不存在时返回 None。
+    pub fn rotate(&self, id: u64) -> Option<ClientKey> {
+        let new_key = generate_client_key();
+        let mut inner = self.inner.write();
+        // 取出旧条目并从 by_key 索引摘除
+        let old_key = inner.entries.get(&id).map(|e| e.key.clone())?;
+        inner.by_key.remove(&old_key);
+        // 写入新明文 + 索引
+        let entry = inner.entries.get_mut(&id)?;
+        entry.key = new_key.clone();
+        let snapshot = entry.clone();
+        inner.by_key.insert(new_key, id);
+        self.save_locked(&inner);
+        Some(snapshot)
     }
 
     /// 重置计数（保留 Key 与名称）
@@ -343,7 +435,7 @@ mod tests {
     #[test]
     fn create_and_verify() {
         let mgr = ClientKeyManager::new();
-        let entry = mgr.create("test".to_string(), None);
+        let entry = mgr.create("test".to_string(), None, None);
         assert!(entry.key.starts_with(CLIENT_KEY_PREFIX));
         assert_eq!(mgr.verify_and_touch(&entry.key), Some(entry.id));
         // 不带前缀的拒绝
@@ -353,7 +445,7 @@ mod tests {
     #[test]
     fn disabled_key_rejected() {
         let mgr = ClientKeyManager::new();
-        let entry = mgr.create("test".to_string(), None);
+        let entry = mgr.create("test".to_string(), None, None);
         mgr.set_disabled(entry.id, true);
         assert_eq!(mgr.verify_and_touch(&entry.key), None);
         mgr.set_disabled(entry.id, false);
@@ -363,7 +455,7 @@ mod tests {
     #[test]
     fn record_usage_accumulates() {
         let mgr = ClientKeyManager::new();
-        let entry = mgr.create("test".to_string(), None);
+        let entry = mgr.create("test".to_string(), None, None);
         mgr.record_usage(entry.id, 100, 50, 0, 0, 0.0);
         mgr.record_usage(entry.id, 200, 30, 5, 10, 1.5);
         let list = mgr.list();
@@ -378,5 +470,36 @@ mod tests {
     fn mask_format() {
         assert_eq!(mask_client_key("csk_abcdefghijklmnop"), "csk_abcd...mnop");
         assert_eq!(mask_client_key("short"), "short");
+    }
+
+    #[test]
+    fn rotate_replaces_key_but_keeps_metadata_and_stats() {
+        let mgr = ClientKeyManager::new();
+        let entry = mgr.create("kb".to_string(), Some("desc".into()), Some("groupA".into()));
+        // 累计一些统计
+        mgr.record_usage(entry.id, 100, 50, 5, 10, 1.5);
+        let old_key = entry.key.clone();
+        let rotated = mgr.rotate(entry.id).expect("rotate should succeed");
+        // 新 Key 与旧 Key 不同、且仍带前缀
+        assert_ne!(rotated.key, old_key);
+        assert!(rotated.key.starts_with(CLIENT_KEY_PREFIX));
+        // 元数据保留
+        assert_eq!(rotated.id, entry.id);
+        assert_eq!(rotated.name, "kb");
+        assert_eq!(rotated.description.as_deref(), Some("desc"));
+        assert_eq!(rotated.group.as_deref(), Some("groupA"));
+        // 统计保留
+        assert_eq!(rotated.total_input_tokens, 100);
+        assert_eq!(rotated.total_output_tokens, 50);
+        // 旧 Key 立即失效
+        assert_eq!(mgr.verify_and_touch(&old_key), None);
+        // 新 Key 命中
+        assert_eq!(mgr.verify_and_touch(&rotated.key), Some(entry.id));
+    }
+
+    #[test]
+    fn rotate_unknown_id_returns_none() {
+        let mgr = ClientKeyManager::new();
+        assert!(mgr.rotate(999).is_none());
     }
 }

--- a/src/admin/groups.rs
+++ b/src/admin/groups.rs
@@ -1,0 +1,376 @@
+//! 账号分组管理（独立实体版）
+//!
+//! 此模块把"分组"从依附于凭据 / 客户端 Key 的字符串标签，提升为一等实体：
+//! - 分组在 `groups.json` 中独立持久化（与 `credentials.json` 同目录）
+//! - 凭据 / 客户端 Key 的 `groups`/`group` 字段引用分组**名字**（保持 schema 兼容）
+//! - 增删改凭据 / Key 时，校验所引用的每个分组名都已注册（防 typo 漂移）
+//! - 改名走级联：自动同步所有引用的凭据与 Key
+//!
+//! 设计参考 `client_keys.rs` 的 RwLock + JSON 持久化模式。
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::Utc;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+/// 单个分组（持久化实体）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Group {
+    /// 分组名（主键，区分大小写、不允许重名、不允许首尾空白）
+    pub name: String,
+    /// 备注（可选）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// 创建时间（ISO8601）
+    pub created_at: String,
+}
+
+/// 分组管理器（线程安全 + 自动持久化）
+pub struct GroupManager {
+    inner: RwLock<Inner>,
+    path: Option<PathBuf>,
+}
+
+struct Inner {
+    /// 按 name 索引；HashMap 保证 O(1) 存在性查询
+    entries: std::collections::HashMap<String, Group>,
+}
+
+impl GroupManager {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Inner {
+                entries: std::collections::HashMap::new(),
+            }),
+            path: None,
+        }
+    }
+
+    /// 从 `groups.json` 加载（不存在时返回空管理器）
+    pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let list: Vec<Group> = if path.exists() {
+            let content = std::fs::read_to_string(&path)?;
+            if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                serde_json::from_str(&content)?
+            }
+        } else {
+            Vec::new()
+        };
+
+        let mut entries = std::collections::HashMap::with_capacity(list.len());
+        for g in list {
+            entries.insert(g.name.clone(), g);
+        }
+
+        Ok(Self {
+            inner: RwLock::new(Inner { entries }),
+            path: Some(path),
+        })
+    }
+
+    fn save_locked(&self, inner: &Inner) {
+        let path = match &self.path {
+            Some(p) => p,
+            None => return,
+        };
+        let mut list: Vec<&Group> = inner.entries.values().collect();
+        list.sort_by(|a, b| a.name.cmp(&b.name));
+        match serde_json::to_string_pretty(&list) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(path, json) {
+                    tracing::warn!("写入分组文件失败: {}", e);
+                }
+            }
+            Err(e) => tracing::warn!("序列化分组失败: {}", e),
+        }
+    }
+
+    /// 列出所有分组（按 name 字典序）
+    pub fn list(&self) -> Vec<Group> {
+        let inner = self.inner.read();
+        let mut list: Vec<Group> = inner.entries.values().cloned().collect();
+        list.sort_by(|a, b| a.name.cmp(&b.name));
+        list
+    }
+
+    /// 单个查询
+    pub fn get(&self, name: &str) -> Option<Group> {
+        self.inner.read().entries.get(name).cloned()
+    }
+
+    /// 是否存在指定分组（用于凭据 / Key 写入前校验）
+    pub fn exists(&self, name: &str) -> bool {
+        self.inner.read().entries.contains_key(name)
+    }
+
+    /// 校验一组名字是否全部已注册；返回未注册的名字列表（调用方据此决定是否拒绝写入）
+    #[allow(dead_code)]
+    pub fn missing<'a>(&self, names: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+        let inner = self.inner.read();
+        names
+            .into_iter()
+            .filter(|n| !inner.entries.contains_key(*n))
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    /// 创建分组。重名直接报错，不会静默覆盖（避免误创建丢备注）
+    pub fn create(&self, name: String, description: Option<String>) -> anyhow::Result<Group> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("分组名不能为空");
+        }
+        if trimmed.chars().count() > 64 {
+            anyhow::bail!("分组名过长（最多 64 字符）");
+        }
+        let mut inner = self.inner.write();
+        if inner.entries.contains_key(trimmed) {
+            anyhow::bail!("分组已存在: {}", trimmed);
+        }
+        let group = Group {
+            name: trimmed.to_string(),
+            description: description.map(|d| d.trim().to_string()).filter(|d| !d.is_empty()),
+            created_at: Utc::now().to_rfc3339(),
+        };
+        inner.entries.insert(group.name.clone(), group.clone());
+        self.save_locked(&inner);
+        Ok(group)
+    }
+
+    /// 更新备注（不改名字）
+    pub fn update_description(
+        &self,
+        name: &str,
+        description: Option<String>,
+    ) -> anyhow::Result<Group> {
+        let mut inner = self.inner.write();
+        let entry = inner
+            .entries
+            .get_mut(name)
+            .ok_or_else(|| anyhow::anyhow!("分组不存在: {}", name))?;
+        entry.description = description.map(|d| d.trim().to_string()).filter(|d| !d.is_empty());
+        let cloned = entry.clone();
+        self.save_locked(&inner);
+        Ok(cloned)
+    }
+
+    /// 改名。返回 `Ok(new_name)`；调用方负责级联更新凭据 / Key 中的引用。
+    /// `new_name` 必须未被占用；若与 `old_name` 完全一致则视为 no-op 直接返回成功。
+    pub fn rename(&self, old_name: &str, new_name: &str) -> anyhow::Result<Group> {
+        let trimmed = new_name.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("新分组名不能为空");
+        }
+        if trimmed.chars().count() > 64 {
+            anyhow::bail!("分组名过长（最多 64 字符）");
+        }
+
+        let mut inner = self.inner.write();
+        if !inner.entries.contains_key(old_name) {
+            anyhow::bail!("分组不存在: {}", old_name);
+        }
+        if trimmed == old_name {
+            return Ok(inner.entries.get(old_name).cloned().unwrap());
+        }
+        if inner.entries.contains_key(trimmed) {
+            anyhow::bail!("目标分组名已存在: {}", trimmed);
+        }
+        let mut group = inner.entries.remove(old_name).unwrap();
+        group.name = trimmed.to_string();
+        inner.entries.insert(group.name.clone(), group.clone());
+        self.save_locked(&inner);
+        Ok(group)
+    }
+
+    /// 删除分组。调用方应先确认无引用（或显式接受级联清理）。
+    /// 返回 `true` 表示真的删了；返回 `false` 表示原本就不存在。
+    pub fn delete(&self, name: &str) -> bool {
+        let mut inner = self.inner.write();
+        let removed = inner.entries.remove(name).is_some();
+        if removed {
+            self.save_locked(&inner);
+        }
+        removed
+    }
+
+    /// 启动迁移：从已有名字集合（凭据 groups + Key.group 聚合）反向写入注册表。
+    /// 已存在的名字保持原备注 / 创建时间不变；只补缺。返回新增数量。
+    pub fn bootstrap_from_existing<I: IntoIterator<Item = String>>(&self, names: I) -> usize {
+        let mut inner = self.inner.write();
+        let now = Utc::now().to_rfc3339();
+        let mut added = 0usize;
+        for raw in names {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if !inner.entries.contains_key(trimmed) {
+                inner.entries.insert(
+                    trimmed.to_string(),
+                    Group {
+                        name: trimmed.to_string(),
+                        description: None,
+                        created_at: now.clone(),
+                    },
+                );
+                added += 1;
+            }
+        }
+        if added > 0 {
+            self.save_locked(&inner);
+        }
+        added
+    }
+}
+
+impl Default for GroupManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 默认管理器路径（相对凭据目录）
+pub fn default_path_in(dir: &Path) -> PathBuf {
+    dir.join("groups.json")
+}
+
+/// Arc 包装，便于注入 axum State
+pub type SharedGroupManager = Arc<GroupManager>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_then_list_sorted() {
+        let mgr = GroupManager::new();
+        mgr.create("zz".into(), None).unwrap();
+        mgr.create("aa".into(), Some("first".into())).unwrap();
+        let list = mgr.list();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "aa");
+        assert_eq!(list[0].description.as_deref(), Some("first"));
+        assert_eq!(list[1].name, "zz");
+    }
+
+    #[test]
+    fn create_rejects_duplicate() {
+        let mgr = GroupManager::new();
+        mgr.create("dup".into(), None).unwrap();
+        assert!(mgr.create("dup".into(), None).is_err());
+        assert!(mgr.create("  dup  ".into(), None).is_err()); // trim 后等价
+    }
+
+    #[test]
+    fn create_rejects_empty_or_too_long() {
+        let mgr = GroupManager::new();
+        assert!(mgr.create("".into(), None).is_err());
+        assert!(mgr.create("   ".into(), None).is_err());
+        assert!(mgr.create("a".repeat(65), None).is_err());
+    }
+
+    #[test]
+    fn missing_reports_unregistered() {
+        let mgr = GroupManager::new();
+        mgr.create("known".into(), None).unwrap();
+        let missing = mgr.missing(["known", "ghost", "another-ghost"].iter().copied());
+        assert_eq!(missing.len(), 2);
+        assert!(missing.contains(&"ghost".to_string()));
+        assert!(missing.contains(&"another-ghost".to_string()));
+    }
+
+    #[test]
+    fn rename_swaps_key() {
+        let mgr = GroupManager::new();
+        mgr.create("old".into(), Some("note".into())).unwrap();
+        let renamed = mgr.rename("old", "new").unwrap();
+        assert_eq!(renamed.name, "new");
+        assert_eq!(renamed.description.as_deref(), Some("note"));
+        assert!(!mgr.exists("old"));
+        assert!(mgr.exists("new"));
+    }
+
+    #[test]
+    fn rename_to_existing_fails() {
+        let mgr = GroupManager::new();
+        mgr.create("a".into(), None).unwrap();
+        mgr.create("b".into(), None).unwrap();
+        assert!(mgr.rename("a", "b").is_err());
+        // 原数据不变
+        assert!(mgr.exists("a"));
+        assert!(mgr.exists("b"));
+    }
+
+    #[test]
+    fn rename_same_name_is_noop() {
+        let mgr = GroupManager::new();
+        mgr.create("x".into(), None).unwrap();
+        assert!(mgr.rename("x", "x").is_ok());
+        assert!(mgr.rename("x", "  x  ").is_ok());
+    }
+
+    #[test]
+    fn delete_returns_correct_flag() {
+        let mgr = GroupManager::new();
+        mgr.create("g".into(), None).unwrap();
+        assert!(mgr.delete("g"));
+        assert!(!mgr.delete("g"));
+        assert!(!mgr.exists("g"));
+    }
+
+    #[test]
+    fn bootstrap_dedups_and_skips_existing() {
+        let mgr = GroupManager::new();
+        mgr.create("existing".into(), Some("kept".into())).unwrap();
+        let added = mgr.bootstrap_from_existing(vec![
+            "existing".into(), // 已存在 → 跳过，备注保留
+            "new1".into(),
+            "new1".into(), // 重复 → 第二次跳过
+            "  new2  ".into(),
+            "".into(), // 空 → 跳过
+        ]);
+        assert_eq!(added, 2); // new1 + new2
+        let list = mgr.list();
+        assert_eq!(list.len(), 3);
+        // existing 的备注没被覆盖
+        let existing = mgr.get("existing").unwrap();
+        assert_eq!(existing.description.as_deref(), Some("kept"));
+    }
+
+    #[test]
+    fn load_empty_file_yields_empty_manager() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("kiro_test_groups_empty_{}.json", std::process::id()));
+        std::fs::write(&path, "").unwrap();
+        let mgr = GroupManager::load(&path).unwrap();
+        assert!(mgr.list().is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn save_roundtrip_preserves_data() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("kiro_test_groups_{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let mgr = GroupManager::load(&path).unwrap();
+        mgr.create("alpha".into(), Some("a-desc".into())).unwrap();
+        mgr.create("beta".into(), None).unwrap();
+
+        // 重新加载
+        let mgr2 = GroupManager::load(&path).unwrap();
+        let list = mgr2.list();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "alpha");
+        assert_eq!(list[0].description.as_deref(), Some("a-desc"));
+        assert_eq!(list[1].name, "beta");
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -750,6 +750,7 @@ fn key_to_item(k: &super::client_keys::ClientKey) -> ClientKeyItem {
         total_output_tokens: k.total_output_tokens,
         total_cache_creation_tokens: k.total_cache_creation_tokens,
         total_cache_read_tokens: k.total_cache_read_tokens,
+        group: k.group.clone(),
     }
 }
 
@@ -785,6 +786,10 @@ pub async fn create_client_key(
             .description
             .map(|d| d.trim().to_string())
             .filter(|d| !d.is_empty()),
+        payload
+            .group
+            .map(|g| g.trim().to_string())
+            .filter(|g| !g.is_empty()),
     );
     Json(CreateClientKeyResponse {
         id: entry.id,
@@ -825,7 +830,13 @@ pub async fn update_client_key(
     let description = payload
         .description
         .map(|d| if d.is_empty() { None } else { Some(d) });
-    if state.client_keys.update_meta(id, payload.name, description) {
+    let group = payload
+        .group
+        .map(|g| {
+            let t = g.trim();
+            if t.is_empty() { None } else { Some(t.to_string()) }
+        });
+    if state.client_keys.update_meta(id, payload.name, description, group) {
         Json(SuccessResponse::new(format!("Key #{} 已更新", id))).into_response()
     } else {
         (
@@ -881,6 +892,34 @@ pub async fn reset_client_key_stats(
     }
 }
 
+/// POST /api/admin/client-keys/:id/rotate
+///
+/// 轮换 Key 值：旧明文立即失效，生成新明文返回（仅此一次可见）。
+/// 保留 id/name/description/group/统计/disabled 不变，无需重新分组绑定。
+pub async fn rotate_client_key(
+    State(state): State<AdminState>,
+    Path(id): Path<u64>,
+) -> impl IntoResponse {
+    use axum::http::StatusCode;
+    match state.client_keys.rotate(id) {
+        Some(entry) => Json(CreateClientKeyResponse {
+            id: entry.id,
+            key: entry.key,
+            name: entry.name,
+            created_at: entry.created_at,
+        })
+        .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(super::types::AdminErrorResponse::not_found(format!(
+                "Key #{} 不存在",
+                id
+            ))),
+        )
+            .into_response(),
+    }
+}
+
 // ============ 用量统计 ============
 
 fn parse_range(params: &std::collections::HashMap<String, String>) -> Result<Range, String> {
@@ -898,6 +937,33 @@ fn parse_key_id(params: &HashMap<String, String>) -> Result<Option<u64>, String>
             .map_err(|_| "keyId 必须是数字".to_string()),
         None => Ok(None),
     }
+}
+
+/// 解析可选的分组筛选参数。空字符串视为不传。
+fn parse_group_filter(params: &HashMap<String, String>) -> Option<String> {
+    params
+        .get("group")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// 把 group 名转换为该分组下所有凭据 id 的白名单，给 UsageAggregator 用。
+/// 返回 None 表示未指定分组（不过滤）；返回 Some(空集) 也是合法值——意味着该分组下没有凭据，
+/// 所有 query 都会自然返回空结果。
+fn group_to_cred_ids(
+    state: &AdminState,
+    group: Option<&str>,
+) -> Option<std::collections::HashSet<u64>> {
+    let g = group?;
+    let snapshot = state.service.get_all_credentials();
+    Some(
+        snapshot
+            .credentials
+            .iter()
+            .filter(|c| c.groups.iter().any(|cg| cg == g))
+            .map(|c| c.id)
+            .collect(),
+    )
 }
 
 fn parse_granularity(params: &HashMap<String, String>) -> Result<StatsGranularity, String> {
@@ -987,7 +1053,7 @@ pub async fn stats_overview(State(state): State<AdminState>) -> impl IntoRespons
     Json(response)
 }
 
-/// GET /api/admin/stats/timeseries?range=24h|7d|30d&granularity=hour|day
+/// GET /api/admin/stats/timeseries?range=24h|7d|30d&granularity=hour|day&group=...
 pub async fn stats_timeseries(
     State(state): State<AdminState>,
     Query(params): Query<std::collections::HashMap<String, String>>,
@@ -996,7 +1062,9 @@ pub async fn stats_timeseries(
         Ok(parts) => parts,
         Err(message) => return stats_bad_request(message),
     };
-    let points = state.usage_aggregator.query_timeseries(window, key_id);
+    let group = parse_group_filter(&params);
+    let cred_ids = group_to_cred_ids(&state, group.as_deref());
+    let points = state.usage_aggregator.query_timeseries(window, key_id, cred_ids.as_ref());
     Json(points).into_response()
 }
 
@@ -1022,14 +1090,24 @@ pub async fn stats_by_credential(
         Ok(parts) => parts,
         Err(message) => return stats_bad_request(message),
     };
-    // 拉一份凭据快照，把 email 附加到响应里方便前端展示
+    let group = parse_group_filter(&params);
+    // 拉一份凭据快照（既给响应附加 email，也用来按 group 构建 cred_ids 白名单，
+    // 避免分别查两次）
     let snapshot = state.service.get_all_credentials();
     let email_map: std::collections::HashMap<u64, Option<String>> = snapshot
         .credentials
         .iter()
         .map(|c| (c.id, c.email.clone()))
         .collect();
-    let data = state.usage_aggregator.query_by_credential(window, key_id);
+    let cred_ids: Option<std::collections::HashSet<u64>> = group.as_deref().map(|g| {
+        snapshot
+            .credentials
+            .iter()
+            .filter(|c| c.groups.iter().any(|cg| cg == g))
+            .map(|c| c.id)
+            .collect()
+    });
+    let data = state.usage_aggregator.query_by_credential(window, key_id, cred_ids.as_ref());
     let enriched: Vec<serde_json::Value> = data
         .into_iter()
         .map(|d| {
@@ -1061,6 +1139,7 @@ pub async fn list_traces(
         credential_id: params
             .get("credentialId")
             .and_then(|s| s.parse::<u64>().ok()),
+        key_id: params.get("keyId").and_then(|s| s.parse::<u64>().ok()),
         failed_attempt_credential_id: params
             .get("failedAttemptCredentialId")
             .and_then(|s| s.parse::<u64>().ok()),
@@ -1094,12 +1173,24 @@ pub async fn list_traces(
         .into_iter()
         .map(|k| (k.id, k.name))
         .collect();
+    // 客户端 Key 名称解析：master apiKey (key_id=0) 在前端显示为"管理员API密钥"，
+    // 其余客户端 Key 命中名称表则取名称、未命中则回退 #id。
+    let key_label = |key_id: u64| -> String {
+        if key_id == 0 {
+            "master".to_string()
+        } else {
+            client_key_name_map
+                .get(&key_id)
+                .cloned()
+                .unwrap_or_else(|| format!("#{}", key_id))
+        }
+    };
 
     let enriched: Vec<serde_json::Value> = records
         .into_iter()
         .map(|r| {
             let final_email = email_map.get(&r.final_credential_id).cloned().flatten();
-            let key_name = client_key_name_map.get(&r.key_id).cloned();
+            let key_name = key_label(r.key_id);
             // attempts 里每跳也附 email
             let attempts: Vec<serde_json::Value> = r
                 .attempts
@@ -1138,8 +1229,9 @@ pub async fn list_traces(
                 "outputTokens": r.output_tokens,
                 "cacheCreationTokens": r.cache_creation_tokens,
                 "cacheReadTokens": r.cache_read_tokens,
-                "totalTokens": r.input_tokens + r.output_tokens
-                    + r.cache_creation_tokens + r.cache_read_tokens,
+                "totalTokens": r.input_tokens + r.output_tokens + r.cache_creation_tokens + r.cache_read_tokens,
+                "credits": r.credits,
+                "firstTokenMs": r.first_token_ms,
                 "attempts": attempts,
             })
         })
@@ -1166,4 +1258,217 @@ pub async fn trace_failure_stats(State(state): State<AdminState>) -> impl IntoRe
         })
         .collect();
     Json(map)
+}
+
+// ============ 账号分组（独立实体）============
+
+fn group_to_item(
+    g: &super::groups::Group,
+    state: &AdminState,
+) -> super::types::GroupItem {
+    super::types::GroupItem {
+        name: g.name.clone(),
+        description: g.description.clone(),
+        created_at: g.created_at.clone(),
+        credential_count: state
+            .service
+            .token_manager()
+            .count_credentials_with_group(&g.name),
+        client_key_count: state.client_keys.count_with_group(&g.name),
+    }
+}
+
+/// GET /api/admin/groups
+pub async fn list_groups(State(state): State<AdminState>) -> impl IntoResponse {
+    let groups = state.groups.list();
+    let items: Vec<super::types::GroupItem> =
+        groups.iter().map(|g| group_to_item(g, &state)).collect();
+    Json(super::types::GroupsResponse {
+        total: items.len(),
+        groups: items,
+    })
+}
+
+/// POST /api/admin/groups
+pub async fn create_group(
+    State(state): State<AdminState>,
+    Json(payload): Json<super::types::CreateGroupRequest>,
+) -> impl IntoResponse {
+    match state
+        .groups
+        .create(payload.name, payload.description)
+    {
+        Ok(g) => Json(group_to_item(&g, &state)).into_response(),
+        Err(e) => {
+            let msg = e.to_string();
+            // "已存在" → 409；其他校验失败 → 400
+            let (code, resp) = if msg.contains("已存在") {
+                (
+                    StatusCode::CONFLICT,
+                    super::types::AdminErrorResponse::invalid_request(msg),
+                )
+            } else {
+                (
+                    StatusCode::BAD_REQUEST,
+                    super::types::AdminErrorResponse::invalid_request(msg),
+                )
+            };
+            (code, Json(resp)).into_response()
+        }
+    }
+}
+
+/// PATCH /api/admin/groups/:name
+///
+/// 改名 / 改备注。改名时级联更新所有引用该分组的凭据 / 客户端 Key。
+pub async fn update_group(
+    State(state): State<AdminState>,
+    Path(name): Path<String>,
+    Json(payload): Json<super::types::UpdateGroupRequest>,
+) -> impl IntoResponse {
+    if !state.groups.exists(&name) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(super::types::AdminErrorResponse::not_found(format!(
+                "分组 {} 不存在",
+                name
+            ))),
+        )
+            .into_response();
+    }
+
+    // 1. 改名（先校验目标名再级联）
+    let mut current_name = name.clone();
+    if let Some(new_name) = payload.new_name.as_deref() {
+        let trimmed = new_name.trim();
+        if !trimmed.is_empty() && trimmed != name {
+            // GroupManager 内做唯一性 / 长度 / 空校验
+            match state.groups.rename(&name, trimmed) {
+                Ok(_) => {}
+                Err(e) => {
+                    let msg = e.to_string();
+                    let code = if msg.contains("已存在") {
+                        StatusCode::CONFLICT
+                    } else {
+                        StatusCode::BAD_REQUEST
+                    };
+                    return (
+                        code,
+                        Json(super::types::AdminErrorResponse::invalid_request(msg)),
+                    )
+                        .into_response();
+                }
+            }
+            // 级联：失败时尝试回滚分组改名（避免注册表与凭据 / Key 不一致）
+            let cred_res = state
+                .service
+                .token_manager()
+                .rename_credential_group(&name, trimmed);
+            if let Err(e) = cred_res {
+                let _ = state.groups.rename(trimmed, &name);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(super::types::AdminErrorResponse::internal_error(format!(
+                        "级联更新凭据失败: {}",
+                        e
+                    ))),
+                )
+                    .into_response();
+            }
+            state.client_keys.rename_group(&name, trimmed);
+            current_name = trimmed.to_string();
+        }
+    }
+
+    // 2. 改备注
+    if let Some(desc) = payload.description {
+        let desc_opt = if desc.trim().is_empty() {
+            None
+        } else {
+            Some(desc)
+        };
+        if let Err(e) = state.groups.update_description(&current_name, desc_opt) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(super::types::AdminErrorResponse::invalid_request(e.to_string())),
+            )
+                .into_response();
+        }
+    }
+
+    let group = match state.groups.get(&current_name) {
+        Some(g) => g,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(super::types::AdminErrorResponse::internal_error(
+                    "分组在更新过程中消失，状态异常",
+                )),
+            )
+                .into_response();
+        }
+    };
+    Json(group_to_item(&group, &state)).into_response()
+}
+
+/// DELETE /api/admin/groups/:name?force=true
+///
+/// 默认拒绝删除仍被引用的分组；带 `force=true` 时级联清理所有引用并删除。
+pub async fn delete_group(
+    State(state): State<AdminState>,
+    Path(name): Path<String>,
+    Query(query): Query<super::types::DeleteGroupQuery>,
+) -> impl IntoResponse {
+    if !state.groups.exists(&name) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(super::types::AdminErrorResponse::not_found(format!(
+                "分组 {} 不存在",
+                name
+            ))),
+        )
+            .into_response();
+    }
+
+    let cred_count = state
+        .service
+        .token_manager()
+        .count_credentials_with_group(&name);
+    let key_count = state.client_keys.count_with_group(&name);
+
+    if (cred_count > 0 || key_count > 0) && !query.force {
+        return (
+            StatusCode::CONFLICT,
+            Json(super::types::AdminErrorResponse::invalid_request(format!(
+                "分组仍被引用（凭据 {} / 客户端 Key {}），传 ?force=true 级联清理",
+                cred_count, key_count
+            ))),
+        )
+            .into_response();
+    }
+
+    if query.force {
+        if let Err(e) = state
+            .service
+            .token_manager()
+            .remove_credential_group(&name)
+        {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(super::types::AdminErrorResponse::internal_error(format!(
+                    "级联清理凭据失败: {}",
+                    e
+                ))),
+            )
+                .into_response();
+        }
+        state.client_keys.clear_group(&name);
+    }
+
+    state.groups.delete(&name);
+    Json(super::types::SuccessResponse::new(format!(
+        "分组 {} 已删除",
+        name
+    )))
+    .into_response()
 }

--- a/src/admin/middleware.rs
+++ b/src/admin/middleware.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 
 use super::client_keys::SharedClientKeyManager;
+use super::groups::SharedGroupManager;
 use super::service::AdminService;
 use super::types::AdminErrorResponse;
 use super::usage_stats::SharedAggregator;
@@ -34,6 +35,8 @@ pub struct AdminState {
     pub usage_aggregator: SharedAggregator,
     /// 请求链路追踪存储（与 anthropic 路由共享）
     pub trace_store: SharedTraceStore,
+    /// 账号分组注册表（持久化到 groups.json）
+    pub groups: SharedGroupManager,
 }
 
 impl AdminState {
@@ -44,6 +47,7 @@ impl AdminState {
         client_keys: SharedClientKeyManager,
         usage_aggregator: SharedAggregator,
         trace_store: SharedTraceStore,
+        groups: SharedGroupManager,
     ) -> Self {
         Self {
             admin_api_key: Arc::new(RwLock::new(admin_api_key.into())),
@@ -52,6 +56,7 @@ impl AdminState {
             client_keys,
             usage_aggregator,
             trace_store,
+            groups,
         }
     }
 }

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -25,10 +25,12 @@ mod service;
 pub mod types;
 mod binary_update;
 pub mod client_keys;
+pub mod groups;
 pub mod usage_stats;
 pub mod trace_db;
 
 pub use client_keys::ClientKeyManager;
+pub use groups::GroupManager;
 pub use middleware::AdminState;
 pub use router::create_admin_router;
 pub use service::AdminService;

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -10,20 +10,21 @@ use super::{
         add_credential, add_proxy, apply_image_update, assign_proxies_round_robin,
         assign_proxy_to_credential, batch_add_proxies, check_all_proxies, check_proxy,
         check_rate_limit, check_update, clear_throttle, complete_social_login,
-        complete_social_relogin, create_client_key, delete_client_key, delete_credential,
-        delete_proxy, disable_quota_exceeded, enable_overage_all, export_credentials,
-        force_refresh_token, get_account_throttle_config, get_all_credentials,
-        get_credential_balance, get_credential_models, get_global_proxy, get_load_balancing_mode, get_log_governance_config,
-        get_proxy_pool, get_update_config, list_client_keys, list_traces, trace_failure_stats, poll_idc_login,
+        complete_social_relogin, create_client_key, create_group, delete_client_key,
+        delete_credential, delete_group, delete_proxy, disable_quota_exceeded, enable_overage_all,
+        export_credentials, force_refresh_token, get_account_throttle_config,
+        get_all_credentials, get_credential_balance, get_credential_models, get_global_proxy,
+        get_load_balancing_mode, get_log_governance_config, get_proxy_pool, get_update_config,
+        list_client_keys, list_groups, list_traces, trace_failure_stats, poll_idc_login,
         poll_idc_relogin, poll_social_login,
         poll_social_relogin, pull_update_image, reset_all_success_count, reset_client_key_stats,
-        reset_failure_count, reset_success_count, rollback_image_update,
+        reset_failure_count, reset_success_count, rollback_image_update, rotate_client_key,
         set_account_throttle_config, set_client_key_disabled, set_credential_disabled,
         set_credential_overage, set_credential_priority, set_global_proxy,
         set_load_balancing_mode, set_log_governance_config, set_proxy_enabled, set_update_config,
         start_idc_login, start_idc_relogin, start_social_login, start_social_relogin,
         stats_by_credential, stats_by_model, stats_overview, stats_timeseries, update_admin_key,
-        update_api_key, update_client_key, update_credential, update_refresh_token,
+        update_api_key, update_client_key, update_credential, update_group, update_refresh_token,
     },
     middleware::{AdminState, admin_auth_middleware},
 };
@@ -148,6 +149,12 @@ pub fn create_admin_router(state: AdminState) -> Router {
         )
         .route("/client-keys/{id}/disabled", post(set_client_key_disabled))
         .route("/client-keys/{id}/reset-stats", post(reset_client_key_stats))
+        .route("/client-keys/{id}/rotate", post(rotate_client_key))
+        .route("/groups", get(list_groups).post(create_group))
+        .route(
+            "/groups/{name}",
+            delete(delete_group).patch(update_group),
+        )
         .route("/stats/overview", get(stats_overview))
         .route("/stats/timeseries", get(stats_timeseries))
         .route("/stats/by-model", get(stats_by_model))

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -444,6 +444,11 @@ impl AdminService {
         svc
     }
 
+    /// 暴露 TokenManager 给 handlers（分组管理需要 count / rename / remove 凭据 groups 字段）
+    pub fn token_manager(&self) -> &Arc<MultiTokenManager> {
+        &self.token_manager
+    }
+
     /// 注入日志治理句柄（trace 存储 + 用量记录器），用于运行时改保留期/开关。
     pub fn with_log_governance(
         mut self,
@@ -499,6 +504,8 @@ impl AdminService {
                     refresh_failure_count: entry.refresh_failure_count,
                     disabled_reason: entry.disabled_reason,
                     endpoint: entry.endpoint.unwrap_or_else(|| default_endpoint.clone()),
+                    groups: entry.groups,
+                    source_channel: entry.source_channel,
                     balance,
                     balance_updated_at,
                 }
@@ -950,6 +957,8 @@ impl AdminService {
             disabled: false, // 新添加的凭据默认启用
             kiro_api_key: req.kiro_api_key,
             endpoint: req.endpoint,
+            groups: req.groups,
+            source_channel: req.source_channel,
         };
 
         // 调用 token_manager 添加凭据
@@ -988,6 +997,9 @@ impl AdminService {
                 req.proxy_username
                     .map(|v| if v.is_empty() { None } else { Some(v) }),
                 req.proxy_password
+                    .map(|v| if v.is_empty() { None } else { Some(v) }),
+                req.groups,
+                req.source_channel
                     .map(|v| if v.is_empty() { None } else { Some(v) }),
             )
             .map_err(|e| self.classify_error(e, id))
@@ -2082,6 +2094,8 @@ impl AdminService {
                 Some(proxy_url), // 设置或清除 proxy_url（Some(None) = 清除，Some(Some(url)) = 设置）
                 None,            // proxy_username 不修改
                 None,            // proxy_password 不修改
+                None,            // groups 不修改
+                None,            // source_channel 不修改
             )
             .map_err(|e| {
                 let msg = e.to_string();
@@ -2151,7 +2165,7 @@ impl AdminService {
             let url = urls[i % urls.len()].clone();
             if self
                 .token_manager
-                .update_credential(*cred_id, None, Some(Some(url)), None, None)
+                .update_credential(*cred_id, None, Some(Some(url)), None, None, None, None)
                 .is_ok()
             {
                 assigned += 1;

--- a/src/admin/trace_db.rs
+++ b/src/admin/trace_db.rs
@@ -107,18 +107,24 @@ pub struct TraceRecord {
     pub duration_ms: u64,
     /// 流式中断时已发送的字节数（区分完整失败 vs 半截中断）
     pub interrupted_after_bytes: Option<u64>,
-    /// 输入 token（互斥口径：未被缓存覆盖的部分）。无 usage 时为 0。
+    /// 输入 token（Anthropic 口径）
     #[serde(default)]
     pub input_tokens: u64,
-    /// 输出 token（估算）。
+    /// 输出 token
     #[serde(default)]
     pub output_tokens: u64,
-    /// 缓存创建 token（互斥口径）。
+    /// 缓存创建 token
     #[serde(default)]
     pub cache_creation_tokens: u64,
-    /// 缓存读取 token（互斥口径）。
+    /// 缓存读取 token
     #[serde(default)]
     pub cache_read_tokens: u64,
+    /// 费用（上游 meteringEvent 累计的 credits）
+    #[serde(default)]
+    pub credits: f64,
+    /// 首 Token 延迟（毫秒，仅流式有值；非流式为 None）
+    #[serde(default)]
+    pub first_token_ms: Option<u64>,
     /// 每跳明细
     pub attempts: Vec<TraceAttempt>,
 }
@@ -167,6 +173,8 @@ pub struct TraceQuery {
     pub error_type: Option<String>,
     /// 最终凭据 id
     pub credential_id: Option<u64>,
+    /// 客户端 Key id（0 = master apiKey）
+    pub key_id: Option<u64>,
     /// 该凭据在某一跳失败过（attempt 级，跨 trace 最终状态）。
     /// 用于"凭据失败详情"：即便整条 trace 最终成功，只要该凭据某跳失败也会命中。
     pub failed_attempt_credential_id: Option<u64>,
@@ -209,7 +217,7 @@ impl TraceStore {
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         conn.execute_batch(SCHEMA)?;
-        migrate_add_token_columns(&conn);
+        Self::migrate(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
             enabled: AtomicBool::new(enabled),
@@ -221,12 +229,54 @@ impl TraceStore {
     pub fn open_in_memory() -> rusqlite::Result<Self> {
         let conn = Connection::open_in_memory()?;
         conn.execute_batch(SCHEMA)?;
-        migrate_add_token_columns(&conn);
+        Self::migrate(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
             enabled: AtomicBool::new(true),
             retention_days: AtomicU64::new(DEFAULT_RETENTION_DAYS),
         })
+    }
+
+    /// 旧库迁移：为 traces 表补齐新增列（幂等，缺哪列加哪列）。
+    /// 老版本的 traces.db 只有基础列，新增的 token/credits/first_token_ms/key_source 需在此 ALTER。
+    fn migrate(conn: &Connection) -> rusqlite::Result<()> {
+        let mut existing: std::collections::HashSet<String> = std::collections::HashSet::new();
+        {
+            let mut stmt = conn.prepare("PRAGMA table_info(traces)")?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+            for name in rows {
+                existing.insert(name?);
+            }
+        }
+        // (列名, 定义) —— 与 SCHEMA 中新增列保持一致
+        // 注意 key_source 不带 NOT NULL：老库已有行需先以 NULL 添加再回填（SQLite ALTER ADD COLUMN
+        // NOT NULL 不带常量 DEFAULT 时无法对已有行赋值）。新插入永远写入合法值。
+        let columns: [(&str, &str); 7] = [
+            ("input_tokens", "INTEGER NOT NULL DEFAULT 0"),
+            ("output_tokens", "INTEGER NOT NULL DEFAULT 0"),
+            ("cache_creation_tokens", "INTEGER NOT NULL DEFAULT 0"),
+            ("cache_read_tokens", "INTEGER NOT NULL DEFAULT 0"),
+            ("credits", "REAL NOT NULL DEFAULT 0"),
+            ("first_token_ms", "INTEGER"),
+            ("key_source", "TEXT"),
+        ];
+        let key_source_added = !existing.contains("key_source");
+        for (name, def) in columns {
+            if !existing.contains(name) {
+                conn.execute_batch(&format!(
+                    "ALTER TABLE traces ADD COLUMN {} {};",
+                    name, def
+                ))?;
+            }
+        }
+        // 老库 key_source 列首次添加后，按 key_id 语义回填：master apiKey (key_id=0) 之外都视为客户端 Key。
+        if key_source_added {
+            conn.execute_batch(
+                "UPDATE traces SET key_source = CASE WHEN key_id = 0 \
+                 THEN 'masterApiKey' ELSE 'clientKey' END WHERE key_source IS NULL;",
+            )?;
+        }
+        Ok(())
     }
 
     /// 是否启用 trace 写入
@@ -272,8 +322,9 @@ impl TraceStore {
                 "INSERT OR REPLACE INTO traces (trace_id, ts, ts_epoch, key_id, key_source, model, \
                  is_stream, final_status, final_credential_id, error_type, error_message, \
                  total_attempts, duration_ms, interrupted_after_bytes, \
-                 input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens) \
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)",
+                 input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, \
+                 credits, first_token_ms) \
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
                 rusqlite::params![
                     rec.trace_id,
                     rec.ts,
@@ -293,6 +344,8 @@ impl TraceStore {
                     rec.output_tokens as i64,
                     rec.cache_creation_tokens as i64,
                     rec.cache_read_tokens as i64,
+                    rec.credits,
+                    rec.first_token_ms.map(|v| v as i64),
                 ],
             )?;
             for a in &rec.attempts {
@@ -360,6 +413,10 @@ impl TraceStore {
             clauses.push("final_credential_id = ?");
             params.push(Box::new(c as i64));
         }
+        if let Some(k) = q.key_id {
+            clauses.push("key_id = ?");
+            params.push(Box::new(k as i64));
+        }
         if let Some(c) = q.failed_attempt_credential_id {
             // 该凭据在某一跳失败过（不论 trace 最终成功与否）
             clauses.push(
@@ -403,7 +460,7 @@ impl TraceStore {
         let sql = format!(
             "SELECT trace_id, ts, key_id, key_source, model, is_stream, final_status, final_credential_id, \
              error_type, error_message, total_attempts, duration_ms, interrupted_after_bytes, \
-             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens \
+             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, credits, first_token_ms \
              FROM traces {} ORDER BY ts_epoch DESC LIMIT {} OFFSET {}",
             where_sql, limit, q.offset
         );
@@ -428,6 +485,8 @@ impl TraceStore {
                 output_tokens: row.get::<_, i64>(14)? as u64,
                 cache_creation_tokens: row.get::<_, i64>(15)? as u64,
                 cache_read_tokens: row.get::<_, i64>(16)? as u64,
+                credits: row.get::<_, f64>(17)?,
+                first_token_ms: row.get::<_, Option<i64>>(18)?.map(|v| v as u64),
                 attempts: Vec::new(),
             })
         })?;
@@ -545,32 +604,13 @@ pub struct FailureStats {
 /// 共享存储句柄
 pub type SharedTraceStore = Arc<TraceStore>;
 
-/// 给已存在的老 `traces` 表补 token 列（幂等）。
-///
-/// SCHEMA 用 `CREATE TABLE IF NOT EXISTS` 不会给已建表加列，所以升级到带 token 的
-/// 版本时，旧库里没有这些列。这里对每列做一次 `ADD COLUMN`，已存在时 SQLite 报
-/// "duplicate column name"，直接忽略即可——纯幂等，不依赖版本号。
-fn migrate_add_token_columns(conn: &Connection) {
-    const COLS: [&str; 4] = [
-        "input_tokens",
-        "output_tokens",
-        "cache_creation_tokens",
-        "cache_read_tokens",
-    ];
-    for col in COLS {
-        let sql = format!("ALTER TABLE traces ADD COLUMN {col} INTEGER NOT NULL DEFAULT 0");
-        // 列已存在会返回 Err（duplicate column），是预期内的幂等结果，忽略。
-        let _ = conn.execute(&sql, []);
-    }
-}
-
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS traces (
     trace_id          TEXT PRIMARY KEY,
     ts                TEXT NOT NULL,
     ts_epoch          INTEGER NOT NULL,
     key_id            INTEGER NOT NULL,
-    key_source        TEXT NOT NULL,
+    key_source        TEXT,
     model             TEXT NOT NULL,
     is_stream         INTEGER NOT NULL,
     final_status      TEXT NOT NULL,
@@ -583,7 +623,9 @@ CREATE TABLE IF NOT EXISTS traces (
     input_tokens      INTEGER NOT NULL DEFAULT 0,
     output_tokens     INTEGER NOT NULL DEFAULT 0,
     cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
-    cache_read_tokens INTEGER NOT NULL DEFAULT 0
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    credits           REAL NOT NULL DEFAULT 0,
+    first_token_ms    INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_traces_ts ON traces(ts_epoch DESC);
 CREATE INDEX IF NOT EXISTS idx_traces_status ON traces(final_status);
@@ -641,6 +683,8 @@ mod tests {
             output_tokens: 779,
             cache_creation_tokens: 0,
             cache_read_tokens: 101760,
+            credits: 0.0,
+            first_token_ms: None,
             attempts: vec![
                 TraceAttempt {
                     attempt: 0,

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -68,6 +68,12 @@ pub struct CredentialStatusItem {
     pub disabled_reason: Option<String>,
     /// 端点名称（决定该凭据走哪套 Kiro API，已回退到默认端点）
     pub endpoint: String,
+    /// 账号所属分组（可属于多个分组）
+    #[serde(default)]
+    pub groups: Vec<String>,
+    /// 账号来源渠道（纯备注）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_channel: Option<String>,
     /// 凭据余额（从缓存中读取的最近一次结果，可能为 None）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance: Option<BalanceResponse>,
@@ -169,6 +175,13 @@ pub struct AddCredentialRequest {
     /// 端点名称（可选，未配置时使用 config.defaultEndpoint）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
+
+    /// 账号所属分组（可属于多个分组，可选）
+    #[serde(default)]
+    pub groups: Vec<String>,
+    /// 账号来源渠道（纯备注，可选）
+    #[serde(default)]
+    pub source_channel: Option<String>,
 }
 
 fn default_auth_method() -> String {
@@ -201,6 +214,12 @@ pub struct UpdateCredentialRequest {
     pub proxy_username: Option<String>,
     /// 凭据级代理认证密码
     pub proxy_password: Option<String>,
+    /// 账号所属分组（None 表示不修改，Some 表示整体替换）
+    #[serde(default)]
+    pub groups: Option<Vec<String>>,
+    /// 账号来源渠道（None 表示不修改，空串表示清除）
+    #[serde(default)]
+    pub source_channel: Option<String>,
 }
 
 /// 添加凭据成功响应
@@ -650,6 +669,8 @@ pub struct ClientKeyItem {
     pub total_output_tokens: u64,
     pub total_cache_creation_tokens: u64,
     pub total_cache_read_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
 }
 
 /// 客户端 Key 列表响应
@@ -667,6 +688,8 @@ pub struct CreateClientKeyRequest {
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
+    pub group: Option<String>,
 }
 
 /// 创建客户端 Key 响应（明文 Key 仅在此处返回一次）
@@ -685,6 +708,8 @@ pub struct CreateClientKeyResponse {
 pub struct UpdateClientKeyRequest {
     pub name: Option<String>,
     pub description: Option<String>,
+    #[serde(default)]
+    pub group: Option<String>,
 }
 
 // ============ IdC 设备授权登录 ============
@@ -913,4 +938,58 @@ impl AdminErrorResponse {
     pub fn internal_error(message: impl Into<String>) -> Self {
         Self::new("internal_error", message)
     }
+}
+
+// ============ 账号分组（独立实体）============
+
+/// 单条分组（列表项）
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupItem {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: String,
+    /// 引用计数：有多少个凭据带这个分组（前端展示 / 删除前提醒）
+    pub credential_count: usize,
+    /// 引用计数：有多少把客户端 Key 绑定这个分组
+    pub client_key_count: usize,
+}
+
+/// 分组列表响应
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupsResponse {
+    pub total: usize,
+    pub groups: Vec<GroupItem>,
+}
+
+/// 创建分组请求
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateGroupRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// 更新分组请求（改名 / 改备注；两者都可选）
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateGroupRequest {
+    /// 新名字；不传或与原名一致则不改名
+    #[serde(default)]
+    pub new_name: Option<String>,
+    /// 新备注；传空字符串清除备注；不传字段则保留
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// 删除分组的可选查询参数
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteGroupQuery {
+    /// 强制删除：即使仍有引用也删；同时级联清理凭据 / Key 的引用
+    #[serde(default)]
+    pub force: bool,
 }

--- a/src/admin/usage_stats.rs
+++ b/src/admin/usage_stats.rs
@@ -194,6 +194,17 @@ impl BucketStats {
             self.errors += 1;
         }
     }
+
+    /// 把另一个 stats 累加到自己上（用于 group 过滤后重新汇总）
+    fn add_stats(&mut self, other: &BucketStats) {
+        self.input_tokens += other.input_tokens;
+        self.output_tokens += other.output_tokens;
+        self.cache_creation_tokens += other.cache_creation_tokens;
+        self.cache_read_tokens += other.cache_read_tokens;
+        self.credits += other.credits;
+        self.calls += other.calls;
+        self.errors += other.errors;
+    }
 }
 
 /// 单个时间桶含分组数据
@@ -424,6 +435,7 @@ impl UsageAggregator {
         &self,
         window: StatsQueryWindow,
         key_id: Option<u64>,
+        cred_filter: Option<&std::collections::HashSet<u64>>,
     ) -> Vec<TimeSeriesPoint> {
         let inner = self.inner.read();
         let buckets = select_buckets(&inner, window.granularity);
@@ -432,15 +444,32 @@ impl UsageAggregator {
             .iter()
             .filter(|b| bucket_in_window(b, window))
             .filter(|b| bucket_matches_key(b, key_id))
-            .map(|b| TimeSeriesPoint {
-                ts: ts_to_rfc3339(b.ts),
-                input_tokens: stats_for_key(b, key_id).input_tokens,
-                output_tokens: stats_for_key(b, key_id).output_tokens,
-                cache_creation_tokens: stats_for_key(b, key_id).cache_creation_tokens,
-                cache_read_tokens: stats_for_key(b, key_id).cache_read_tokens,
-                calls: stats_for_key(b, key_id).calls,
-                errors: stats_for_key(b, key_id).errors,
-                credits: stats_for_key(b, key_id).credits,
+            .map(|b| {
+                // 不带 group 过滤 → 走老逻辑（更快，命中预聚合 by_key/overall 桶）
+                let stats = match cred_filter {
+                    None => stats_for_key(b, key_id),
+                    Some(allow) => credential_group_for_key(b, key_id)
+                        .map(|group| {
+                            let mut s = BucketStats::default();
+                            for (cid, cs) in group {
+                                if allow.contains(cid) {
+                                    s.add_stats(cs);
+                                }
+                            }
+                            s
+                        })
+                        .unwrap_or_default(),
+                };
+                TimeSeriesPoint {
+                    ts: ts_to_rfc3339(b.ts),
+                    input_tokens: stats.input_tokens,
+                    output_tokens: stats.output_tokens,
+                    cache_creation_tokens: stats.cache_creation_tokens,
+                    cache_read_tokens: stats.cache_read_tokens,
+                    calls: stats.calls,
+                    errors: stats.errors,
+                    credits: stats.credits,
+                }
             })
             .collect();
         points.sort_by_key(|p| p.ts.clone());
@@ -485,6 +514,7 @@ impl UsageAggregator {
         &self,
         window: StatsQueryWindow,
         key_id: Option<u64>,
+        cred_filter: Option<&std::collections::HashSet<u64>>,
     ) -> Vec<CredentialDistribution> {
         let inner = self.inner.read();
         let buckets = select_buckets(&inner, window.granularity);
@@ -494,6 +524,11 @@ impl UsageAggregator {
                 continue;
             };
             for (id, stats) in group {
+                if let Some(allow) = cred_filter {
+                    if !allow.contains(id) {
+                        continue;
+                    }
+                }
                 let entry = acc.entry(*id).or_default();
                 entry.input_tokens += stats.input_tokens;
                 entry.output_tokens += stats.output_tokens;

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -130,10 +130,26 @@ pub(crate) struct RequestTracer {
     model: String,
     is_stream: bool,
     started_at: Instant,
+    /// 首个上游 chunk 到达时刻（仅流式标记；取第一次）
+    first_token_at: parking_lot::Mutex<Option<Instant>>,
     attempts: parking_lot::Mutex<Vec<TraceAttempt>>,
-    /// 最终 token 用量 (input, output, cache_creation, cache_read)，互斥口径。
-    /// 由各上报路径在 token 算出后调 [`Self::set_usage`] 填入，finalize 时落库。
-    usage: parking_lot::Mutex<Option<(i32, i32, i32, i32)>>,
+}
+
+/// 本次请求的用量快照（落入 trace 行，与 usage_log 同源）
+#[derive(Clone, Copy, Default)]
+pub(crate) struct TraceUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub credits: f64,
+}
+
+impl TraceUsage {
+    /// 错误早退等无用量场景
+    pub fn zero() -> Self {
+        Self::default()
+    }
 }
 
 struct RequestTraceOptions {
@@ -153,15 +169,17 @@ impl RequestTracer {
             model: options.model,
             is_stream: options.is_stream,
             started_at: Instant::now(),
+            first_token_at: parking_lot::Mutex::new(None),
             attempts: parking_lot::Mutex::new(Vec::new()),
-            usage: parking_lot::Mutex::new(None),
         }
     }
 
-    /// 记录本次请求的最终 token 用量（互斥口径，与 usage 日志 / SSE 上报同源）。
-    /// 在 finalize 之前调用；多次调用以最后一次为准。
-    pub fn set_usage(&self, input: i32, output: i32, cache_creation: i32, cache_read: i32) {
-        *self.usage.lock() = Some((input, output, cache_creation, cache_read));
+    /// 标记首个上游 chunk 到达（幂等，仅记录第一次）
+    pub fn mark_first_token(&self) {
+        let mut slot = self.first_token_at.lock();
+        if slot.is_none() {
+            *slot = Some(Instant::now());
+        }
     }
 
     /// 组装并落库一条完整链路。store 为 None 时不做任何事。
@@ -171,14 +189,16 @@ impl RequestTracer {
         error_type: Option<&str>,
         error_message: Option<&str>,
         interrupted_after_bytes: Option<u64>,
+        usage: TraceUsage,
     ) {
         let Some(store) = &self.store else { return };
         let attempts = std::mem::take(&mut *self.attempts.lock());
         // 最终凭据：最后一跳的命中凭据（成功跳即命中凭据，失败跳即最后尝试的凭据）
         let final_credential_id = attempts.last().map(|a| a.credential_id).unwrap_or(0);
-        // 最终 token 用量（互斥口径）；未上报时记 0。
-        let (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens) =
-            self.usage.lock().unwrap_or((0, 0, 0, 0));
+        let first_token_ms = self
+            .first_token_at
+            .lock()
+            .map(|t| t.duration_since(self.started_at).as_millis() as u64);
         let rec = TraceRecord {
             trace_id: self.trace_id.clone(),
             ts: self.ts.clone(),
@@ -193,10 +213,12 @@ impl RequestTracer {
             total_attempts: attempts.len() as u32,
             duration_ms: self.started_at.elapsed().as_millis() as u64,
             interrupted_after_bytes,
-            input_tokens: input_tokens.max(0) as u64,
-            output_tokens: output_tokens.max(0) as u64,
-            cache_creation_tokens: cache_creation_tokens.max(0) as u64,
-            cache_read_tokens: cache_read_tokens.max(0) as u64,
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_creation_tokens: usage.cache_creation_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+            credits: usage.credits,
+            first_token_ms,
             attempts,
         };
         store.insert(&rec);
@@ -576,7 +598,7 @@ pub async fn post_messages(
     // where the upstream may return a tool_use with name=web_search. Take the internal agentic loop: search internally and feed the results back.
     if websearch::has_web_search_among_tools(&payload) {
         tracing::info!("detected mixed tools containing web_search, entering the web_search agentic loop");
-        return super::websearch_loop::run_web_search_loop(provider, payload, hook, payload_stream)
+        return super::websearch_loop::run_web_search_loop(provider, payload, hook, payload_stream, key_ctx.group.clone())
             .await;
     }
 
@@ -659,7 +681,7 @@ pub async fn post_messages(
         let tracer = std::sync::Arc::new(RequestTracer::new(
             &state,
             RequestTraceOptions {
-                key_ctx,
+                key_ctx: key_ctx.clone(),
                 model: payload.model.clone(),
                 is_stream: true,
             },
@@ -675,6 +697,7 @@ pub async fn post_messages(
             hook,
             cache_usage,
             tracer,
+            key_ctx.group.clone(),
         )
         .await
     } else {
@@ -683,7 +706,7 @@ pub async fn post_messages(
         let tracer = std::sync::Arc::new(RequestTracer::new(
             &state,
             RequestTraceOptions {
-                key_ctx,
+                key_ctx: key_ctx.clone(),
                 model: payload.model.clone(),
                 is_stream: false,
             },
@@ -699,6 +722,7 @@ pub async fn post_messages(
             hook,
             cache_usage,
             tracer,
+            key_ctx.group.clone(),
         )
         .await
     }
@@ -716,14 +740,15 @@ async fn handle_stream_request(
     hook: UsageRecordHook,
     cache_usage: super::cache_metering::CacheUsage,
     tracer: std::sync::Arc<RequestTracer>,
+    group: Option<String>,
 ) -> Response {
     // 调用 Kiro API（支持多凭据故障转移）
-    let call_result = match provider.call_api_stream(request_body, Some(tracer.as_ref())).await {
+    let call_result = match provider.call_api_stream(request_body, Some(tracer.as_ref()), group.as_deref()).await {
         Ok(resp) => resp,
         Err(e) => {
             hook.record(0, input_tokens, 0, 0, 0, 0.0, "error");
             // 重试链路全部失败、未开始返回内容：error_type 取最后一跳分类
-            tracer.finalize("error", last_attempt_outcome(&tracer), Some(&e.to_string()), None);
+            tracer.finalize("error", last_attempt_outcome(&tracer), Some(&e.to_string()), None, TraceUsage::zero());
             return map_provider_error(e);
         }
     };
@@ -790,6 +815,7 @@ fn create_sse_stream(
                 chunk_result = body_stream.next() => {
                     match chunk_result {
                         Some(Ok(chunk)) => {
+                            tracer.mark_first_token();
                             sent_bytes += chunk.len() as u64;
                             // 解码事件
                             if let Err(e) = decoder.feed(&chunk) {
@@ -823,13 +849,14 @@ fn create_sse_stream(
                             tracing::error!("读取响应流失败: {}", e);
                             // 发送最终事件并结束（记为 error）
                             let final_events = ctx.generate_final_events();
-                            record_stream_usage(&hook, &ctx, credential_id, "error", &tracer);
+                            record_stream_usage(&hook, &ctx, credential_id, "error");
                             // 已开始返回内容后上游断流：标记为 interrupted，带已发送字节数
                             tracer.finalize(
                                 "interrupted",
                                 Some(outcome::STREAM_INTERRUPTED),
                                 Some(&e.to_string()),
                                 Some(sent_bytes),
+                                stream_trace_usage(&ctx),
                             );
                             let bytes: Vec<Result<Bytes, Infallible>> = final_events
                                 .into_iter()
@@ -840,8 +867,8 @@ fn create_sse_stream(
                         None => {
                             // 流结束，发送最终事件
                             let final_events = ctx.generate_final_events();
-                            record_stream_usage(&hook, &ctx, credential_id, "success", &tracer);
-                            tracer.finalize("success", None, None, None);
+                            record_stream_usage(&hook, &ctx, credential_id, "success");
+                            tracer.finalize("success", None, None, None, stream_trace_usage(&ctx));
                             let bytes: Vec<Result<Bytes, Infallible>> = final_events
                                 .into_iter()
                                 .map(|e| Ok(Bytes::from(e.to_sse_string())))
@@ -864,15 +891,14 @@ fn create_sse_stream(
     initial_stream.chain(processing_stream)
 }
 
-/// 从 StreamContext 提取最终用量，写入 hook，并同步给 tracer（trace 与 usage 同源）。
+/// 从 StreamContext 提取最终用量并写入 hook
 fn record_stream_usage(
     hook: &UsageRecordHook,
     ctx: &StreamContext,
     credential_id: u64,
     status: &str,
-    tracer: &RequestTracer,
 ) {
-    // 互斥分摊后的 (input, cache_creation, cache_read)，与 SSE 上报口径一致。
+    // 互斥分摊后的 (input, cache_creation, cache_read)，与 trace 上报口径一致。
     let (input, cache_creation, cache_read) = ctx.resolved_usage();
     hook.record(
         credential_id,
@@ -883,7 +909,18 @@ fn record_stream_usage(
         ctx.credits,
         status,
     );
-    tracer.set_usage(input, ctx.output_tokens, cache_creation, cache_read);
+}
+
+/// 从 StreamContext 提取用量，转成 trace 行用量（与 record_stream_usage 同源）
+fn stream_trace_usage(ctx: &StreamContext) -> TraceUsage {
+    let (input, cache_creation, cache_read) = ctx.resolved_usage();
+    TraceUsage {
+        input_tokens: input.max(0) as u64,
+        output_tokens: ctx.output_tokens.max(0) as u64,
+        cache_creation_tokens: cache_creation.max(0) as u64,
+        cache_read_tokens: cache_read.max(0) as u64,
+        credits: if ctx.credits.is_finite() && ctx.credits > 0.0 { ctx.credits } else { 0.0 },
+    }
 }
 
 use super::converter::get_context_window_size;
@@ -902,13 +939,14 @@ async fn handle_non_stream_request(
     hook: UsageRecordHook,
     cache_usage: super::cache_metering::CacheUsage,
     tracer: std::sync::Arc<RequestTracer>,
+    group: Option<String>,
 ) -> Response {
     // 调用 Kiro API（支持多凭据故障转移）
-    let call_result = match provider.call_api(request_body, Some(tracer.as_ref())).await {
+    let call_result = match provider.call_api(request_body, Some(tracer.as_ref()), group.as_deref()).await {
         Ok(resp) => resp,
         Err(e) => {
             hook.record(0, input_tokens, 0, 0, 0, 0.0, "error");
-            tracer.finalize("error", last_attempt_outcome(&tracer), Some(&e.to_string()), None);
+            tracer.finalize("error", last_attempt_outcome(&tracer), Some(&e.to_string()), None, TraceUsage::zero());
             return map_provider_error(e);
         }
     };
@@ -926,6 +964,7 @@ async fn handle_non_stream_request(
                 Some(outcome::STREAM_INTERRUPTED),
                 Some(&e.to_string()),
                 None,
+                TraceUsage::zero(),
             );
             return (
                 StatusCode::BAD_GATEWAY,
@@ -953,9 +992,8 @@ async fn handle_non_stream_request(
     let mut stop_reason = "end_turn".to_string();
     // 从 contextUsageEvent 计算的实际输入 tokens
     let mut context_input_tokens: Option<i32> = None;
-    // meteringEvent 上报的 token 与缓存数据
-    // 上游 metering 只给 credit；input 来自 contextUsage，output 来自估算。
-    // 缓存 input/cache_* 的互斥分摊在拿到 total 真值后由 cache_usage 完成。
+    // meteringEvent 上报的 credit 计费量（上游真实下发）；
+    // input/cache_* 的互斥分摊在拿到 total 真值后由 cache_usage 完成。
     let mut credits: f64 = 0.0;
 
     // 收集工具调用的增量 JSON
@@ -1079,9 +1117,9 @@ async fn handle_non_stream_request(
     // 估算输出 tokens（上游不下发 token，全部走估算）
     let output_tokens = token::estimate_output_tokens(&content);
 
-    // 全量 prompt token：contextUsage 真实值优先，否则用客户端估算。
+    // 输入 tokens：contextUsage 真实值优先，否则用客户端估算
     let total_input_tokens = resolve_usage_input_tokens(input_tokens, context_input_tokens);
-    // 互斥分摊：total − 缓存覆盖 = 未缓存 input；三者相加恒等于 total。
+    // 互斥分摊：input + cache_creation + cache_read == total
     let (final_input_tokens, cache_creation_tokens, cache_read_tokens) =
         cache_usage.split_against_total(total_input_tokens);
 
@@ -1111,13 +1149,19 @@ async fn handle_non_stream_request(
         credits,
         "success",
     );
-    tracer.set_usage(
-        final_input_tokens,
-        output_tokens,
-        cache_creation_tokens,
-        cache_read_tokens,
+    tracer.finalize(
+        "success",
+        None,
+        None,
+        None,
+        TraceUsage {
+            input_tokens: final_input_tokens.max(0) as u64,
+            output_tokens: output_tokens.max(0) as u64,
+            cache_creation_tokens: cache_creation_tokens.max(0) as u64,
+            cache_read_tokens: cache_read_tokens.max(0) as u64,
+            credits: if credits.is_finite() && credits > 0.0 { credits } else { 0.0 },
+        },
     );
-    tracer.finalize("success", None, None, None);
     (StatusCode::OK, Json(response_body)).into_response()
 }
 
@@ -1308,7 +1352,7 @@ pub async fn post_messages_cc(
     // where the upstream may return a tool_use with name=web_search. Take the internal agentic loop: search internally and feed the results back.
     if websearch::has_web_search_among_tools(&payload) {
         tracing::info!("detected mixed tools containing web_search, entering the web_search agentic loop");
-        return super::websearch_loop::run_web_search_loop(provider, payload, hook, payload_stream)
+        return super::websearch_loop::run_web_search_loop(provider, payload, hook, payload_stream, key_ctx.group.clone())
             .await;
     }
 
@@ -1378,8 +1422,7 @@ pub async fn post_messages_cc(
     let tool_name_map = conversion_result.tool_name_map;
     let known_tool_names = conversion_result.known_tool_names;
 
-    // CacheMeter：根据 cache_control 断点查 / 写中转层提示词缓存。
-    // 返回 estimate 口径的覆盖量；真实 input/cache 互斥分摊在拿到 total 真值时进行。
+    // CacheMeter：根据 cache_control 断点查 / 写中转层提示词缓存（estimate 口径）。
     let cache_usage = state
         .cache_meter
         .as_ref()
@@ -1391,7 +1434,7 @@ pub async fn post_messages_cc(
         let tracer = std::sync::Arc::new(RequestTracer::new(
             &state,
             RequestTraceOptions {
-                key_ctx,
+                key_ctx: key_ctx.clone(),
                 model: payload.model.clone(),
                 is_stream: true,
             },
@@ -1407,6 +1450,7 @@ pub async fn post_messages_cc(
             total_input_tokens,
             cache_usage,
             tracer,
+            key_ctx.group.clone(),
         )
         .await
     } else {
@@ -1415,7 +1459,7 @@ pub async fn post_messages_cc(
         let tracer = std::sync::Arc::new(RequestTracer::new(
             &state,
             RequestTraceOptions {
-                key_ctx,
+                key_ctx: key_ctx.clone(),
                 model: payload.model.clone(),
                 is_stream: false,
             },
@@ -1431,6 +1475,7 @@ pub async fn post_messages_cc(
             hook,
             cache_usage,
             tracer,
+            key_ctx.group.clone(),
         )
         .await
     }
@@ -1451,13 +1496,14 @@ async fn handle_stream_request_buffered(
     fallback_input_tokens: i32,
     cache_usage: super::cache_metering::CacheUsage,
     tracer: std::sync::Arc<RequestTracer>,
+    group: Option<String>,
 ) -> Response {
     // 调用 Kiro API（支持多凭据故障转移）
-    let call_result = match provider.call_api_stream(request_body, Some(tracer.as_ref())).await {
+    let call_result = match provider.call_api_stream(request_body, Some(tracer.as_ref()), group.as_deref()).await {
         Ok(resp) => resp,
         Err(e) => {
             hook.record(0, fallback_input_tokens, 0, 0, 0, 0.0, "error");
-            tracer.finalize("error", last_attempt_outcome(&tracer), Some(&e.to_string()), None);
+            tracer.finalize("error", last_attempt_outcome(&tracer), Some(&e.to_string()), None, TraceUsage::zero());
             return map_provider_error(e);
         }
     };
@@ -1537,6 +1583,7 @@ fn create_buffered_sse_stream(
                     chunk_result = body_stream.next() => {
                         match chunk_result {
                             Some(Ok(chunk)) => {
+                                tracer.mark_first_token();
                                 sent_bytes += chunk.len() as u64;
                                 // 解码事件
                                 if let Err(e) = decoder.feed(&chunk) {
@@ -1564,13 +1611,19 @@ fn create_buffered_sse_stream(
                                 let all_events = ctx.finish_and_get_all_events();
                                 let (i, o, cc, cr, credits) = ctx.final_usage();
                                 hook.record(credential_id, i, o, cc, cr, credits, "error");
-                                tracer.set_usage(i, o, cc, cr);
                                 // 缓冲模式 chunk 读取失败：上游中途断流
                                 tracer.finalize(
                                     "interrupted",
                                     Some(outcome::STREAM_INTERRUPTED),
                                     Some(&e.to_string()),
                                     Some(sent_bytes),
+                                    TraceUsage {
+                                        input_tokens: i.max(0) as u64,
+                                        output_tokens: o.max(0) as u64,
+                                        cache_creation_tokens: cc.max(0) as u64,
+                                        cache_read_tokens: cr.max(0) as u64,
+                                        credits: if credits.is_finite() && credits > 0.0 { credits } else { 0.0 },
+                                    },
                                 );
                                 let bytes: Vec<Result<Bytes, Infallible>> = all_events
                                     .into_iter()
@@ -1583,8 +1636,19 @@ fn create_buffered_sse_stream(
                                 let all_events = ctx.finish_and_get_all_events();
                                 let (i, o, cc, cr, credits) = ctx.final_usage();
                                 hook.record(credential_id, i, o, cc, cr, credits, "success");
-                                tracer.set_usage(i, o, cc, cr);
-                                tracer.finalize("success", None, None, None);
+                                tracer.finalize(
+                                    "success",
+                                    None,
+                                    None,
+                                    None,
+                                    TraceUsage {
+                                        input_tokens: i.max(0) as u64,
+                                        output_tokens: o.max(0) as u64,
+                                        cache_creation_tokens: cc.max(0) as u64,
+                                        cache_read_tokens: cr.max(0) as u64,
+                                        credits: if credits.is_finite() && credits > 0.0 { credits } else { 0.0 },
+                                    },
+                                );
                                 let bytes: Vec<Result<Bytes, Infallible>> = all_events
                                     .into_iter()
                                     .map(|e| Ok(Bytes::from(e.to_sse_string())))

--- a/src/anthropic/middleware.rs
+++ b/src/anthropic/middleware.rs
@@ -21,10 +21,12 @@ use super::cache_metering::SharedCacheMeter;
 use super::types::ErrorResponse;
 
 /// 命中的鉴权上下文（注入到请求扩展，供 handler 记录用量）
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct KeyContext {
     /// 命中的客户端 Key id；0 表示用 master apiKey 调用
     pub key_id: u64,
+    /// 该 Key 绑定的账号分组；None 表示未绑定（含 master apiKey），可使用全部账号
+    pub group: Option<String>,
     /// 命中的入口 Key 类型。
     pub key_source: TraceKeySource,
 }
@@ -45,7 +47,7 @@ pub struct AppState {
     pub usage_recorder: Option<SharedRecorder>,
     /// 用量聚合器
     pub usage_aggregator: Option<SharedAggregator>,
-    /// 中转层 prompt cache（基于 cache_control 断点的内存缓存）
+    /// 中转层缓存计量（基于 cache_control 断点的内存缓存）
     pub cache_meter: Option<SharedCacheMeter>,
     /// 请求链路追踪存储（SQLite，可选）
     pub trace_store: Option<SharedTraceStore>,
@@ -103,7 +105,7 @@ impl AppState {
         self
     }
 
-    /// 注入 CacheMeter
+    /// 注入缓存计量器
     pub fn with_cache_meter(mut self, cache: Option<SharedCacheMeter>) -> Self {
         self.cache_meter = cache;
         self
@@ -138,6 +140,7 @@ pub async fn auth_middleware(
     if auth::constant_time_eq(&presented, &master) {
         request.extensions_mut().insert(KeyContext {
             key_id: 0,
+            group: None,
             key_source: TraceKeySource::MasterApiKey,
         });
         return next.run(request).await;
@@ -146,8 +149,10 @@ pub async fn auth_middleware(
     // 2) 客户端 Key
     if let Some(mgr) = &state.client_keys {
         if let Some(id) = mgr.verify_and_touch(&presented) {
+            let group = mgr.group_of(id);
             request.extensions_mut().insert(KeyContext {
                 key_id: id,
+                group,
                 key_source: TraceKeySource::ClientKey,
             });
             return next.run(request).await;

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -205,6 +205,7 @@ async fn run_round(
     payload: &MessagesRequest,
     hook: &UsageRecordHook,
     fallback_input_tokens: i32,
+    group: Option<&str>,
 ) -> Result<(RoundOutcome, u64), Response> {
     let conversion = match convert_request(payload) {
         Ok(c) => c,
@@ -239,7 +240,7 @@ async fn run_round(
         }
     };
 
-    let call_result = match provider.call_api_stream(&request_body, None).await {
+    let call_result = match provider.call_api_stream(&request_body, None, group).await {
         Ok(r) => r,
         Err(e) => {
             hook.record(0, fallback_input_tokens, 0, 0, 0, 0.0, "error");
@@ -523,6 +524,7 @@ pub(super) async fn run_web_search_loop(
     mut payload: MessagesRequest,
     hook: UsageRecordHook,
     stream_client: bool,
+    group: Option<String>,
 ) -> Response {
     let fallback_input_tokens = token::count_all_tokens(
         payload.model.clone(),
@@ -538,7 +540,7 @@ pub(super) async fn run_web_search_loop(
 
     for round_idx in 0..=MAX_WEB_SEARCH_ROUNDS {
         let (round, credential_id) =
-            match run_round(&provider, &payload, &hook, fallback_input_tokens).await {
+            match run_round(&provider, &payload, &hook, fallback_input_tokens, group.as_deref()).await {
                 Ok(v) => v,
                 Err(resp) => return resp,
             };

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -125,6 +125,21 @@ pub struct KiroCredentials {
     /// 端点名必须在启动时注册的端点 registry 中存在。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
+
+    /// 账号所属分组（可属于多个分组）
+    ///
+    /// 客户端 Key 绑定某个分组后，用该 Key 发起的请求只会调度到 groups 包含该分组名的账号。
+    /// 空数组表示该账号不属于任何分组（仅未绑定分组的 Key / master apiKey 可使用）。
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<String>,
+
+    /// 账号来源渠道（纯备注）
+    ///
+    /// 标记该账号的购买来源/渠道，便于运营追踪。不参与调度、导出或筛选。
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_channel: Option<String>,
 }
 
 /// 判断是否为零（用于跳过序列化）
@@ -168,6 +183,8 @@ impl std::fmt::Debug for KiroCredentials {
             .field("disabled", &self.disabled)
             .field("kiro_api_key", &fmt_redacted(&self.kiro_api_key))
             .field("endpoint", &self.endpoint)
+            .field("groups", &self.groups)
+            .field("source_channel", &self.source_channel)
             .finish()
     }
 }
@@ -472,6 +489,8 @@ mod tests {
             disabled: false,
             kiro_api_key: None,
             endpoint: None,
+            groups: vec![],
+            source_channel: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -661,6 +680,8 @@ mod tests {
             disabled: false,
             kiro_api_key: None,
             endpoint: None,
+            groups: vec![],
+            source_channel: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -694,6 +715,8 @@ mod tests {
             disabled: false,
             kiro_api_key: None,
             endpoint: None,
+            groups: vec![],
+            source_channel: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -810,6 +833,8 @@ mod tests {
             disabled: false,
             kiro_api_key: None,
             endpoint: None,
+            groups: vec![],
+            source_channel: None,
         };
 
         let json = original.to_pretty_json().unwrap();

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -24,7 +24,11 @@ use parking_lot::Mutex;
 const MAX_RETRIES_PER_CREDENTIAL: usize = 3;
 
 /// 总重试次数硬上限（避免无限重试）
-const MAX_TOTAL_RETRIES: usize = 9;
+///
+/// 注：上游 429 多为账号级速率配额（SERVICE_REQUEST_RATE_EXCEEDED），高峰期
+/// 多账号同时触顶时，过多重试会在账号间连环撞墙、放大限流。故上限取较小值，
+/// 配合 429 专用长退避（见 retry_delay_throttle），被限时尽早返回而非耗尽配额。
+const MAX_TOTAL_RETRIES: usize = 4;
 
 /// HTTP Client 缓存容量上限（不含常驻的全局代理 client）。
 /// 代理池条目较多时，避免每个不同代理都常驻一个 reqwest::Client 导致内存无界增长。
@@ -231,8 +235,9 @@ impl KiroProvider {
         &self,
         request_body: &str,
         sink: Option<&dyn TraceSink>,
+        group: Option<&str>,
     ) -> anyhow::Result<KiroCallResult> {
-        self.call_api_with_retry(request_body, false, sink).await
+        self.call_api_with_retry(request_body, false, sink, group).await
     }
 
     /// 发送流式 API 请求
@@ -240,8 +245,9 @@ impl KiroProvider {
         &self,
         request_body: &str,
         sink: Option<&dyn TraceSink>,
+        group: Option<&str>,
     ) -> anyhow::Result<KiroCallResult> {
-        self.call_api_with_retry(request_body, true, sink).await
+        self.call_api_with_retry(request_body, true, sink, group).await
     }
 
     /// 发送 MCP API 请求（WebSearch 等工具调用）
@@ -257,8 +263,8 @@ impl KiroProvider {
         let mut force_refreshed: HashSet<u64> = HashSet::new();
 
         for attempt in 0..max_retries {
-            // MCP 调用（WebSearch 等工具）不涉及模型选择，无需按模型过滤凭据
-            let ctx = match self.token_manager.acquire_context(None).await {
+            // MCP 调用（WebSearch 等工具）不涉及模型选择，也不参与分组隔离
+            let ctx = match self.token_manager.acquire_context(None, None).await {
                 Ok(c) => c,
                 Err(e) => {
                     last_error = Some(e);
@@ -372,7 +378,13 @@ impl KiroProvider {
                 );
                 last_error = Some(anyhow::anyhow!("MCP 请求失败: {} {}", status, body));
                 if attempt + 1 < max_retries {
-                    sleep(Self::retry_delay(attempt)).await;
+                    // 429 限流用更长退避；408/5xx 仍用通用快速退避
+                    let delay = if status.as_u16() == 429 {
+                        Self::retry_delay_throttle(attempt)
+                    } else {
+                        Self::retry_delay(attempt)
+                    };
+                    sleep(delay).await;
                 }
                 continue;
             }
@@ -405,8 +417,10 @@ impl KiroProvider {
         request_body: &str,
         is_stream: bool,
         sink: Option<&dyn TraceSink>,
+        group: Option<&str>,
     ) -> anyhow::Result<KiroCallResult> {
-        let total_credentials = self.token_manager.total_count();
+        // 重试预算按当前请求所属分组的账号数计算，避免小分组按全局账号数获得过多无效重试
+        let total_credentials = self.token_manager.total_count_in_group(group).max(1);
         let max_retries = (total_credentials * MAX_RETRIES_PER_CREDENTIAL).min(MAX_TOTAL_RETRIES);
         let mut last_error: Option<anyhow::Error> = None;
         let mut force_refreshed: HashSet<u64> = HashSet::new();
@@ -418,7 +432,7 @@ impl KiroProvider {
         for attempt in 0..max_retries {
             let attempt_start = Instant::now();
             // 获取调用上下文（绑定 index、credentials、token）
-            let mut ctx = match self.token_manager.acquire_context(model.as_deref()).await {
+            let mut ctx = match self.token_manager.acquire_context(model.as_deref(), group).await {
                 Ok(c) => c,
                 Err(e) => {
                     Self::emit_attempt(
@@ -715,7 +729,13 @@ impl KiroProvider {
                     body
                 ));
                 if attempt + 1 < max_retries {
-                    sleep(Self::retry_delay(attempt)).await;
+                    // 429 限流用更长退避给账号配额恢复时间；408/5xx 仍用通用快速退避
+                    let delay = if status.as_u16() == 429 {
+                        Self::retry_delay_throttle(attempt)
+                    } else {
+                        Self::retry_delay(attempt)
+                    };
+                    sleep(delay).await;
                 }
                 continue;
             }
@@ -806,6 +826,21 @@ impl KiroProvider {
         // 指数退避 + 少量抖动，避免上游抖动时放大故障
         const BASE_MS: u64 = 200;
         const MAX_MS: u64 = 2_000;
+        let exp = BASE_MS.saturating_mul(2u64.saturating_pow(attempt.min(6) as u32));
+        let backoff = exp.min(MAX_MS);
+        let jitter_max = (backoff / 4).max(1);
+        let jitter = fastrand::u64(0..=jitter_max);
+        Duration::from_millis(backoff.saturating_add(jitter))
+    }
+
+    /// 429 限流专用退避：比通用退避更长。
+    ///
+    /// 上游 429（SERVICE_REQUEST_RATE_EXCEEDED）是账号级速率配额耗尽，需要更长
+    /// 时间恢复；用通用的 ≤2s 快速退避只会让请求在配额恢复前反复撞墙、持续触顶。
+    /// 这里 base 1s、封顶 8s，给账号配额留出恢复窗口。
+    fn retry_delay_throttle(attempt: usize) -> Duration {
+        const BASE_MS: u64 = 1_000;
+        const MAX_MS: u64 = 8_000;
         let exp = BASE_MS.saturating_mul(2u64.saturating_pow(attempt.min(6) as u32));
         let backoff = exp.min(MAX_MS);
         let jitter_max = (backoff / 4).max(1);

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -835,6 +835,12 @@ pub struct CredentialEntrySnapshot {
     /// 端点名称（未显式配置时返回 None，由 Admin 层回退到默认值）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
+    /// 账号所属分组（可属于多个分组）
+    #[serde(default)]
+    pub groups: Vec<String>,
+    /// 账号来源渠道（纯备注）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_channel: Option<String>,
 }
 
 /// 凭据管理器状态快照
@@ -898,6 +904,17 @@ pub struct CallContext {
     pub credentials: KiroCredentials,
     /// 访问 Token
     pub token: String,
+}
+
+/// 判断某账号的分组集合是否匹配请求所属分组（严格隔离）
+///
+/// - `group = None`：Key 未绑定分组（含 master apiKey），匹配所有账号。
+/// - `group = Some(g)`：仅匹配 `cred_groups` 包含 `g` 的账号。
+fn group_matches(cred_groups: &[String], group: Option<&str>) -> bool {
+    match group {
+        None => true,
+        Some(g) => cred_groups.iter().any(|cg| cg == g),
+    }
 }
 
 impl MultiTokenManager {
@@ -1070,6 +1087,17 @@ impl MultiTokenManager {
         self.entries.lock().len()
     }
 
+    /// 获取指定分组的凭据总数（group=None 时等于 total_count）
+    ///
+    /// 用于按分组计算 failover 重试预算，避免小分组按全局账号数获得过多无效重试。
+    pub fn total_count_in_group(&self, group: Option<&str>) -> usize {
+        self.entries
+            .lock()
+            .iter()
+            .filter(|e| group_matches(&e.credentials.groups, group))
+            .count()
+    }
+
     /// 获取可用凭据数量
     pub fn available_count(&self) -> usize {
         let now = Instant::now();
@@ -1087,7 +1115,7 @@ impl MultiTokenManager {
     ///
     /// # 参数
     /// - `model`: 可选的模型名称，用于过滤支持该模型的凭据（如 opus 模型需要付费订阅）
-    fn select_next_credential(&self, model: Option<&str>) -> Option<(u64, KiroCredentials)> {
+    fn select_next_credential(&self, model: Option<&str>, group: Option<&str>) -> Option<(u64, KiroCredentials)> {
         let entries = self.entries.lock();
         let now = Instant::now();
 
@@ -1109,6 +1137,10 @@ impl MultiTokenManager {
                 }
                 // 如果是 opus 模型，需要检查订阅等级
                 if is_opus && !e.credentials.supports_opus() {
+                    return false;
+                }
+                // 账号分组隔离：Key 绑定分组时只用该分组内的账号
+                if !group_matches(&e.credentials.groups, group) {
                     return false;
                 }
                 true
@@ -1150,8 +1182,8 @@ impl MultiTokenManager {
     ///
     /// # 参数
     /// - `model`: 可选的模型名称，用于过滤支持该模型的凭据（如 opus 模型需要付费订阅）
-    pub async fn acquire_context(&self, model: Option<&str>) -> anyhow::Result<CallContext> {
-        let total = self.total_count();
+    pub async fn acquire_context(&self, model: Option<&str>, group: Option<&str>) -> anyhow::Result<CallContext> {
+        let total = self.total_count_in_group(group);
         let max_attempts = (total * MAX_FAILURES_PER_CREDENTIAL as usize).max(1);
         let mut attempt_count = 0;
 
@@ -1181,6 +1213,7 @@ impl MultiTokenManager {
                             e.id == current_id
                                 && !e.disabled
                                 && !e.throttled_until.map(|t| t > now).unwrap_or(false)
+                                && group_matches(&e.credentials.groups, group)
                         })
                         .map(|e| (e.id, e.credentials.clone()))
                 };
@@ -1189,7 +1222,7 @@ impl MultiTokenManager {
                     hit
                 } else {
                     // 当前凭据不可用或 balanced 模式，根据负载均衡策略选择
-                    let mut best = self.select_next_credential(model);
+                    let mut best = self.select_next_credential(model, group);
 
                     // 没有可用凭据：如果是"自动禁用导致全灭"，做一次类似重启的自愈
                     if best.is_none() {
@@ -1208,7 +1241,7 @@ impl MultiTokenManager {
                                 }
                             }
                             drop(entries);
-                            best = self.select_next_credential(model);
+                            best = self.select_next_credential(model, group);
                         }
                     }
 
@@ -2021,6 +2054,8 @@ impl MultiTokenManager {
                         .map(|d| d.as_secs())
                         .filter(|s| *s > 0),
                     endpoint: e.credentials.endpoint.clone(),
+                    groups: e.credentials.groups.clone(),
+                    source_channel: e.credentials.source_channel.clone(),
                 })
                 .collect(),
             current_id,
@@ -2733,6 +2768,8 @@ impl MultiTokenManager {
         proxy_url: Option<Option<String>>,
         proxy_username: Option<Option<String>>,
         proxy_password: Option<Option<String>>,
+        groups: Option<Vec<String>>,
+        source_channel: Option<Option<String>>,
     ) -> anyhow::Result<()> {
         {
             let mut entries = self.entries.lock();
@@ -2753,9 +2790,102 @@ impl MultiTokenManager {
             if let Some(v) = proxy_password {
                 entry.credentials.proxy_password = v.filter(|s| !s.is_empty());
             }
+            if let Some(g) = groups {
+                entry.credentials.groups =
+                    g.into_iter().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+            }
+            if let Some(v) = source_channel {
+                entry.credentials.source_channel =
+                    v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+            }
         }
         self.persist_credentials()?;
         Ok(())
+    }
+
+    /// 列出所有凭据当前引用的分组名（去重排序）。
+    /// 用于启动迁移到 GroupManager 注册表，以及前端的引用计数显示。
+    pub fn list_credential_groups(&self) -> Vec<String> {
+        let entries = self.entries.lock();
+        let mut set: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for e in entries.iter() {
+            for g in &e.credentials.groups {
+                if !g.is_empty() {
+                    set.insert(g.clone());
+                }
+            }
+        }
+        let mut list: Vec<String> = set.into_iter().collect();
+        list.sort();
+        list
+    }
+
+    /// 统计指定分组被多少个凭据引用（用于分组管理页 / 删除前提示）。
+    pub fn count_credentials_with_group(&self, group: &str) -> usize {
+        let entries = self.entries.lock();
+        entries
+            .iter()
+            .filter(|e| e.credentials.groups.iter().any(|g| g == group))
+            .count()
+    }
+
+    /// 把所有凭据 `groups` 字段中等于 `old` 的元素改为 `new`（分组改名级联用）。
+    /// 已经显式带 `new` 的凭据不会重复添加。返回受影响的凭据数。
+    pub fn rename_credential_group(&self, old: &str, new: &str) -> anyhow::Result<usize> {
+        let mut affected = 0usize;
+        {
+            let mut entries = self.entries.lock();
+            for entry in entries.iter_mut() {
+                let groups = &mut entry.credentials.groups;
+                let mut hit = false;
+                let mut already_has_new = false;
+                for g in groups.iter() {
+                    if g == old {
+                        hit = true;
+                    }
+                    if g == new {
+                        already_has_new = true;
+                    }
+                }
+                if hit {
+                    if already_has_new {
+                        // old 和 new 共存：只去掉 old，避免重复
+                        groups.retain(|g| g != old);
+                    } else {
+                        for g in groups.iter_mut() {
+                            if g == old {
+                                *g = new.to_string();
+                            }
+                        }
+                    }
+                    affected += 1;
+                }
+            }
+        }
+        if affected > 0 {
+            self.persist_credentials()?;
+        }
+        Ok(affected)
+    }
+
+    /// 把 `name` 这个分组从所有凭据的 `groups` 字段中移除（强删分组级联用）。
+    /// 返回受影响的凭据数。
+    pub fn remove_credential_group(&self, name: &str) -> anyhow::Result<usize> {
+        let mut affected = 0usize;
+        {
+            let mut entries = self.entries.lock();
+            for entry in entries.iter_mut() {
+                let before = entry.credentials.groups.len();
+                entry.credentials.groups.retain(|g| g != name);
+                if entry.credentials.groups.len() != before {
+                    affected += 1;
+                }
+            }
+        }
+        if affected > 0 {
+            self.persist_credentials()?;
+        }
+        Ok(affected)
     }
 
     /// 删除凭据（Admin API）
@@ -3459,7 +3589,7 @@ mod tests {
         assert_eq!(manager.available_count(), 0);
 
         // 应触发自愈：重置失败计数并重新启用，避免必须重启进程
-        let ctx = manager.acquire_context(None).await.unwrap();
+        let ctx = manager.acquire_context(None, None).await.unwrap();
         assert!(ctx.token == "t1" || ctx.token == "t2");
         assert_eq!(manager.available_count(), 2);
     }
@@ -3482,7 +3612,7 @@ mod tests {
         let manager =
             MultiTokenManager::new(config, vec![bad_cred, good_cred], None, None, false).unwrap();
 
-        let ctx = manager.acquire_context(None).await.unwrap();
+        let ctx = manager.acquire_context(None, None).await.unwrap();
         assert_eq!(ctx.id, 2);
         assert_eq!(ctx.token, "good-token");
     }
@@ -3528,7 +3658,7 @@ mod tests {
         assert_eq!(manager.available_count(), 0);
 
         let err = manager
-            .acquire_context(None)
+            .acquire_context(None, None)
             .await
             .err()
             .unwrap()
@@ -3573,7 +3703,7 @@ mod tests {
         assert_eq!(manager.available_count(), 0);
 
         let err = manager
-            .acquire_context(None)
+            .acquire_context(None, None)
             .await
             .err()
             .unwrap()
@@ -4009,5 +4139,134 @@ mod tests {
         assert!(reloaded, "单凭据无 ID 时仍应能匹配并 reload");
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    // ===== 账号分组隔离回归测试 =====
+
+    /// 构造一个带 token、属于指定分组的可用凭据
+    fn grouped_cred(token: &str, groups: &[&str]) -> KiroCredentials {
+        let mut c = KiroCredentials::default();
+        c.access_token = Some(token.to_string());
+        c.expires_at = Some((Utc::now() + Duration::hours(1)).to_rfc3339());
+        c.groups = groups.iter().map(|s| s.to_string()).collect();
+        c
+    }
+
+    #[test]
+    fn test_group_matches_helper() {
+        // 未绑定分组(None)匹配任何账号
+        assert!(group_matches(&[], None));
+        assert!(group_matches(&["g1".to_string()], None));
+        // 绑定分组时只匹配 groups 含该名的账号
+        assert!(group_matches(&["g1".to_string(), "g2".to_string()], Some("g1")));
+        assert!(!group_matches(&["g2".to_string()], Some("g1")));
+        assert!(!group_matches(&[], Some("g1")));
+    }
+
+    #[test]
+    fn test_select_next_credential_filters_by_group() {
+        // A∈g1, B∈g2, C∈无分组
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![
+                grouped_cred("a", &["g1"]),
+                grouped_cred("b", &["g2"]),
+                grouped_cred("c", &[]),
+            ],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        // g1 只能选到 A(id=1)
+        let g1 = manager.select_next_credential(None, Some("g1"));
+        assert_eq!(g1.map(|(id, _)| id), Some(1));
+        // g2 只能选到 B(id=2)
+        let g2 = manager.select_next_credential(None, Some("g2"));
+        assert_eq!(g2.map(|(id, _)| id), Some(2));
+        // 不存在的分组 → 无可用账号
+        assert!(manager.select_next_credential(None, Some("nope")).is_none());
+        // 未绑定分组(None) → 可选到账号
+        assert!(manager.select_next_credential(None, None).is_some());
+    }
+
+    #[test]
+    fn test_total_count_in_group() {
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![
+                grouped_cred("a", &["g1"]),
+                grouped_cred("b", &["g1", "g2"]),
+                grouped_cred("c", &[]),
+            ],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(manager.total_count_in_group(Some("g1")), 2); // A,B
+        assert_eq!(manager.total_count_in_group(Some("g2")), 1); // B
+        assert_eq!(manager.total_count_in_group(None), 3); // 全部
+        assert_eq!(manager.total_count_in_group(Some("none")), 0);
+    }
+
+    #[test]
+    fn test_balanced_mode_independent_per_group() {
+        let mut config = Config::default();
+        config.load_balancing_mode = "balanced".to_string();
+        // g1: A(id1),B(id2)；g2: C(id3)
+        let manager = MultiTokenManager::new(
+            config,
+            vec![
+                grouped_cred("a", &["g1"]),
+                grouped_cred("b", &["g1"]),
+                grouped_cred("c", &["g2"]),
+            ],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        // 让 A(id1) 成功若干次 → balanced 应转向 success_count 更小的 B(id2)
+        manager.report_success(1);
+        manager.report_success(1);
+        let pick = manager.select_next_credential(None, Some("g1"));
+        assert_eq!(pick.map(|(id, _)| id), Some(2), "balanced 应在 g1 内选 success_count 最小的 B");
+        // g2 不受 g1 计数影响，仍只会选到 C(id3)
+        let pick_g2 = manager.select_next_credential(None, Some("g2"));
+        assert_eq!(pick_g2.map(|(id, _)| id), Some(3));
+    }
+
+    #[tokio::test]
+    async fn test_acquire_context_strict_isolation_fails_when_group_empty() {
+        // g1 只有一个账号 A(id1)，禁用后绑定 g1 的请求应直接失败，不回退到 g2/无分组
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![
+                grouped_cred("a", &["g1"]),
+                grouped_cred("b", &["g2"]),
+                grouped_cred("c", &[]),
+            ],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        // 正常情况下 g1 能拿到 context
+        assert!(manager.acquire_context(None, Some("g1")).await.is_ok());
+
+        // 手动禁用 g1 内唯一账号 A(id1)
+        manager.set_disabled(1, true).unwrap();
+
+        // 严格隔离：g1 无可用账号 → Err，且不会选到 B/C
+        let res = manager.acquire_context(None, Some("g1")).await;
+        assert!(res.is_err(), "g1 内全部账号禁用后应失败，不回退到其他分组");
+
+        // 但 g2 仍可用
+        assert!(manager.acquire_context(None, Some("g2")).await.is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,25 @@ async fn main() {
     let usage_aggregator = std::sync::Arc::new(admin::UsageAggregator::new());
     usage_aggregator.rebuild_from_logs(&cache_dir);
 
+    // 账号分组注册表（持久化到 groups.json）。
+    // 启动时若文件不存在则首次创建，并把现有凭据 / 客户端 Key 的 groups 字段反向迁移进去，
+    // 保证老用户升级后所有已用分组都自动注册，不会因为本次改造而消失。
+    let groups_path = admin::groups::default_path_in(&cache_dir);
+    let group_manager = std::sync::Arc::new(
+        admin::GroupManager::load(&groups_path).unwrap_or_else(|e| {
+            tracing::warn!("加载分组注册表失败 ({}): {}", groups_path.display(), e);
+            admin::GroupManager::new()
+        }),
+    );
+    {
+        let mut all_used: Vec<String> = token_manager.list_credential_groups();
+        all_used.extend(client_key_manager.used_group_names());
+        let added = group_manager.bootstrap_from_existing(all_used);
+        if added > 0 {
+            tracing::info!("分组注册表：自动迁移 {} 个已用分组", added);
+        }
+    }
+
     // 请求链路追踪存储（SQLite，traces.db）。失败不致命：trace 不可用但服务正常。
     let trace_store: Option<admin::SharedTraceStore> = match admin::TraceStore::open(
         cache_dir.join("traces.db"),
@@ -280,6 +299,7 @@ async fn main() {
                 client_key_manager.clone(),
                 usage_aggregator.clone(),
                 admin_trace_store,
+                group_manager.clone(),
             );
 
             // 启动余额后台刷新调度器（每 5 分钟一次，与缓存 TTL 对齐）


### PR DESCRIPTION
## 背景

之前的"分组"只是凭据 / 客户端 Key 字段中的字符串标签，依附于实体存在：

- 删完所有用某分组的凭据后，分组消失，下次想用必须重新输入
- 分组名 typo 一字之差就分裂成不同分组（"客户A" vs "客户a"）
- 没有统一的分组列表可供选择，必须靠记忆手动输入
- 凭据列表无法按分组筛选，概览页统计无法按分组聚合

本 PR 把"分组"提升为一等实体：在 `groups.json` 独立持久化注册表，凭据 / 客户端 Key 通过名字引用；同时打通凭据列表筛选、概览页按分组统计两个使用场景。

## 后端改动

### 1. 新增 `GroupManager`（src/admin/groups.rs）

- 独立持久化到 `groups.json`（与 credentials.json / client_api_keys.json 同目录，已加入 .gitignore）
- 数据结构 `Group { name, description, created_at }`
- 线程安全（RwLock）+ JSON 持久化，模式与现有 `ClientKeyManager` 一致
- 含 11 个单元测试覆盖 CRUD 边界条件（重名拒绝、空名拒绝、长度限制 ≤64、改名级联、删除引用计数、bootstrap 迁移等）

### 2. 新增 4 个 Admin API

| 方法 | 路径 | 说明 |
|---|---|---|
| `GET` | `/api/admin/groups` | 列表（含每个分组的 credentialCount / clientKeyCount 引用计数） |
| `POST` | `/api/admin/groups` | 创建（重名 → 409；空名 / 名长 >64 → 400） |
| `PATCH` | `/api/admin/groups/:name` | 改名 + 改备注（自动级联引用） |
| `DELETE` | `/api/admin/groups/:name` | 删除（默认拒绝有引用 → 409；`?force=true` 级联清理后强删） |

### 3. 改名 / 删除自动级联

- `MultiTokenManager.rename_credential_group` + `remove_credential_group`
- `ClientKeyManager.rename_group` + `clear_group`
- 改名时自动同步**所有引用此分组的凭据 `groups` 字段与客户端 Key.group 字段**
- `?force=true` 强删时自动从所有引用方清理（避免悬挂引用）

### 4. 启动平滑迁移

- 启动时若 `groups.json` 不存在，扫描所有凭据 `groups` + 客户端 Key.group **反向写入注册表**
- 老用户升级**零改动**：所有已用过的分组自动注册，不会消失

### 5. 概览页按分组维度统计

- `UsageAggregator.query_timeseries` / `query_by_credential` 接受 `Option<&HashSet<u64>>` 凭据 ID 白名单参数
- handlers 接受 `?group=xxx`，用 token_manager 快照转成白名单
- `StatsFilter` 类型扩展 `group` 字段
- `query_by_model` 暂不支持（缺 model+credential 双维度桶），前端给出明确琥珀色提示而不是静默返回错误数据

## 前端改动

### 1. 新增 `/admin#/groups` 分组管理页

- 卡片网格展示所有分组，含「凭据 N / Key M」引用计数 Badge
- 创建：弹框输入名字 + 备注
- 编辑：改名 / 改备注，改名时弹「会级联同步」提示
- 删除：无引用单层确认；有引用二次确认 + force 级联清理
- 顶部标签栏新增「分组管理」入口（FolderTree 图标）

### 2. `GroupSelect` 改造为「只能从注册列表选」

- `GroupSingleSelect`：去掉「+ 新建分组」option（避免 typo 漂移）
- `GroupMultiSelect`：重写为 DropdownMenu + Checkbox 多选下拉，收起时只显示一个按钮节省空间
- 按钮文案智能：`选择分组` / 单分组名 / `已选 N 个`
- 含「管理分组」快捷入口直跳 `#/groups`
- 已注销分组（之前用过但已删除）显示斜体 + 琥珀色提示，便于识别清理

### 3. 凭据列表分组筛选

- dashboard 顶部工具栏新增分组筛选下拉
- 「全部分组 / 未分组 / 各注册分组」三档
- 切换时分页自动复位到第 1 页避免空页
- 标题 Badge 显示「已筛 / 总数」+ 筛选标签可一键清除
- 样式与右侧按钮统一：`rounded-full` + `bg-card/60 backdrop-blur` + `border-border`

### 4. 概览页按分组维度统计

- `KeyFilterCard` 拓展为同时筛选「入口 Key + 账号分组」
- 切换 group 自动重新请求（hooks queryKey 含 group）
- 模型分布卡片在分组筛选启用时显示琥珀色提示条说明限制

### 5. 调用方改造（4 处）

- add-credential / edit-credential / client-keys-page / dashboard 的 `groupOptions` 改从 `useGroupOptions()` 拉，不再聚合凭据 `groups`
- 这样新创建的分组**立即在所有 GroupSelect 出现**，不依赖凭据存在

## 兼容性

- 凭据 / 客户端 Key 的 schema 不变，仍用名字引用
- 启动迁移自动把已用分组写入注册表，老用户**零改动**平滑切换

## 用例

适合多客户共享中转、需要账号池逻辑切片的场景：

```
凭据 A, B, E 打上「客户A」分组  →  这 3 个凭据组成「客户A 池」
客户端 Key 绑定「客户A」分组   →  用该 Key 发请求时只调度到 A/B/E
                                  客户A 用得猛把额度用完，不会动到其他池子
分组改名 "客户A" → "VIP-A"     →  自动级联，无需逐个凭据手动改
```

## 测试

- **后端单测**：11 个单元测试全部通过（GroupManager CRUD 边界条件）
- **端到端**：本地服务完整 API 验证 — list / create / 重名 409 / rename 级联 / delete 拒绝 + `?force=true` / bootstrap 迁移 1 个已用分组
- **编译**：`cargo check` + `bun run build` 均通过

## 改动规模

- 25 文件，+1694 / -159
- 新增 4 个文件：
  - `src/admin/groups.rs`
  - `admin-ui/src/api/groups.ts`
  - `admin-ui/src/hooks/use-groups.ts`
  - `admin-ui/src/components/groups-page.tsx`
