### PR TITLE
Prevent credential reuse and normalize effort tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Adaptive thinking：
 }
 ```
 
-`additionalModelRequestFields.output_config` 是 Kiro 上游的窄兼容字段。当前只会在已知可接受该字段的 Opus 4.6 adaptive thinking 路径上传递；Sonnet 4.5 / 4.8、Opus 4.6 非 adaptive thinking 等路径会跳过该字段，避免上游返回 `additionalModelRequestFields is not supported for this model`。
+`additionalModelRequestFields.output_config` 是 Kiro 上游的窄兼容字段。当前只会在已知可接受该字段的 Opus 4.6 adaptive thinking 路径上传递；Sonnet 4.5 / 4.8、Opus 4.6 非 adaptive thinking 等路径会跳过该字段，避免上游返回 `additionalModelRequestFields is not supported for this model`。`effort` 会先归一化大小写和空格；已知 4.5 / 4.6 系列不接受 `xhigh`，会降级为最接近的 `high`；Opus 4.7 / 4.8、Fable 5、Mythos 5 会保留 `xhigh`；其它未知模型的已知 effort 值也会保持原样，避免维护一张容易过期的模型白名单；未知 effort 值会回退到 `high`。
 
 Kiro 上游可能返回原生 `reasoningContentEvent`。`kiro-rs` 会把它转换为 Anthropic 兼容内容：
 

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -1018,6 +1018,10 @@ impl AdminService {
         }
         self.save_balance_cache();
 
+        if let Some(trace_store) = &self.trace_store {
+            trace_store.delete_for_credential(id);
+        }
+
         Ok(())
     }
 

--- a/src/admin/trace_db.rs
+++ b/src/admin/trace_db.rs
@@ -566,6 +566,44 @@ impl TraceStore {
         }
     }
 
+    /// 删除指定凭据关联的 trace 记录，避免删除账号后新账号复用同一 credential_id
+    /// 时继承旧账号的失败统计。
+    pub fn delete_for_credential(&self, credential_id: u64) {
+        if credential_id == 0 {
+            return;
+        }
+        let mut conn = self.conn.lock();
+        let tx = match conn.transaction() {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("trace 凭据清理事务失败: {}", e);
+                return;
+            }
+        };
+        let res = (|| -> rusqlite::Result<usize> {
+            tx.execute(
+                "DELETE FROM trace_attempts WHERE credential_id = ?1 \
+                 OR trace_id IN (SELECT trace_id FROM traces WHERE final_credential_id = ?1)",
+                [credential_id],
+            )?;
+            let n = tx.execute(
+                "DELETE FROM traces WHERE final_credential_id = ?1",
+                [credential_id],
+            )?;
+            Ok(n)
+        })();
+        match res {
+            Ok(n) => {
+                if let Err(e) = tx.commit() {
+                    tracing::warn!("trace 凭据清理提交失败: {}", e);
+                } else if n > 0 {
+                    tracing::info!("已清理凭据 #{} 的 {} 条 trace 记录", credential_id, n);
+                }
+            }
+            Err(e) => tracing::warn!("trace 凭据清理失败: {}", e),
+        }
+    }
+
     /// 按凭据聚合失败跳数，归并为三类：鉴权 / 账号风控 / 其他。
     /// 统计 trace_attempts 里 outcome != 'success' 的跳，按 credential_id + outcome 分组。
     /// 返回 credential_id → (auth, throttle, other)。仅 warn 失败，返回空。
@@ -797,6 +835,40 @@ mod tests {
                 })
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn delete_for_credential_removes_failure_stats() {
+        let store = mem_store();
+        store.insert(&sample(TraceSample {
+            trace_id: "old",
+            status: "error",
+            credential_id: 5,
+            model: "m1",
+        }));
+        store.insert(&sample(TraceSample {
+            trace_id: "keep",
+            status: "error",
+            credential_id: 6,
+            model: "m1",
+        }));
+
+        assert!(store.failure_stats().contains_key(&5));
+        store.delete_for_credential(5);
+
+        let stats = store.failure_stats();
+        assert!(!stats.contains_key(&5));
+        assert!(stats.contains_key(&6));
+        assert!(
+            store
+                .query(&TraceQuery {
+                    credential_id: Some(5),
+                    limit: 50,
+                    ..Default::default()
+                })
+                .is_empty(),
+            "deleted credential traces should not attach to a future account with the same id"
         );
     }
 

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -203,18 +203,111 @@ fn should_emit_output_config(req: &MessagesRequest, model_id: &str) -> bool {
             .is_some_and(|t| t.thinking_type == "adaptive")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EffortTier {
+    Low,
+    Medium,
+    High,
+    XHigh,
+    Max,
+}
+
+impl EffortTier {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "low" => Some(Self::Low),
+            "medium" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            "xhigh" | "x-high" | "x_high" => Some(Self::XHigh),
+            "max" => Some(Self::Max),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::XHigh => "xhigh",
+            Self::Max => "max",
+        }
+    }
+}
+
+fn normalize_effort_for_model(model_id: &str, raw_effort: &str) -> Option<String> {
+    let trimmed = raw_effort.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let requested = match EffortTier::parse(trimmed) {
+        Some(tier) => tier,
+        None => {
+            tracing::debug!(
+                model_id = %model_id,
+                effort = %trimmed,
+                fallback_effort = EffortTier::High.as_str(),
+                "falling back unsupported output_config.effort"
+            );
+            return Some(EffortTier::High.as_str().to_string());
+        }
+    };
+
+    // `xhigh` is a newer effort tier. Known older effort-capable models reject
+    // it with `Invalid additionalModelRequestFields`, so map to the nearest
+    // lower tier instead of failing the request. Unknown/future models keep
+    // recognized values intact to avoid maintaining a brittle full allow-list.
+    let normalized = if requested == EffortTier::XHigh && !model_supports_xhigh_effort(model_id) {
+        EffortTier::High
+    } else {
+        requested
+    };
+    if normalized != requested || normalized.as_str() != trimmed {
+        tracing::debug!(
+            model_id = %model_id,
+            effort = %trimmed,
+            normalized_effort = normalized.as_str(),
+            "normalized output_config.effort for model"
+        );
+    }
+
+    Some(normalized.as_str().to_string())
+}
+
+fn model_supports_xhigh_effort(model_id: &str) -> bool {
+    let model = model_id.to_ascii_lowercase();
+
+    // Anthropic documents xhigh for Opus 4.7/4.8, Fable 5, and Mythos 5.
+    if model.contains("opus-4.7")
+        || model.contains("opus-4.8")
+        || model.contains("fable-5")
+        || model.contains("mythos-5")
+        || model.contains("claude-5")
+    {
+        return true;
+    }
+
+    // Known Kiro/Claude model ids that predate xhigh. Keep this as a compact
+    // deny-list, not a full capability matrix.
+    !matches!(
+        model.as_str(),
+        "claude-opus-4.6"
+            | "claude-sonnet-4.6"
+            | "claude-opus-4.5"
+            | "claude-sonnet-4.5"
+            | "claude-haiku-4.5"
+    )
+}
+
 fn build_additional_model_request_fields(
     req: &MessagesRequest,
     model_id: &str,
 ) -> Option<AdditionalModelRequestFields> {
     let output_config = if should_emit_output_config(req, model_id) {
         req.output_config.as_ref().and_then(|oc| {
-            if oc.effort.trim().is_empty() {
-                return None;
-            }
-            Some(KiroOutputConfig {
-                effort: oc.effort.clone(),
-            })
+            normalize_effort_for_model(model_id, &oc.effort)
+                .map(|effort| KiroOutputConfig { effort })
         })
     } else {
         if let Some(oc) = &req.output_config
@@ -825,7 +918,7 @@ fn convert_tools(tools: &Option<Vec<super::types::Tool>>, tool_name_map: &mut Ha
 }
 
 /// 生成thinking标签前缀
-fn generate_thinking_prefix(req: &MessagesRequest) -> Option<String> {
+fn generate_thinking_prefix(req: &MessagesRequest, model_id: &str) -> Option<String> {
     if let Some(t) = &req.thinking {
         if t.thinking_type == "enabled" {
             return Some(format!(
@@ -836,8 +929,8 @@ fn generate_thinking_prefix(req: &MessagesRequest) -> Option<String> {
             let effort = req
                 .output_config
                 .as_ref()
-                .map(|c| c.effort.as_str())
-                .unwrap_or("high");
+                .and_then(|c| normalize_effort_for_model(model_id, &c.effort))
+                .unwrap_or_else(|| "high".to_string());
             return Some(format!(
                 "<thinking_mode>adaptive</thinking_mode><thinking_effort>{}</thinking_effort>",
                 effort
@@ -864,7 +957,7 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
     let mut history = Vec::new();
 
     // 生成thinking前缀（如果需要）
-    let thinking_prefix = generate_thinking_prefix(req);
+    let thinking_prefix = generate_thinking_prefix(req, model_id);
 
     // 1. 处理系统消息
     if let Some(ref system) = req.system {
@@ -1216,6 +1309,10 @@ mod tests {
     }
 
     fn minimal_request_with_output_config(model: &str) -> MessagesRequest {
+        minimal_request_with_effort(model, "high")
+    }
+
+    fn minimal_request_with_effort(model: &str, effort: &str) -> MessagesRequest {
         use super::super::types::{Message as AnthropicMessage, OutputConfig};
 
         MessagesRequest {
@@ -1231,7 +1328,7 @@ mod tests {
             tool_choice: None,
             thinking: None,
             output_config: Some(OutputConfig {
-                effort: "high".to_string(),
+                effort: effort.to_string(),
             }),
             metadata: None,
         }
@@ -1241,6 +1338,17 @@ mod tests {
         use super::super::types::Thinking;
 
         let mut req = minimal_request_with_output_config(model);
+        req.thinking = Some(Thinking {
+            thinking_type: "adaptive".to_string(),
+            budget_tokens: 20000,
+        });
+        req
+    }
+
+    fn minimal_adaptive_thinking_request_with_effort(model: &str, effort: &str) -> MessagesRequest {
+        use super::super::types::Thinking;
+
+        let mut req = minimal_request_with_effort(model, effort);
         req.thinking = Some(Thinking {
             thinking_type: "adaptive".to_string(),
             budget_tokens: 20000,
@@ -1317,6 +1425,100 @@ mod tests {
             fields.output_config.unwrap().effort,
             "high",
             "effort should be passed through for the supported model"
+        );
+    }
+
+    #[test]
+    fn test_output_config_downgrades_xhigh_for_opus_4_6() {
+        let req =
+            minimal_adaptive_thinking_request_with_effort("claude-opus-4-6-thinking", "xhigh");
+        let result = convert_request(&req).unwrap();
+
+        let fields = result
+            .additional_model_request_fields
+            .expect("opus 4.6 adaptive thinking should keep output_config");
+        assert_eq!(
+            fields.output_config.unwrap().effort,
+            "high",
+            "opus 4.6 upstream only accepts low/medium/high/max, so xhigh should downgrade"
+        );
+    }
+
+    #[test]
+    fn test_output_config_downgrades_xhigh_for_known_older_models() {
+        for model in [
+            "claude-opus-4.6",
+            "claude-sonnet-4.6",
+            "claude-opus-4.5",
+            "claude-sonnet-4.5",
+            "claude-haiku-4.5",
+        ] {
+            assert_eq!(
+                normalize_effort_for_model(model, "xhigh").as_deref(),
+                Some("high"),
+                "{model} should not emit xhigh"
+            );
+        }
+    }
+
+    #[test]
+    fn test_output_config_preserves_xhigh_for_models_without_known_restriction() {
+        assert_eq!(
+            normalize_effort_for_model("claude-opus-4.7", "xhigh").as_deref(),
+            Some("xhigh"),
+            "opus 4.7 supports xhigh"
+        );
+        assert_eq!(
+            normalize_effort_for_model("claude-opus-4.8", "xhigh").as_deref(),
+            Some("xhigh"),
+            "opus 4.8 supports xhigh"
+        );
+        assert_eq!(
+            normalize_effort_for_model("claude-5", "xhigh").as_deref(),
+            Some("xhigh"),
+            "claude 5 supports xhigh"
+        );
+        assert_eq!(
+            normalize_effort_for_model("claude-sonnet-5.1", "xhigh").as_deref(),
+            Some("xhigh"),
+            "future models should not require explicit allow-listing for recognized effort values"
+        );
+        assert_eq!(
+            normalize_effort_for_model("claude-unknown-9", "xhigh").as_deref(),
+            Some("xhigh"),
+            "unknown future models should keep recognized effort values"
+        );
+    }
+
+    #[test]
+    fn test_output_config_normalizes_effort_case_and_spacing() {
+        let req =
+            minimal_adaptive_thinking_request_with_effort("claude-opus-4-6-thinking", "  MAX  ");
+        let result = convert_request(&req).unwrap();
+
+        let fields = result
+            .additional_model_request_fields
+            .expect("opus 4.6 adaptive thinking should keep output_config");
+        assert_eq!(
+            fields.output_config.unwrap().effort,
+            "max",
+            "effort should be normalized before being sent to upstream"
+        );
+    }
+
+    #[test]
+    fn test_output_config_unknown_effort_falls_back_to_high() {
+        let req =
+            minimal_adaptive_thinking_request_with_effort("claude-opus-4-6-thinking", "extreme");
+        let result = convert_request(&req).unwrap();
+
+        let fields = result
+            .additional_model_request_fields
+            .expect("opus 4.6 adaptive thinking should keep output_config");
+        assert_eq!(
+            fields.output_config.unwrap().effort,
+            "high",
+            "unknown effort values should fall back instead of causing upstream validation errors"
         );
     }
 

--- a/src/kiro/model/requests/kiro.rs
+++ b/src/kiro/model/requests/kiro.rs
@@ -43,7 +43,9 @@ pub struct KiroRequest {
     ///     "output_config": { "effort": "max" }
     /// }
     /// ```
-    /// Five tiers: `low / medium / high / xhigh / max`
+    /// Effort tiers are model-dependent. Older 4.5/4.6 models accept
+    /// `low / medium / high / max`; newer effort-capable models may also
+    /// accept `xhigh`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_model_request_fields: Option<AdditionalModelRequestFields>,
 }
@@ -62,7 +64,9 @@ pub struct AdditionalModelRequestFields {
 
 /// The effort control field recognized by the AWS Q backend
 ///
-/// Accepts five tiers: `low / medium / high / xhigh / max`
+/// Accepted tiers are model-dependent. Older 4.5/4.6 models accept
+/// `low / medium / high / max`; newer effort-capable models may also accept
+/// `xhigh`.
 ///
 /// Measured (via a ladder experiment), the same prompt between `low` and `max` differs
 /// by roughly 5x in response time and output length, so this **is a protocol field that genuinely takes effect**,

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -869,6 +869,9 @@ pub struct MultiTokenManager {
     entries: Mutex<Vec<CredentialEntry>>,
     /// 当前活动凭据 ID
     current_id: Mutex<u64>,
+    /// 下一个待分配凭据 ID。进程内单调递增，避免删除账号后新账号复用旧 ID，
+    /// 从而继承旧账号按 credential_id 聚合的 trace/usage 历史。
+    next_id: AtomicU64,
     /// Token 刷新锁，确保同一时间只有一个刷新操作
     refresh_lock: TokioMutex<()>,
     /// 凭据文件路径（用于回写）
@@ -915,6 +918,22 @@ fn group_matches(cred_groups: &[String], group: Option<&str>) -> bool {
         None => true,
         Some(g) => cred_groups.iter().any(|cg| cg == g),
     }
+}
+
+fn credential_matches_request(
+    credentials: &KiroCredentials,
+    model: Option<&str>,
+    group: Option<&str>,
+) -> bool {
+    let is_opus = model
+        .map(|m| m.to_ascii_lowercase().contains("opus"))
+        .unwrap_or(false);
+
+    if is_opus && !credentials.supports_opus() {
+        return false;
+    }
+
+    group_matches(&credentials.groups, group)
 }
 
 impl MultiTokenManager {
@@ -1026,6 +1045,7 @@ impl MultiTokenManager {
             proxy: Mutex::new(proxy),
             entries: Mutex::new(entries),
             current_id: Mutex::new(initial_id),
+            next_id: AtomicU64::new(next_id),
             refresh_lock: TokioMutex::new(()),
             credentials_path,
             is_multiple_format: AtomicBool::new(is_multiple_format),
@@ -1119,11 +1139,6 @@ impl MultiTokenManager {
         let entries = self.entries.lock();
         let now = Instant::now();
 
-        // 检查是否是 opus 模型
-        let is_opus = model
-            .map(|m| m.to_lowercase().contains("opus"))
-            .unwrap_or(false);
-
         // 过滤可用凭据
         let available: Vec<_> = entries
             .iter()
@@ -1135,12 +1150,8 @@ impl MultiTokenManager {
                 if e.throttled_until.map(|t| t > now).unwrap_or(false) {
                     return false;
                 }
-                // 如果是 opus 模型，需要检查订阅等级
-                if is_opus && !e.credentials.supports_opus() {
-                    return false;
-                }
-                // 账号分组隔离：Key 绑定分组时只用该分组内的账号
-                if !group_matches(&e.credentials.groups, group) {
+                // 模型/分组隔离：请求模型必须由该账号支持，且账号必须匹配请求分组
+                if !credential_matches_request(&e.credentials, model, group) {
                     return false;
                 }
                 true
@@ -1213,7 +1224,7 @@ impl MultiTokenManager {
                             e.id == current_id
                                 && !e.disabled
                                 && !e.throttled_until.map(|t| t > now).unwrap_or(false)
-                                && group_matches(&e.credentials.groups, group)
+                                && credential_matches_request(&e.credentials, model, group)
                         })
                         .map(|e| (e.id, e.credentials.clone()))
                 };
@@ -2700,11 +2711,10 @@ impl MultiTokenManager {
             refresh_token(&new_cred, &self.config, effective_proxy.as_ref()).await?
         };
 
-        // 4. 分配新 ID
-        let new_id = {
-            let entries = self.entries.lock();
-            entries.iter().map(|e| e.id).max().unwrap_or(0) + 1
-        };
+        // 4. 分配新 ID。必须使用单调计数器，不能按当前 entries 最大值重算；
+        // 否则删除最后一个账号后再添加会复用旧 ID，导致 trace/usage/kiro_stats
+        // 这类按 credential_id 聚合的历史被新账号继承。
+        let new_id = self.next_id.fetch_add(1, Ordering::Relaxed);
 
         // 5. 设置 ID 并保留用户输入的元数据
         validated_cred.id = Some(new_id);
@@ -4019,6 +4029,43 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_add_credential_does_not_reuse_deleted_id() {
+        let path = tmp_creds_path("add_cred_no_reuse_deleted_id");
+        let mut cred1 = KiroCredentials::default();
+        cred1.id = Some(1);
+        cred1.kiro_api_key = Some("ksk_existing_1".to_string());
+        cred1.auth_method = Some("api_key".to_string());
+
+        let mut cred2 = KiroCredentials::default();
+        cred2.id = Some(2);
+        cred2.kiro_api_key = Some("ksk_existing_2".to_string());
+        cred2.auth_method = Some("api_key".to_string());
+
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![cred1, cred2],
+            None,
+            Some(path.clone()),
+            true,
+        )
+        .unwrap();
+
+        manager.delete_credential(2).unwrap();
+
+        let mut new_cred = KiroCredentials::default();
+        new_cred.kiro_api_key = Some("ksk_new_3".to_string());
+        new_cred.auth_method = Some("api_key".to_string());
+
+        let new_id = manager.add_credential(new_cred).await.unwrap();
+        assert_eq!(
+            new_id, 3,
+            "new credential IDs must not reuse deleted IDs, otherwise historical failure logs attach to the new account"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
     // ── try_reload_credential_from_file ─────────────────────────────────────
 
     /// 文件中有新 refreshToken 时，reload 返回 true 并更新内存凭据
@@ -4189,6 +4236,33 @@ mod tests {
         assert!(manager.select_next_credential(None, Some("nope")).is_none());
         // 未绑定分组(None) → 可选到账号
         assert!(manager.select_next_credential(None, None).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_acquire_context_priority_current_respects_model_support() {
+        let mut free_cred = grouped_cred("free", &[]);
+        free_cred.subscription_title = Some("KIRO FREE".to_string());
+
+        let mut pro_cred = grouped_cred("pro", &[]);
+        pro_cred.subscription_title = Some("KIRO PRO".to_string());
+        pro_cred.priority = 10;
+
+        let manager =
+            MultiTokenManager::new(Config::default(), vec![free_cred, pro_cred], None, None, false)
+                .unwrap();
+
+        // Warm current_id with the highest-priority Free account.
+        let current = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(current.id, 1);
+
+        let opus = manager
+            .acquire_context(Some("claude-opus-4.6"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            opus.id, 2,
+            "priority current_id must not bypass Opus subscription filtering"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

这个 PR 主要处理两类线上问题：

1. Kiro 上游对 `additionalModelRequestFields.output_config.effort` 的枚举支持并不一致。旧模型如 Opus 4.6 会拒绝 `xhigh`，返回：
   `Invalid additionalModelRequestFields: does not have a value in the enumeration ["low", "medium", "high", "max"]`
2. 管理面板中，删除一个有失败记录的账号后再添加新账号，新账号可能显示旧账号的失败日志/失败统计。根因是失败 trace 按 `credential_id` 聚合，而新增账号可能复用被删除账号的 ID。

另外顺手补了一个调度安全修复：priority 模式下当前账号 `current_id` 不能绕过模型能力过滤。

## 改动内容

### 1. effort 兼容与降级

新增 `EffortTier` 解析和 `normalize_effort_for_model` 归一化逻辑：

- 支持解析 `low / medium / high / max / xhigh`
- 支持 `x-high`、`x_high` 这类输入归一到 `xhigh`
- 空 effort 不发送
- 未知 effort 回退为 `high`，避免直接把非法值透传给上游
- 已知旧模型不发送 `xhigh`，自动降级到 `high`

当前策略不是维护完整模型白名单，而是一个保守的兼容策略：

- 已知 4.5 / 4.6 系列不接受 `xhigh`，降级为 `high`
- Opus 4.7 / 4.8、Fable 5、Mythos 5 保留 `xhigh`
- 未知未来模型保留已识别 effort，避免新模型上线后必须立刻改代码

同时系统提示里的 `<thinking_effort>` 也复用同一套归一化逻辑，避免 wire field 和 prompt tag 表达不一致。

### 2. 文档同步

更新 README 和 Kiro wire model 注释，说明：

- `additionalModelRequestFields.output_config` 是窄兼容字段，只在已知可接受的 adaptive thinking 路径发送
- 4.5 / 4.6 系列不接受 `xhigh`
- 新模型/未知模型按兼容策略保留已知 effort
- 未知 effort 会回退到 `high`

### 3. priority 模式模型能力过滤修复

之前 `select_next_credential` 会按模型过滤账号，例如 Free 账号不应接 Opus 请求。

但 priority 模式下，如果 `current_id` 指向某个账号，`acquire_context` 的 current-hit 分支只检查：

- 未禁用
- 未冷却
- 分组匹配

没有重新检查模型能力，导致 current 账号可能绕过 Opus 订阅过滤。

本 PR 增加 `credential_matches_request`，让 `select_next_credential` 和 priority `current_id` 命中路径共用同一套模型/分组过滤逻辑。

### 4. 删除账号后新账号继承旧失败日志的问题

问题原因：

- `success_count` 等统计存在 `kiro_stats.json`，删除账号时会重写统计文件，所以通常不会继承
- 失败日志卡片使用的是 `traces.db` 中的 `/traces/failure-stats`
- trace 失败统计按 `credential_id` 聚合
- 删除账号后，如果新账号复用旧账号 ID，就会看到旧账号的失败日志

修复包括两部分：

1. 新增账号 ID 改为运行期单调分配

   `add_credential` 不再用「当前 entries 最大 ID + 1」重新计算，而是使用 `next_id.fetch_add(1)`。这样同一进程内删除账号后再添加，不会复用刚删除的 ID。

2. 删除账号时清理对应 trace

   在 `TraceStore` 新增 `delete_for_credential(credential_id)`，删除：
   - `final_credential_id = credential_id` 的 trace
   - `trace_attempts.credential_id = credential_id` 的 attempt
   - 相关 trace 的 attempts

   `AdminService::delete_credential` 在删除账号和清理余额缓存后调用该方法，避免旧失败统计挂到后续账号上。

## 测试

已通过以下测试：

```bash
cargo test test_output_config
cargo test test_acquire_context_priority_current_respects_model_support
cargo test test_add_credential_does_not_reuse_deleted_id
cargo test delete_for_credential_removes_failure_stats