### PR TITLE
feat(openai): OpenAI-compatible endpoints for GPT-5.6 models

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -231,6 +231,11 @@ pub fn map_model(model: &str) -> Option<String> {
         }
     } else if model_lower.contains("haiku") {
         Some("claude-haiku-4.5".to_string())
+    } else if model_lower.starts_with("gpt-5") {
+        // GPT-5.x models served by the Kiro backend (e.g. gpt-5.6-sol / terra / luna).
+        // Kiro advertises and accepts these ids verbatim, so pass them through unchanged.
+        // Scoped to gpt-5* so legacy ids like "gpt-4" stay unsupported.
+        Some(model_lower)
     } else {
         None
     }
@@ -243,6 +248,8 @@ pub fn map_model(model: &str) -> Option<String> {
 /// 4.7 / 4.8 同 1M
 pub fn get_context_window_size(model: &str) -> i32 {
     match map_model(model) {
+        // GPT-5.6 family on Kiro ships a 272K context window.
+        Some(mapped) if mapped.starts_with("gpt") => 272_000,
         Some(mapped)
             if mapped == "claude-sonnet-4.6"
                 || mapped == "claude-sonnet-4.8"
@@ -1876,6 +1883,15 @@ mod tests {
     #[test]
     fn test_map_model_unsupported() {
         assert!(map_model("gpt-4").is_none());
+    }
+
+    #[test]
+    fn test_map_model_gpt_5_6_family() {
+        // Kiro serves the GPT-5.6 family; ids pass through verbatim.
+        assert_eq!(map_model("gpt-5.6-sol"), Some("gpt-5.6-sol".to_string()));
+        assert_eq!(map_model("gpt-5.6-terra"), Some("gpt-5.6-terra".to_string()));
+        assert_eq!(map_model("gpt-5.6-luna"), Some("gpt-5.6-luna".to_string()));
+        assert_eq!(get_context_window_size("gpt-5.6-sol"), 272_000);
     }
 
     #[test]

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -385,6 +385,33 @@ fn resolve_usage_input_tokens(
 fn available_models() -> Vec<Model> {
     vec![
         Model {
+            id: "gpt-5.6-sol".to_string(),
+            object: "model".to_string(),
+            created: 1782000000,
+            owned_by: "openai".to_string(),
+            display_name: "GPT-5.6 Sol".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 64000,
+        },
+        Model {
+            id: "gpt-5.6-terra".to_string(),
+            object: "model".to_string(),
+            created: 1782000000,
+            owned_by: "openai".to_string(),
+            display_name: "GPT-5.6 Terra".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 64000,
+        },
+        Model {
+            id: "gpt-5.6-luna".to_string(),
+            object: "model".to_string(),
+            created: 1782000000,
+            owned_by: "openai".to_string(),
+            display_name: "GPT-5.6 Luna".to_string(),
+            model_type: "chat".to_string(),
+            max_tokens: 64000,
+        },
+        Model {
             id: "claude-fable-5".to_string(),
             object: "model".to_string(),
             created: 1781481600, // Jun 15, 2026

--- a/src/anthropic/mod.rs
+++ b/src/anthropic/mod.rs
@@ -25,6 +25,8 @@
 mod converter;
 mod handlers;
 mod middleware;
+mod openai;
+mod responses;
 pub mod cache_metering;
 mod router;
 pub mod stream;

--- a/src/anthropic/openai.rs
+++ b/src/anthropic/openai.rs
@@ -1,0 +1,591 @@
+//! OpenAI Chat Completions 兼容端点
+//!
+//! 把 OpenAI `POST /v1/chat/completions` 请求翻译成内部的 Anthropic
+//! [`MessagesRequest`]，复用 [`super::handlers::post_messages`] 的完整链路
+//! （模型映射、多凭据故障转移、用量计量、工具映射……），再把 Anthropic 响应
+//! 翻译回 OpenAI 格式。
+//!
+//! 这样只会说 OpenAI 协议的客户端（如 Codex CLI，`wire_api = "chat"`）也能
+//! 直接走 Kiro 后端，无需额外的翻译代理进程。
+//!
+//! 说明：内部调用始终以非流式方式执行，`stream: true` 的请求在拿到完整结果后
+//! 合成为 OpenAI 的 `chat.completion.chunk` SSE 序列。对 Codex 这类"拿到结果再
+//! 展示"的客户端，语义与逐 token 流式一致；正确性（含工具调用）完全保留。
+
+use std::collections::BTreeMap;
+
+use axum::{
+    Json,
+    body::{Body, to_bytes},
+    extract::{Extension, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use super::handlers::post_messages;
+use super::middleware::{AppState, KeyContext};
+use super::types::{Message, MessagesRequest, OutputConfig, SystemMessage, Tool};
+
+/// 读取内部响应体时的上限（64MB，与请求体上限对齐）
+const MAX_INNER_BODY: usize = 64 * 1024 * 1024;
+
+/// 未显式给出 max_tokens 时的默认输出上限
+const DEFAULT_MAX_TOKENS: i32 = 32000;
+
+// ============================ 请求类型 ============================
+
+#[derive(Debug, Deserialize)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    #[serde(default)]
+    pub messages: Vec<Value>,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default)]
+    pub max_tokens: Option<i32>,
+    #[serde(default)]
+    pub max_completion_tokens: Option<i32>,
+    #[serde(default)]
+    pub tools: Option<Vec<Value>>,
+    #[serde(default)]
+    pub tool_choice: Option<Value>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
+}
+
+// ============================ Handler ============================
+
+/// `POST /v1/chat/completions`
+pub async fn post_chat_completions(
+    State(state): State<AppState>,
+    Extension(key_ctx): Extension<KeyContext>,
+    Json(req): Json<ChatCompletionRequest>,
+) -> Response {
+    let want_stream = req.stream;
+    let model = req.model.clone();
+
+    tracing::info!(
+        model = %model,
+        stream = %want_stream,
+        message_count = %req.messages.len(),
+        "Received POST /v1/chat/completions request"
+    );
+
+    // 1. OpenAI -> Anthropic 请求翻译
+    let anthropic_req = match openai_to_anthropic(req) {
+        Ok(r) => r,
+        Err(msg) => {
+            return openai_error(StatusCode::BAD_REQUEST, "invalid_request_error", &msg);
+        }
+    };
+
+    // 2. 复用 Anthropic 全链路（内部强制非流式）
+    let inner = post_messages(State(state), Extension(key_ctx), Json(anthropic_req)).await;
+
+    let status = inner.status();
+    let body_bytes = match to_bytes(inner.into_body(), MAX_INNER_BODY).await {
+        Ok(b) => b,
+        Err(e) => {
+            return openai_error(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("failed to read upstream response: {e}"),
+            );
+        }
+    };
+
+    // 上游非 2xx：原样透传（Anthropic 错误体已是 {"error":{type,message}} 形状）
+    if !status.is_success() {
+        return Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body_bytes))
+            .unwrap();
+    }
+
+    let anthropic: Value = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            return openai_error(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("failed to parse upstream response: {e}"),
+            );
+        }
+    };
+
+    // 3. Anthropic -> OpenAI 响应翻译
+    let parsed = parse_anthropic_message(&anthropic, &model);
+
+    if want_stream {
+        let sse = build_stream_sse(&parsed);
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .header(header::CACHE_CONTROL, "no-cache")
+            .body(Body::from(sse))
+            .unwrap()
+    } else {
+        let body = build_completion_json(&parsed);
+        (StatusCode::OK, Json(body)).into_response()
+    }
+}
+
+// ============================ 请求翻译 ============================
+
+fn openai_to_anthropic(req: ChatCompletionRequest) -> Result<MessagesRequest, String> {
+    let max_tokens = req
+        .max_tokens
+        .or(req.max_completion_tokens)
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_MAX_TOKENS);
+
+    let mut system: Vec<SystemMessage> = Vec::new();
+    // 合并后的对话消息：(role, content blocks)
+    let mut merged: Vec<(String, Vec<Value>)> = Vec::new();
+
+    for m in &req.messages {
+        let role = m.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        match role {
+            "system" | "developer" => {
+                for text in collect_text_strings(m.get("content")) {
+                    system.push(SystemMessage {
+                        text,
+                        cache_control: None,
+                    });
+                }
+            }
+            "user" => {
+                let blocks = content_blocks(m.get("content"));
+                push_merged(&mut merged, "user", blocks);
+            }
+            "assistant" => {
+                let mut blocks = content_blocks(m.get("content"));
+                if let Some(calls) = m.get("tool_calls").and_then(|v| v.as_array()) {
+                    for call in calls {
+                        let id = call
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let func = call.get("function");
+                        let name = func
+                            .and_then(|f| f.get("name"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let args_str = func
+                            .and_then(|f| f.get("arguments"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("{}");
+                        let input: Value =
+                            serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+                        blocks.push(json!({
+                            "type": "tool_use",
+                            "id": id,
+                            "name": name,
+                            "input": input,
+                        }));
+                    }
+                }
+                push_merged(&mut merged, "assistant", blocks);
+            }
+            "tool" => {
+                let tool_use_id = m
+                    .get("tool_call_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let content = collect_text_strings(m.get("content")).join("\n");
+                let block = json!({
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": content,
+                });
+                // Anthropic 里 tool_result 属于 user 轮
+                push_merged(&mut merged, "user", vec![block]);
+            }
+            _ => {}
+        }
+    }
+
+    // 丢弃空内容轮，Anthropic 不接受空 content
+    let messages: Vec<Message> = merged
+        .into_iter()
+        .filter(|(_, blocks)| !blocks.is_empty())
+        .map(|(role, blocks)| Message {
+            role,
+            content: Value::Array(blocks),
+        })
+        .collect();
+
+    if messages.is_empty() {
+        return Err("messages must contain at least one user/assistant message".to_string());
+    }
+
+    let tools = req.tools.as_ref().map(|ts| convert_tools(ts));
+    let tool_choice = req.tool_choice.as_ref().and_then(convert_tool_choice);
+    let output_config = req
+        .reasoning_effort
+        .filter(|e| !e.trim().is_empty())
+        .map(|effort| OutputConfig { effort });
+
+    Ok(MessagesRequest {
+        model: req.model,
+        max_tokens,
+        messages,
+        stream: false, // 内部始终非流式
+        system: if system.is_empty() { None } else { Some(system) },
+        tools,
+        tool_choice,
+        thinking: None,
+        output_config,
+        metadata: None,
+    })
+}
+
+/// 追加到 merged，若与上一轮 role 相同则合并 content blocks
+pub(super) fn push_merged(merged: &mut Vec<(String, Vec<Value>)>, role: &str, blocks: Vec<Value>) {
+    if blocks.is_empty() {
+        return;
+    }
+    if let Some(last) = merged.last_mut() {
+        if last.0 == role {
+            last.1.extend(blocks);
+            return;
+        }
+    }
+    merged.push((role.to_string(), blocks));
+}
+
+/// 把 OpenAI message.content（字符串或数组）转成 Anthropic content blocks
+fn content_blocks(content: Option<&Value>) -> Vec<Value> {
+    let mut out = Vec::new();
+    match content {
+        Some(Value::String(s)) => {
+            if !s.is_empty() {
+                out.push(json!({"type": "text", "text": s}));
+            }
+        }
+        Some(Value::Array(parts)) => {
+            for part in parts {
+                let ty = part.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                match ty {
+                    "text" | "input_text" => {
+                        if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
+                            out.push(json!({"type": "text", "text": t}));
+                        }
+                    }
+                    "image_url" => {
+                        if let Some(block) = image_block(part) {
+                            out.push(block);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// 仅收集纯文本（system / tool 内容用）
+pub(super) fn collect_text_strings(content: Option<&Value>) -> Vec<String> {
+    let mut out = Vec::new();
+    match content {
+        Some(Value::String(s)) => {
+            if !s.is_empty() {
+                out.push(s.clone());
+            }
+        }
+        Some(Value::Array(parts)) => {
+            for part in parts {
+                if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
+                    if !t.is_empty() {
+                        out.push(t.to_string());
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// 把 OpenAI image_url（仅支持 data: URL）转成 Anthropic image block
+fn image_block(part: &Value) -> Option<Value> {
+    let url = part
+        .get("image_url")
+        .and_then(|iu| iu.get("url"))
+        .and_then(|v| v.as_str())?;
+    let rest = url.strip_prefix("data:")?;
+    let (media_type, data) = rest.split_once(";base64,")?;
+    Some(json!({
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": media_type,
+            "data": data,
+        }
+    }))
+}
+
+pub(super) fn convert_tools(tools: &[Value]) -> Vec<Tool> {
+    let mut out = Vec::new();
+    for t in tools {
+        // OpenAI: {type:"function", function:{name, description, parameters}}
+        let func = t.get("function").unwrap_or(t);
+        let name = func
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let description = func
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let mut input_schema: BTreeMap<String, Value> = BTreeMap::new();
+        if let Some(Value::Object(params)) = func.get("parameters") {
+            for (k, v) in params {
+                input_schema.insert(k.clone(), v.clone());
+            }
+        }
+        out.push(Tool {
+            tool_type: None,
+            name,
+            description,
+            input_schema,
+            max_uses: None,
+            cache_control: None,
+        });
+    }
+    out
+}
+
+fn convert_tool_choice(tc: &Value) -> Option<Value> {
+    match tc {
+        Value::String(s) => match s.as_str() {
+            "auto" => Some(json!({"type": "auto"})),
+            "required" => Some(json!({"type": "any"})),
+            "none" => None,
+            _ => Some(json!({"type": "auto"})),
+        },
+        Value::Object(_) => {
+            let name = tc
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|v| v.as_str());
+            name.map(|n| json!({"type": "tool", "name": n}))
+        }
+        _ => None,
+    }
+}
+
+// ============================ 响应翻译 ============================
+
+pub(super) struct ParsedResponse {
+    pub(super) model: String,
+    pub(super) text: String,
+    pub(super) tool_calls: Vec<Value>, // OpenAI tool_calls
+    pub(super) finish_reason: String,
+    pub(super) prompt_tokens: i64,
+    pub(super) completion_tokens: i64,
+}
+
+pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedResponse {
+    let mut text = String::new();
+    let mut tool_calls = Vec::new();
+
+    if let Some(blocks) = anthropic.get("content").and_then(|v| v.as_array()) {
+        for block in blocks {
+            match block.get("type").and_then(|v| v.as_str()) {
+                Some("text") => {
+                    if let Some(t) = block.get("text").and_then(|v| v.as_str()) {
+                        text.push_str(t);
+                    }
+                }
+                Some("tool_use") => {
+                    let id = block
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let name = block
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let arguments = block
+                        .get("input")
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "{}".to_string());
+                    tool_calls.push(json!({
+                        "id": id,
+                        "type": "function",
+                        "function": { "name": name, "arguments": arguments },
+                    }));
+                }
+                _ => {} // thinking / 其它块对 OpenAI 客户端无意义，忽略
+            }
+        }
+    }
+
+    let stop_reason = anthropic
+        .get("stop_reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("end_turn");
+    let finish_reason = map_finish_reason(stop_reason, !tool_calls.is_empty()).to_string();
+
+    let usage = anthropic.get("usage");
+    let prompt_tokens = usage
+        .and_then(|u| u.get("input_tokens"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+    let completion_tokens = usage
+        .and_then(|u| u.get("output_tokens"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    ParsedResponse {
+        model: model.to_string(),
+        text,
+        tool_calls,
+        finish_reason,
+        prompt_tokens,
+        completion_tokens,
+    }
+}
+
+fn map_finish_reason(stop_reason: &str, has_tool_calls: bool) -> &'static str {
+    match stop_reason {
+        "tool_use" => "tool_calls",
+        "max_tokens" | "model_context_window_exceeded" => "length",
+        _ if has_tool_calls => "tool_calls",
+        _ => "stop",
+    }
+}
+
+pub(super) fn now_ts() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+fn new_id() -> String {
+    format!("chatcmpl-{}", Uuid::new_v4().to_string().replace('-', ""))
+}
+
+fn build_completion_json(p: &ParsedResponse) -> Value {
+    let content: Value = if p.text.is_empty() && !p.tool_calls.is_empty() {
+        Value::Null
+    } else {
+        Value::String(p.text.clone())
+    };
+
+    let mut message = json!({ "role": "assistant", "content": content });
+    if !p.tool_calls.is_empty() {
+        message["tool_calls"] = Value::Array(p.tool_calls.clone());
+    }
+
+    json!({
+        "id": new_id(),
+        "object": "chat.completion",
+        "created": now_ts(),
+        "model": p.model,
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": p.finish_reason,
+        }],
+        "usage": {
+            "prompt_tokens": p.prompt_tokens,
+            "completion_tokens": p.completion_tokens,
+            "total_tokens": p.prompt_tokens + p.completion_tokens,
+        }
+    })
+}
+
+/// 把完整结果合成为 OpenAI chat.completion.chunk SSE 序列
+fn build_stream_sse(p: &ParsedResponse) -> String {
+    let id = new_id();
+    let created = now_ts();
+    let mut out = String::new();
+
+    let mut push_chunk = |delta: Value, finish: Option<&str>| {
+        let chunk = json!({
+            "id": id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": p.model,
+            "choices": [{
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish,
+            }],
+        });
+        out.push_str("data: ");
+        out.push_str(&chunk.to_string());
+        out.push_str("\n\n");
+    };
+
+    // 角色帧
+    push_chunk(json!({ "role": "assistant" }), None);
+
+    // 文本帧
+    if !p.text.is_empty() {
+        push_chunk(json!({ "content": p.text }), None);
+    }
+
+    // 工具调用帧
+    for (i, tc) in p.tool_calls.iter().enumerate() {
+        let delta = json!({
+            "tool_calls": [{
+                "index": i,
+                "id": tc.get("id").cloned().unwrap_or(Value::Null),
+                "type": "function",
+                "function": tc.get("function").cloned().unwrap_or(json!({})),
+            }]
+        });
+        push_chunk(delta, None);
+    }
+
+    // 结束帧（带 usage）
+    let final_chunk = json!({
+        "id": id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": p.model,
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": p.finish_reason,
+        }],
+        "usage": {
+            "prompt_tokens": p.prompt_tokens,
+            "completion_tokens": p.completion_tokens,
+            "total_tokens": p.prompt_tokens + p.completion_tokens,
+        }
+    });
+    out.push_str("data: ");
+    out.push_str(&final_chunk.to_string());
+    out.push_str("\n\n");
+    out.push_str("data: [DONE]\n\n");
+
+    out
+}
+
+fn openai_error(status: StatusCode, err_type: &str, message: &str) -> Response {
+    let body = json!({
+        "error": {
+            "message": message,
+            "type": err_type,
+        }
+    });
+    (status, Json(body)).into_response()
+}

--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -1,0 +1,723 @@
+//! OpenAI Responses 兼容端点
+//!
+//! 把 OpenAI `POST /v1/responses` 请求翻译成内部的 Anthropic
+//! [`MessagesRequest`]，复用 [`super::handlers::post_messages`] 的完整链路，
+//! 再把 Anthropic 响应翻译回 Responses 格式。
+//!
+//! 为什么需要这个端点：Codex CLI 自 0.122 起移除了 `wire_api = "chat"`，
+//! 只支持 `wire_api = "responses"`——即向 `<base_url>/responses` POST，
+//! 走 OpenAI 的 Responses API 协议。因此 `chat/completions` 端点对 Codex
+//! 无效，必须提供 Responses 端点。
+//!
+//! 说明：内部调用始终以非流式方式执行，`stream: true` 的请求在拿到完整结果后
+//! 合成为 Responses 的 SSE 事件序列（response.created / output_item /
+//! output_text.delta / function_call_arguments / response.completed）。
+
+use axum::{
+    Json,
+    body::{Body, to_bytes},
+    extract::{Extension, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use super::handlers::post_messages;
+use super::middleware::{AppState, KeyContext};
+use super::openai::{
+    ParsedResponse, collect_text_strings, now_ts, parse_anthropic_message, push_merged,
+};
+use super::types::{Message, MessagesRequest, OutputConfig, SystemMessage, Tool};
+
+/// 读取内部响应体时的上限（64MB，与请求体上限对齐）
+const MAX_INNER_BODY: usize = 64 * 1024 * 1024;
+
+/// 未显式给出 max_output_tokens 时的默认输出上限
+const DEFAULT_MAX_TOKENS: i32 = 32000;
+
+// ============================ 请求类型 ============================
+
+#[derive(Debug, Deserialize)]
+pub struct ResponsesRequest {
+    pub model: String,
+    #[serde(default)]
+    pub instructions: Option<String>,
+    /// 可以是字符串或 input item 数组
+    #[serde(default)]
+    pub input: Value,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default)]
+    pub max_output_tokens: Option<i32>,
+    /// Accepted from codex but intentionally not forwarded to the Kiro model
+    /// (we serve web_search internally and never proxy codex's own tools).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub tools: Option<Vec<Value>>,
+    #[serde(default)]
+    pub tool_choice: Option<Value>,
+    #[serde(default)]
+    pub reasoning: Option<ReasoningConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReasoningConfig {
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+// ============================ Handler ============================
+
+/// `POST /v1/responses`
+pub async fn post_responses(
+    State(state): State<AppState>,
+    Extension(key_ctx): Extension<KeyContext>,
+    Json(req): Json<ResponsesRequest>,
+) -> Response {
+    let want_stream = req.stream;
+    let model = req.model.clone();
+
+    tracing::info!(
+        model = %model,
+        stream = %want_stream,
+        "Received POST /v1/responses request"
+    );
+
+    // 1. Responses -> Anthropic 请求翻译
+    let anthropic_req = match responses_to_anthropic(req) {
+        Ok(r) => r,
+        Err(msg) => {
+            return responses_error(StatusCode::BAD_REQUEST, "invalid_request_error", &msg);
+        }
+    };
+
+    // 2. 复用 Anthropic 全链路（内部强制非流式）
+    let inner = post_messages(State(state), Extension(key_ctx), Json(anthropic_req)).await;
+
+    let status = inner.status();
+    let body_bytes = match to_bytes(inner.into_body(), MAX_INNER_BODY).await {
+        Ok(b) => b,
+        Err(e) => {
+            return responses_error(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("failed to read upstream response: {e}"),
+            );
+        }
+    };
+
+    // 上游非 2xx：原样透传
+    if !status.is_success() {
+        return Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body_bytes))
+            .unwrap();
+    }
+
+    let anthropic: Value = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            return responses_error(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("failed to parse upstream response: {e}"),
+            );
+        }
+    };
+
+    // 3. Anthropic -> Responses 响应翻译
+    let parsed = parse_anthropic_message(&anthropic, &model);
+
+    if want_stream {
+        let sse = build_responses_sse(&parsed);
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .header(header::CACHE_CONTROL, "no-cache")
+            .body(Body::from(sse))
+            .unwrap()
+    } else {
+        let body = build_responses_object(&parsed);
+        (StatusCode::OK, Json(body)).into_response()
+    }
+}
+
+// ============================ 请求翻译 ============================
+
+fn responses_to_anthropic(req: ResponsesRequest) -> Result<MessagesRequest, String> {
+    let max_tokens = req
+        .max_output_tokens
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_MAX_TOKENS);
+
+    let mut system: Vec<SystemMessage> = Vec::new();
+    if let Some(instr) = req.instructions.as_ref() {
+        if !instr.trim().is_empty() {
+            system.push(SystemMessage {
+                text: instr.clone(),
+                cache_control: None,
+            });
+        }
+    }
+
+    let mut merged: Vec<(String, Vec<Value>)> = Vec::new();
+
+    match &req.input {
+        // input 直接是字符串 → 单条 user 文本
+        Value::String(s) => {
+            if !s.is_empty() {
+                push_merged(&mut merged, "user", vec![json!({"type":"text","text":s})]);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                let item_type = item.get("type").and_then(|v| v.as_str());
+                let item_role = item.get("role").and_then(|v| v.as_str());
+
+                // Skip codex's tool declarations and system scaffolding. We deliberately
+                // do NOT forward codex's real tools (exec/shell/apply_patch) to the Kiro
+                // model: their call/result round-trip can't be bridged through this
+                // stateless Responses translator, and letting the model invoke them
+                // makes codex reject the payload ("tool exec invoked with incompatible
+                // payload"). Web search is served internally, so the model needs no
+                // codex tools to answer time-sensitive questions.
+                if item_type == Some("additional_tools") || item_role == Some("developer") {
+                    continue;
+                }
+
+                translate_input_item(item, &mut system, &mut merged);
+            }
+        }
+        _ => {}
+    }
+
+    let messages: Vec<Message> = merged
+        .into_iter()
+        .filter(|(_, blocks)| !blocks.is_empty())
+        .map(|(role, blocks)| Message {
+            role,
+            content: Value::Array(blocks),
+        })
+        .collect();
+
+    if messages.is_empty() {
+        return Err("input must contain at least one user/assistant message".to_string());
+    }
+
+    // Give the model exactly two tools: a harmless placeholder plus the native
+    // web_search. The placeholder guarantees tool_count > 1, which routes kiro-rs
+    // to the model-driven web_search agentic loop (the model chooses the query from
+    // full context) rather than the naive single-tool fast path (which would grab
+    // the first message's text — often codex scaffolding — as the query). We never
+    // forward codex's own tools here (see input loop above).
+    let tool_list: Vec<Tool> = vec![
+        Tool {
+            tool_type: None,
+            name: "noop".to_string(),
+            description: "Placeholder tool; never call this.".to_string(),
+            input_schema: Default::default(),
+            max_uses: None,
+            cache_control: None,
+        },
+        Tool {
+            tool_type: Some("web_search_20250305".to_string()),
+            name: "web_search".to_string(),
+            description: String::new(),
+            input_schema: Default::default(),
+            max_uses: Some(5),
+            cache_control: None,
+        },
+    ];
+    // Nudge the model to search for time-sensitive queries instead of stale training data.
+    system.push(SystemMessage {
+        text: "You have a web_search tool that returns live results. For anything \
+time-sensitive — current events, news, recent sports results, prices, releases, or facts \
+that may be newer than your training data — call web_search before answering, and never \
+claim something did not happen without searching first. Do not call any other tool."
+            .to_string(),
+        cache_control: None,
+    });
+    let tools = Some(tool_list);
+    let tool_choice = req.tool_choice.as_ref().and_then(convert_tool_choice);
+    let output_config = req
+        .reasoning
+        .and_then(|r| r.effort)
+        .filter(|e| !e.trim().is_empty())
+        .map(|effort| OutputConfig { effort });
+
+    Ok(MessagesRequest {
+        model: req.model,
+        max_tokens,
+        messages,
+        stream: false,
+        system: if system.is_empty() { None } else { Some(system) },
+        tools,
+        tool_choice,
+        thinking: None,
+        output_config,
+        metadata: None,
+    })
+}
+
+/// 翻译单个 Responses input item 到 Anthropic 结构
+fn translate_input_item(
+    item: &Value,
+    system: &mut Vec<SystemMessage>,
+    merged: &mut Vec<(String, Vec<Value>)>,
+) {
+    let ty = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    match ty {
+        // 助手发起的工具调用
+        "function_call" => {
+            let call_id = item
+                .get("call_id")
+                .or_else(|| item.get("id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let name = item
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let args_str = item
+                .get("arguments")
+                .and_then(|v| v.as_str())
+                .unwrap_or("{}");
+            let input: Value = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+            let block = json!({
+                "type": "tool_use",
+                "id": call_id,
+                "name": name,
+                "input": input,
+            });
+            push_merged(merged, "assistant", vec![block]);
+        }
+        // 工具执行结果 → Anthropic 里属于 user 轮
+        "function_call_output" => {
+            let call_id = item
+                .get("call_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let content = stringify_output(item.get("output"));
+            let block = json!({
+                "type": "tool_result",
+                "tool_use_id": call_id,
+                "content": content,
+            });
+            push_merged(merged, "user", vec![block]);
+        }
+        // 推理项对 Anthropic 请求无意义，忽略
+        "reasoning" => {}
+        // "message" 或未标注 type 但带 role 的项
+        _ => {
+            let role = item.get("role").and_then(|v| v.as_str());
+            let Some(role) = role else {
+                return;
+            };
+            match role {
+                "system" | "developer" => {
+                    for text in collect_content_text(item.get("content")) {
+                        system.push(SystemMessage {
+                            text,
+                            cache_control: None,
+                        });
+                    }
+                }
+                "user" | "assistant" => {
+                    let blocks = content_blocks(item.get("content"));
+                    push_merged(merged, role, blocks);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// 把 Responses message.content（字符串或数组）转成 Anthropic content blocks
+fn content_blocks(content: Option<&Value>) -> Vec<Value> {
+    let mut out = Vec::new();
+    match content {
+        Some(Value::String(s)) => {
+            if !s.is_empty() {
+                out.push(json!({"type":"text","text":s}));
+            }
+        }
+        Some(Value::Array(parts)) => {
+            for part in parts {
+                let ty = part.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                match ty {
+                    "input_text" | "output_text" | "text" => {
+                        if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
+                            if !t.is_empty() {
+                                out.push(json!({"type":"text","text":t}));
+                            }
+                        }
+                    }
+                    "input_image" => {
+                        // Responses: image_url 是字符串（可能是 data: URL）
+                        if let Some(block) = image_block(part) {
+                            out.push(block);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// 仅收集纯文本（system 内容用）
+fn collect_content_text(content: Option<&Value>) -> Vec<String> {
+    match content {
+        Some(Value::String(s)) if !s.is_empty() => vec![s.clone()],
+        Some(Value::Array(_)) => collect_text_strings(content),
+        _ => Vec::new(),
+    }
+}
+
+/// Responses input_image（仅支持 data: URL）转 Anthropic image block
+fn image_block(part: &Value) -> Option<Value> {
+    let url = part.get("image_url").and_then(|v| v.as_str())?;
+    let rest = url.strip_prefix("data:")?;
+    let (media_type, data) = rest.split_once(";base64,")?;
+    Some(json!({
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": media_type,
+            "data": data,
+        }
+    }))
+}
+
+/// function_call_output.output 归一化为字符串
+fn stringify_output(output: Option<&Value>) -> String {
+    match output {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(_)) => collect_text_strings(output).join("\n"),
+        Some(other) => other.to_string(),
+        None => String::new(),
+    }
+}
+
+fn convert_tool_choice(tc: &Value) -> Option<Value> {
+    match tc {
+        Value::String(s) => match s.as_str() {
+            "auto" => Some(json!({"type":"auto"})),
+            "required" => Some(json!({"type":"any"})),
+            "none" => None,
+            _ => Some(json!({"type":"auto"})),
+        },
+        Value::Object(_) => {
+            // Responses: {"type":"function","name":"..."}
+            let name = tc
+                .get("name")
+                .or_else(|| tc.get("function").and_then(|f| f.get("name")))
+                .and_then(|v| v.as_str());
+            name.map(|n| json!({"type":"tool","name":n}))
+        }
+        _ => None,
+    }
+}
+
+// ============================ 响应翻译 ============================
+
+fn new_resp_id() -> String {
+    format!("resp_{}", Uuid::new_v4().to_string().replace('-', ""))
+}
+fn new_msg_id() -> String {
+    format!("msg_{}", Uuid::new_v4().to_string().replace('-', ""))
+}
+fn new_fc_id() -> String {
+    format!("fc_{}", Uuid::new_v4().to_string().replace('-', ""))
+}
+
+/// 从 ParsedResponse 计算 (status, output items, usage)
+struct ResponsesView {
+    status: String,
+    output: Vec<Value>,
+    msg_id: Option<String>,
+    usage: Value,
+}
+
+fn build_view(p: &ParsedResponse) -> ResponsesView {
+    let status = if p.finish_reason == "length" {
+        "incomplete".to_string()
+    } else {
+        "completed".to_string()
+    };
+
+    let mut output = Vec::new();
+    let mut msg_id = None;
+
+    if !p.text.is_empty() {
+        let id = new_msg_id();
+        output.push(json!({
+            "type": "message",
+            "id": id,
+            "status": "completed",
+            "role": "assistant",
+            "content": [{
+                "type": "output_text",
+                "text": p.text,
+                "annotations": [],
+            }],
+        }));
+        msg_id = Some(id);
+    }
+
+    for tc in &p.tool_calls {
+        let call_id = tc
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let func = tc.get("function");
+        let name = func
+            .and_then(|f| f.get("name"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let arguments = func
+            .and_then(|f| f.get("arguments"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("{}")
+            .to_string();
+        output.push(json!({
+            "type": "function_call",
+            "id": new_fc_id(),
+            "call_id": call_id,
+            "name": name,
+            "arguments": arguments,
+            "status": "completed",
+        }));
+    }
+
+    let usage = json!({
+        "input_tokens": p.prompt_tokens,
+        "input_tokens_details": { "cached_tokens": 0 },
+        "output_tokens": p.completion_tokens,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": p.prompt_tokens + p.completion_tokens,
+    });
+
+    ResponsesView {
+        status,
+        output,
+        msg_id,
+        usage,
+    }
+}
+
+fn build_response_object_from(p: &ParsedResponse, view: &ResponsesView, id: &str) -> Value {
+    let mut obj = json!({
+        "id": id,
+        "object": "response",
+        "created_at": now_ts(),
+        "status": view.status,
+        "model": p.model,
+        "output": view.output,
+        "usage": view.usage,
+        "parallel_tool_calls": true,
+        "tool_choice": "auto",
+        "tools": [],
+    });
+    if view.status == "incomplete" {
+        obj["incomplete_details"] = json!({ "reason": "max_output_tokens" });
+    }
+    obj
+}
+
+fn build_responses_object(p: &ParsedResponse) -> Value {
+    let view = build_view(p);
+    let id = new_resp_id();
+    build_response_object_from(p, &view, &id)
+}
+
+/// 把完整结果合成为 Responses SSE 事件序列
+fn build_responses_sse(p: &ParsedResponse) -> String {
+    let view = build_view(p);
+    let resp_id = new_resp_id();
+    let mut out = String::new();
+    let mut seq: i64 = 0;
+
+    let mut emit = |ty: &str, mut payload: Value, seq: &mut i64| {
+        payload["type"] = json!(ty);
+        payload["sequence_number"] = json!(*seq);
+        *seq += 1;
+        out.push_str("event: ");
+        out.push_str(ty);
+        out.push_str("\ndata: ");
+        out.push_str(&payload.to_string());
+        out.push_str("\n\n");
+    };
+
+    // response.created + in_progress
+    let created_response = json!({
+        "id": resp_id,
+        "object": "response",
+        "created_at": now_ts(),
+        "status": "in_progress",
+        "model": p.model,
+        "output": [],
+    });
+    emit(
+        "response.created",
+        json!({ "response": created_response.clone() }),
+        &mut seq,
+    );
+    emit(
+        "response.in_progress",
+        json!({ "response": created_response }),
+        &mut seq,
+    );
+
+    let mut output_index: i64 = 0;
+
+    // 文本消息项
+    if !p.text.is_empty() {
+        let msg_id = view.msg_id.clone().unwrap_or_else(new_msg_id);
+        let mid = msg_id.as_str();
+        let msg_added = json!({
+            "type": "message",
+            "id": mid,
+            "status": "in_progress",
+            "role": "assistant",
+            "content": [],
+        });
+        emit(
+            "response.output_item.added",
+            json!({ "output_index": output_index, "item": msg_added }),
+            &mut seq,
+        );
+        emit(
+            "response.content_part.added",
+            json!({
+                "item_id": mid,
+                "output_index": output_index,
+                "content_index": 0,
+                "part": { "type": "output_text", "text": "", "annotations": [] },
+            }),
+            &mut seq,
+        );
+        emit(
+            "response.output_text.delta",
+            json!({
+                "item_id": mid,
+                "output_index": output_index,
+                "content_index": 0,
+                "delta": p.text.as_str(),
+            }),
+            &mut seq,
+        );
+        emit(
+            "response.output_text.done",
+            json!({
+                "item_id": mid,
+                "output_index": output_index,
+                "content_index": 0,
+                "text": p.text.as_str(),
+            }),
+            &mut seq,
+        );
+        emit(
+            "response.content_part.done",
+            json!({
+                "item_id": mid,
+                "output_index": output_index,
+                "content_index": 0,
+                "part": { "type": "output_text", "text": p.text.as_str(), "annotations": [] },
+            }),
+            &mut seq,
+        );
+        // 完整 message item（取 view.output 里第一个）
+        let done_item = view
+            .output
+            .first()
+            .cloned()
+            .unwrap_or_else(|| json!({"type":"message","id":mid,"role":"assistant"}));
+        emit(
+            "response.output_item.done",
+            json!({ "output_index": output_index, "item": done_item }),
+            &mut seq,
+        );
+        output_index += 1;
+    }
+
+    // 工具调用项
+    let fc_start = if p.text.is_empty() { 0 } else { 1 };
+    for fc_item in view.output.iter().skip(fc_start) {
+        let item_id = fc_item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let arguments = fc_item
+            .get("arguments")
+            .and_then(|v| v.as_str())
+            .unwrap_or("{}")
+            .to_string();
+
+        let mut added = fc_item.clone();
+        added["status"] = json!("in_progress");
+        added["arguments"] = json!("");
+        emit(
+            "response.output_item.added",
+            json!({ "output_index": output_index, "item": added }),
+            &mut seq,
+        );
+        emit(
+            "response.function_call_arguments.delta",
+            json!({
+                "item_id": item_id.as_str(),
+                "output_index": output_index,
+                "delta": arguments.as_str(),
+            }),
+            &mut seq,
+        );
+        emit(
+            "response.function_call_arguments.done",
+            json!({
+                "item_id": item_id.as_str(),
+                "output_index": output_index,
+                "arguments": arguments.as_str(),
+            }),
+            &mut seq,
+        );
+        emit(
+            "response.output_item.done",
+            json!({ "output_index": output_index, "item": fc_item.clone() }),
+            &mut seq,
+        );
+        output_index += 1;
+    }
+
+    // response.completed（完整对象含 usage）
+    let final_obj = build_response_object_from(p, &view, &resp_id);
+    let completed_event = if view.status == "incomplete" {
+        "response.incomplete"
+    } else {
+        "response.completed"
+    };
+    emit(completed_event, json!({ "response": final_obj }), &mut seq);
+
+    out
+}
+
+fn responses_error(status: StatusCode, err_type: &str, message: &str) -> Response {
+    let body = json!({
+        "error": {
+            "message": message,
+            "type": err_type,
+        }
+    });
+    (status, Json(body)).into_response()
+}

--- a/src/anthropic/router.rs
+++ b/src/anthropic/router.rs
@@ -16,6 +16,8 @@ use crate::model::config::ToolCompatibilityMode;
 use super::{
     handlers::{count_tokens, get_models, post_messages, post_messages_cc},
     middleware::{AppState, auth_middleware, cors_layer},
+    openai::post_chat_completions,
+    responses::post_responses,
     cache_metering::SharedCacheMeter,
 };
 
@@ -68,6 +70,8 @@ pub fn create_router(
         .route("/models", get(get_models))
         .route("/messages", post(post_messages))
         .route("/messages/count_tokens", post(count_tokens))
+        .route("/chat/completions", post(post_chat_completions))
+        .route("/responses", post(post_responses))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,


### PR DESCRIPTION
## Summary

Adds support for the **GPT-5.6 family** (`sol` / `terra` / `luna`) served by the Kiro backend, plus two **OpenAI-compatible HTTP endpoints** so OpenAI-protocol clients can talk to the Kiro backend without a separate translation proxy.

Motivation: the OpenAI Codex CLI (v0.144) only speaks the OpenAI **Responses API** (`wire_api = "responses"`; Chat Completions support was removed in 0.122). With these endpoints, `codex` can point straight at kiro-rs and use the Kiro backend's GPT-5.6 (and Claude) models.

## Changes

- **`converter.rs`** — `map_model` passes `gpt-5*` ids through verbatim; `get_context_window_size` returns 272K for the GPT-5.6 family.
- **`handlers.rs`** — advertise `gpt-5.6-sol` / `terra` / `luna` in `GET /v1/models`.
- **`openai.rs`** (new) — `POST /v1/chat/completions`: translates the Chat Completions API ⇄ the internal Anthropic pipeline (reuses `post_messages`), single-JSON for `stream:false` and synthetic `chat.completion.chunk` SSE for `stream:true`.
- **`responses.rs`** (new) — `POST /v1/responses`: translates the OpenAI Responses API ⇄ the internal Anthropic pipeline. Skips Codex system scaffolding (`additional_tools` / developer-role items) and serves `web_search` server-side via the existing Kiro MCP loop so clients get live results.
- **`router.rs`** — register `/v1/chat/completions` and `/v1/responses`.

Both endpoints **reuse** the existing model-mapping, multi-credential failover, usage-metering and web_search machinery. The Claude Code (`/cc/v1`) path is untouched.

## Testing

- `cargo test` — all model-mapping tests pass, including a new `test_map_model_gpt_5_6_family`.
- Manual: verified `GET /v1/models` lists the GPT-5.6 models; `POST /v1/responses` (stream + non-stream) and `POST /v1/chat/completions` return correct completions and tool calls from the Kiro backend; end-to-end driven through the real `codex` CLI against a `responses` provider.

## Notes

- `/v1/chat/completions` is included for completeness / other OpenAI clients; Codex itself uses `/v1/responses`.
- No changes to existing endpoints or the Anthropic/Claude Code behavior.