### PR TITLE
fix: 向下游透传 429 与 Retry-After

### DIFF
--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -293,6 +293,25 @@ fn count_image_budget(payload: &super::types::MessagesRequest) -> ImageBudget {
 
 /// 将 KiroProvider 错误映射为 HTTP 响应
 pub(super) fn map_provider_error(err: Error) -> Response {
+    if let Some(rate_limit) = err.downcast_ref::<crate::kiro::provider::UpstreamRateLimitError>() {
+        tracing::warn!(error = %err, "上游限流（映射为 429）");
+        let mut response = (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(ErrorResponse::new(
+                "rate_limit_error",
+                "Upstream rate limit exceeded. Retry later.",
+            )),
+        )
+            .into_response();
+        if let Some(value) = rate_limit
+            .retry_after()
+            .and_then(|value| value.parse::<header::HeaderValue>().ok())
+        {
+            response.headers_mut().insert(header::RETRY_AFTER, value);
+        }
+        return response;
+    }
+
     let err_str = err.to_string();
 
     // 上下文窗口满了（对话历史累积超出模型上下文窗口限制）
@@ -1776,6 +1795,18 @@ mod tests {
             "ValidationException: transient backend issue".to_string()
         ));
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn upstream_rate_limit_maps_to_429_with_retry_after() {
+        let err = crate::kiro::provider::UpstreamRateLimitError::new(Some("1800".to_string()));
+        let resp = map_provider_error(err.into());
+
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            resp.headers().get(header::RETRY_AFTER).unwrap(),
+            "1800"
+        );
     }
 
     #[test]

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -20,6 +20,26 @@ use crate::kiro::token_manager::MultiTokenManager;
 use crate::model::config::TlsBackend;
 use parking_lot::Mutex;
 
+/// 上游在所有重试/故障转移均失败后仍返回 429。
+///
+/// 使用独立错误类型，避免 Anthropic 适配层把限流误映射成 502；`retry_after`
+/// 原样保存上游响应头。账号级风控没有该响应头时，由调用处填入本地冷却时长。
+#[derive(Debug, thiserror::Error)]
+#[error("upstream rate limited")]
+pub struct UpstreamRateLimitError {
+    retry_after: Option<String>,
+}
+
+impl UpstreamRateLimitError {
+    pub(crate) fn new(retry_after: Option<String>) -> Self {
+        Self { retry_after }
+    }
+
+    pub fn retry_after(&self) -> Option<&str> {
+        self.retry_after.as_deref()
+    }
+}
+
 /// 每个凭据的最大重试次数
 const MAX_RETRIES_PER_CREDENTIAL: usize = 3;
 
@@ -321,6 +341,11 @@ impl KiroProvider {
             };
 
             let status = response.status();
+            let retry_after = response
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned);
 
             // 成功响应
             if status.is_success() {
@@ -376,7 +401,11 @@ impl KiroProvider {
                     status,
                     body
                 );
-                last_error = Some(anyhow::anyhow!("MCP 请求失败: {} {}", status, body));
+                last_error = if status.as_u16() == 429 {
+                    Some(UpstreamRateLimitError::new(retry_after).into())
+                } else {
+                    Some(anyhow::anyhow!("MCP 请求失败: {} {}", status, body))
+                };
                 if attempt + 1 < max_retries {
                     // 429 限流用更长退避；408/5xx 仍用通用快速退避
                     let delay = if status.as_u16() == 429 {
@@ -516,6 +545,13 @@ impl KiroProvider {
             };
 
             let status = response.status();
+            // `Response::text` 会消费 response，先保存 Retry-After。该值来自已通过
+            // HTTP header 校验的上游响应，适配层仍会在写回前再次校验。
+            let retry_after = response
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned);
 
             // 成功响应
             if status.is_success() {
@@ -639,33 +675,24 @@ impl KiroProvider {
                     body
                 );
 
-                let remaining = self.token_manager.report_account_throttled(ctx.id, cooldown);
+                self.token_manager.report_account_throttled(ctx.id, cooldown);
+                let remaining = self
+                    .token_manager
+                    .available_count_for_request(model.as_deref(), group);
                 Self::emit_attempt(
                     sink, attempt, ctx.id, endpoint_name, Some(429),
                     outcome::ACCOUNT_THROTTLED, Some(&body), attempt_start,
                 );
-                last_error = Some(anyhow::anyhow!(
-                    "{} API 请求失败（账号级风控，凭据 #{} 已冷却 {} 分钟）: {} {}",
-                    api_type,
-                    ctx.id,
-                    cooldown_secs / 60,
-                    status,
-                    body
-                ));
+                // 账号级风控通常不返回 Retry-After；此时使用本地实际冷却时间，
+                // 让下游网关在同一时段内也停止调度该虚拟账号。
+                let rate_limit_error = UpstreamRateLimitError::new(
+                    retry_after.clone().or_else(|| Some(cooldown_secs.to_string())),
+                );
 
                 if remaining == 0 {
-                    anyhow::bail!(
-                        "{} API 请求失败：所有凭据都处于账号风控冷却或已禁用状态。\
-                         上游对凭据 #{} 的账号触发了 \"suspicious activity\" 临时限速，\
-                         建议：(1) 增加更多不同 AWS 账号的凭据；\
-                         (2) 在管理面板降低冷却时长或手动解除冷却以重试；\
-                         (3) 提交 AWS Support 申诉解封该账号。原始响应: {} {}",
-                        api_type,
-                        ctx.id,
-                        status,
-                        body
-                    );
+                    return Err(rate_limit_error.into());
                 }
+                last_error = Some(rate_limit_error.into());
                 continue;
             }
 
@@ -722,12 +749,16 @@ impl KiroProvider {
                     sink, attempt, ctx.id, endpoint_name, Some(status.as_u16()),
                     outcome::TRANSIENT, Some(&body), attempt_start,
                 );
-                last_error = Some(anyhow::anyhow!(
-                    "{} API 请求失败: {} {}",
-                    api_type,
-                    status,
-                    body
-                ));
+                last_error = if status.as_u16() == 429 {
+                    Some(UpstreamRateLimitError::new(retry_after).into())
+                } else {
+                    Some(anyhow::anyhow!(
+                        "{} API 请求失败: {} {}",
+                        api_type,
+                        status,
+                        body
+                    ))
+                };
                 if attempt + 1 < max_retries {
                     // 429 限流用更长退避给账号配额恢复时间；408/5xx 仍用通用快速退避
                     let delay = if status.as_u16() == 429 {

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1237,6 +1237,30 @@ impl MultiTokenManager {
             .count()
     }
 
+    /// 获取当前请求范围内的可用凭据数量。
+    ///
+    /// 与全局 [`Self::available_count`] 不同，这里同时应用模型能力和客户端 Key
+    /// 绑定的分组过滤，供严格隔离场景判断是否还能故障转移。
+    pub fn available_count_for_request(
+        &self,
+        model: Option<&str>,
+        group: Option<&str>,
+    ) -> usize {
+        let now = Instant::now();
+        self.entries
+            .lock()
+            .iter()
+            .filter(|entry| {
+                !entry.disabled
+                    && !entry
+                        .throttled_until
+                        .map(|until| until > now)
+                        .unwrap_or(false)
+                    && credential_matches_request(&entry.credentials, model, group)
+            })
+            .count()
+    }
+
     /// 根据负载均衡模式选择下一个凭据
     ///
     /// - priority 模式：选择优先级最高（priority 最小）的可用凭据
@@ -4520,6 +4544,27 @@ mod tests {
         assert_eq!(manager.total_count_in_group(Some("g2")), 1); // B
         assert_eq!(manager.total_count_in_group(None), 3); // 全部
         assert_eq!(manager.total_count_in_group(Some("none")), 0);
+    }
+
+    #[test]
+    fn test_available_count_for_request_respects_group_throttle() {
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![
+                grouped_cred("a", &["g1"]),
+                grouped_cred("b", &["g2"]),
+            ],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(manager.available_count_for_request(None, Some("g1")), 1);
+        // g1 的唯一凭据进入冷却后，即使全局还有 g2，g1 也必须视为无可用账号。
+        assert_eq!(manager.report_account_throttled(1, StdDuration::from_secs(60)), 1);
+        assert_eq!(manager.available_count_for_request(None, Some("g1")), 0);
+        assert_eq!(manager.available_count_for_request(None, Some("g2")), 1);
     }
 
     #[test]


### PR DESCRIPTION
## 问题

当 Kiro 上游最终返回 429 时，provider 目前把错误包装为普通 `anyhow::Error`，Anthropic 适配层随后统一映射成 502。这样 Sub2API 等下游网关无法识别账号限流，也无法根据 `Retry-After` 暂停调度。

历史 issue #2 中也能看到 429 最终表现为 adapter 502 的现象。

## 修改

- 增加类型化的 `UpstreamRateLimitError`。
- `/v1/messages` 与 MCP 请求耗尽重试后返回 HTTP 429，而不是 502。
- 保留上游 `Retry-After`；`suspicious activity` 未提供该头时，使用本地 `accountThrottleCooldownSecs` 作为回避时长。
- 返回稳定的 Anthropic `rate_limit_error`，不向客户端暴露上游响应正文或凭据细节。
- 严格分组调度时，按 model + group 判断是否仍有可故障转移的凭据，避免其他组有可用账号时本组最后一个 429 被覆盖成 502。

## 验证

- `cargo test --no-default-features`: 476 passed, 0 failed
- `OPENSSL_NO_VENDOR=1 cargo check`: passed

Related to #2.