### PR TITLE
fix(responses): stabilize Codex tool continuations

### DIFF
--- a/src/anthropic/openai.rs
+++ b/src/anthropic/openai.rs
@@ -398,11 +398,20 @@ pub(super) struct ParsedResponse {
     pub(super) finish_reason: String,
     pub(super) prompt_tokens: i64,
     pub(super) completion_tokens: i64,
+    /// 思考文本（content 里的 thinking 块 + web_search loop 的顶层
+    /// `kiro_thinking` 带外字段）。chat/completions 路径不消费，
+    /// Responses 路径渲染为 reasoning summary item。
+    pub(super) thinking: String,
+    /// 内部代答的 web_search 展示（server_tool_use 块）：(id, query)。
+    /// Responses 路径渲染为 web_search_call item。
+    pub(super) web_searches: Vec<(String, String)>,
 }
 
 pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedResponse {
     let mut text = String::new();
     let mut tool_calls = Vec::new();
+    let mut thinking = String::new();
+    let mut web_searches = Vec::new();
 
     if let Some(blocks) = anthropic.get("content").and_then(|v| v.as_array()) {
         for block in blocks {
@@ -410,6 +419,27 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
                 Some("text") => {
                     if let Some(t) = block.get("text").and_then(|v| v.as_str()) {
                         text.push_str(t);
+                    }
+                }
+                Some("thinking") => {
+                    if let Some(t) = block.get("thinking").and_then(|v| v.as_str()) {
+                        thinking.push_str(t);
+                    }
+                }
+                Some("server_tool_use") => {
+                    // 内部代答的 web_search 展示块（websearch_loop Contract A）
+                    if block.get("name").and_then(|v| v.as_str()) == Some("web_search") {
+                        let id = block
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let query = block
+                            .pointer("/input/query")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        web_searches.push((id, query));
                     }
                 }
                 Some("tool_use") => {
@@ -433,8 +463,18 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
                         "function": { "name": name, "arguments": arguments },
                     }));
                 }
-                _ => {} // thinking / 其它块对 OpenAI 客户端无意义，忽略
+                _ => {} // web_search_tool_result / 其它块对 OpenAI 客户端无意义，忽略
             }
+        }
+    }
+
+    // web_search loop 的带外思考文本（不进 content，避免 Anthropic 客户端回放）
+    if let Some(t) = anthropic.get("kiro_thinking").and_then(|v| v.as_str()) {
+        if !t.is_empty() {
+            if !thinking.is_empty() {
+                thinking.push_str("\n\n");
+            }
+            thinking.push_str(t);
         }
     }
 
@@ -461,6 +501,8 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
         finish_reason,
         prompt_tokens,
         completion_tokens,
+        thinking,
+        web_searches,
     }
 }
 

--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -1062,6 +1062,15 @@ fn build_responses_sse(p: &ParsedResponse, kinds: &ToolKindMap) -> String {
                     }),
                     &mut seq,
                 );
+                emit(
+                    "response.custom_tool_call_input.done",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "input": input.as_str(),
+                    }),
+                    &mut seq,
+                );
             }
             "reasoning" => {
                 let text = item
@@ -1619,9 +1628,29 @@ mod tests {
         assert!(sse.contains("event: response.output_item.added"));
         assert!(sse.contains("event: response.output_item.done"));
         assert!(sse.contains("event: response.custom_tool_call_input.delta"));
+        assert!(sse.contains("event: response.custom_tool_call_input.done"));
         assert!(sse.contains("\"custom_tool_call\""));
         assert!(sse.contains("PATCH BODY"));
         assert!(sse.contains("event: response.completed"));
+        let delta_pos = sse
+            .find("event: response.custom_tool_call_input.delta")
+            .unwrap();
+        let input_done_pos = sse
+            .find("event: response.custom_tool_call_input.done")
+            .unwrap();
+        let item_done_pos = sse.find("event: response.output_item.done").unwrap();
+        assert!(
+            delta_pos < input_done_pos && input_done_pos < item_done_pos,
+            "custom input must finish before the output item is marked done"
+        );
+        let input_done_line = sse
+            .lines()
+            .find(|l| {
+                l.starts_with("data: ")
+                    && l.contains("response.custom_tool_call_input.done")
+            })
+            .expect("custom input done event data line");
+        assert!(input_done_line.contains("\"input\":\"PATCH BODY\""));
         // added 也必须带完整 input（codex 反序列化要求字段存在）
         let added_line = sse
             .lines()

--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -9,9 +9,29 @@
 //! 走 OpenAI 的 Responses API 协议。因此 `chat/completions` 端点对 Codex
 //! 无效，必须提供 Responses 端点。
 //!
+//! 工具桥接（完整 codex 能力的关键）：codex 的工具按声明类型分两类，
+//! 应答的 item 种类必须与声明一致，否则 codex 直接终止本轮
+//! （"tool <name> invoked with incompatible payload"）：
+//! - `type:"function"`（shell / exec_command / write_stdin / update_plan /
+//!   view_image / MCP 工具）→ 应答 `function_call`（JSON 字符串 `arguments`）；
+//! - `type:"custom"`（自由文本工具：apply_patch 的 lark 语法、code-mode exec）
+//!   → 应答 `custom_tool_call`（原始字符串 `input`）。
+//!   Anthropic 侧没有自由文本工具，进方向包一层
+//!   `{"input": <string>}` 单字段 schema，出方向再解包。
+//! 每个请求维护一张 name → 声明类型 的 [`ToolKindMap`]，请求翻译时生成、
+//! 响应构造时消费，保证出方向 item 类型永远与声明一致。
+//!
+//! web_search 始终由 kiro-rs 内部代答（codex 自带的搜索插件在自定义
+//! provider 下 401）：注入原生 `web_search_20250305`，请求因此必然进入
+//! handlers 的 web_search agentic loop——该 loop 会内部消化 web_search、
+//! 把其它 client 工具的 tool_use 原样透传（见 websearch_loop.rs）。
+//!
 //! 说明：内部调用始终以非流式方式执行，`stream: true` 的请求在拿到完整结果后
 //! 合成为 Responses 的 SSE 事件序列（response.created / output_item /
 //! output_text.delta / function_call_arguments / response.completed）。
+//! codex 只从 `response.output_item.done` 构建回合内容，缓冲式合成足够。
+
+use std::collections::{BTreeMap, HashMap};
 
 use axum::{
     Json,
@@ -37,6 +57,53 @@ const MAX_INNER_BODY: usize = 64 * 1024 * 1024;
 /// 未显式给出 max_output_tokens 时的默认输出上限
 const DEFAULT_MAX_TOKENS: i32 = 32000;
 
+/// 无 codex 工具时的严格提示（保持既有已验证的纯聊天/搜索行为）
+const NUDGE_STRICT: &str = "You have a web_search tool that returns live results. For anything \
+time-sensitive — current events, news, recent sports results, prices, releases, or facts \
+that may be newer than your training data — call web_search before answering, and never \
+claim something did not happen without searching first. Do not call any other tool.";
+
+/// 有 codex 工具时的软化提示（其它工具照常使用）
+const NUDGE_SOFT: &str = "You have a web_search tool that returns live results. For anything \
+time-sensitive — current events, news, recent sports results, prices, releases, or facts \
+that may be newer than your training data — call web_search before answering, and never \
+claim something did not happen without searching first. Use your other tools normally for \
+all other work.";
+
+// ============================ 工具声明类型 ============================
+
+/// Responses 客户端声明的工具类型。出方向的 item 种类必须与之一致。
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum DeclaredToolKind {
+    /// `type:"function"` → 应答 `function_call`
+    Function,
+    /// `type:"custom"`（自由文本）→ 应答 `custom_tool_call`
+    Custom,
+}
+
+/// 一个已声明工具的完整身份。codex 0.144 的工具可能挂在 `namespace`
+/// 分组下（如 collaboration 子代理工具）：对 Anthropic 模型展平为
+/// `ns__name`，应答时还原为 `name` + `namespace` 字段。
+#[derive(Clone, Debug)]
+struct DeclaredTool {
+    kind: DeclaredToolKind,
+    /// 原始工具名（不含 namespace 前缀）
+    name: String,
+    /// 所属 namespace（codex 的 ToolName::new(namespace, name) 需要）
+    namespace: Option<String>,
+}
+
+/// 展平名（模型看到的名字）→ 声明信息（每请求独立，无全局状态）
+type ToolKindMap = HashMap<String, DeclaredTool>;
+
+/// 模型侧的展平工具名：namespace 用 `__` 连接（Anthropic 工具名不允许 `.`）
+fn flat_tool_name(namespace: Option<&str>, name: &str) -> String {
+    match namespace {
+        Some(ns) if !ns.is_empty() => format!("{ns}__{name}"),
+        _ => name.to_string(),
+    }
+}
+
 // ============================ 请求类型 ============================
 
 #[derive(Debug, Deserialize)]
@@ -51,10 +118,9 @@ pub struct ResponsesRequest {
     pub stream: bool,
     #[serde(default)]
     pub max_output_tokens: Option<i32>,
-    /// Accepted from codex but intentionally not forwarded to the Kiro model
-    /// (we serve web_search internally and never proxy codex's own tools).
+    /// codex 声明的工具（function / custom / web_search / ...），
+    /// 会被翻译为 Anthropic 工具并转发给 Kiro 模型。
     #[serde(default)]
-    #[allow(dead_code)]
     pub tools: Option<Vec<Value>>,
     #[serde(default)]
     pub tool_choice: Option<Value>,
@@ -85,8 +151,8 @@ pub async fn post_responses(
         "Received POST /v1/responses request"
     );
 
-    // 1. Responses -> Anthropic 请求翻译
-    let anthropic_req = match responses_to_anthropic(req) {
+    // 1. Responses -> Anthropic 请求翻译（同时得到工具声明类型表）
+    let (anthropic_req, tool_kinds) = match responses_to_anthropic(req) {
         Ok(r) => r,
         Err(msg) => {
             return responses_error(StatusCode::BAD_REQUEST, "invalid_request_error", &msg);
@@ -132,7 +198,7 @@ pub async fn post_responses(
     let parsed = parse_anthropic_message(&anthropic, &model);
 
     if want_stream {
-        let sse = build_responses_sse(&parsed);
+        let sse = build_responses_sse(&parsed, &tool_kinds);
         Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "text/event-stream")
@@ -140,14 +206,16 @@ pub async fn post_responses(
             .body(Body::from(sse))
             .unwrap()
     } else {
-        let body = build_responses_object(&parsed);
+        let body = build_responses_object(&parsed, &tool_kinds);
         (StatusCode::OK, Json(body)).into_response()
     }
 }
 
 // ============================ 请求翻译 ============================
 
-fn responses_to_anthropic(req: ResponsesRequest) -> Result<MessagesRequest, String> {
+fn responses_to_anthropic(
+    req: ResponsesRequest,
+) -> Result<(MessagesRequest, ToolKindMap), String> {
     let max_tokens = req
         .max_output_tokens
         .filter(|v| *v > 0)
@@ -164,6 +232,9 @@ fn responses_to_anthropic(req: ResponsesRequest) -> Result<MessagesRequest, Stri
     }
 
     let mut merged: Vec<(String, Vec<Value>)> = Vec::new();
+    // codex 0.144 把工具声明放进 input 里的 `additional_tools` item
+    //（顶层 `tools` 通常为空）；两处都收集，合并转换。
+    let mut declared_entries: Vec<Value> = req.tools.clone().unwrap_or_default();
 
     match &req.input {
         // input 直接是字符串 → 单条 user 文本
@@ -175,16 +246,14 @@ fn responses_to_anthropic(req: ResponsesRequest) -> Result<MessagesRequest, Stri
         Value::Array(items) => {
             for item in items {
                 let item_type = item.get("type").and_then(|v| v.as_str());
-                let item_role = item.get("role").and_then(|v| v.as_str());
 
-                // Skip codex's tool declarations and system scaffolding. We deliberately
-                // do NOT forward codex's real tools (exec/shell/apply_patch) to the Kiro
-                // model: their call/result round-trip can't be bridged through this
-                // stateless Responses translator, and letting the model invoke them
-                // makes codex reject the payload ("tool exec invoked with incompatible
-                // payload"). Web search is served internally, so the model needs no
-                // codex tools to answer time-sensitive questions.
-                if item_type == Some("additional_tools") || item_role == Some("developer") {
+                // additional_tools item：真正的工具声明清单（codex 0.144）。
+                // developer 角色的 message item（AGENTS.md / user_instructions /
+                // environment_context）会在 translate_input_item 里归入 system。
+                if item_type == Some("additional_tools") {
+                    if let Some(list) = item.get("tools").and_then(|v| v.as_array()) {
+                        declared_entries.extend(list.iter().cloned());
+                    }
                     continue;
                 }
 
@@ -207,39 +276,53 @@ fn responses_to_anthropic(req: ResponsesRequest) -> Result<MessagesRequest, Stri
         return Err("input must contain at least one user/assistant message".to_string());
     }
 
-    // Give the model exactly two tools: a harmless placeholder plus the native
-    // web_search. The placeholder guarantees tool_count > 1, which routes kiro-rs
-    // to the model-driven web_search agentic loop (the model chooses the query from
-    // full context) rather than the naive single-tool fast path (which would grab
-    // the first message's text — often codex scaffolding — as the query). We never
-    // forward codex's own tools here (see input loop above).
-    let tool_list: Vec<Tool> = vec![
-        Tool {
-            tool_type: None,
-            name: "noop".to_string(),
-            description: "Placeholder tool; never call this.".to_string(),
-            input_schema: Default::default(),
-            max_uses: None,
+    // 翻译 codex 声明的工具，并记录每个工具的声明类型（出方向要用）。
+    let mut tool_kinds: ToolKindMap = HashMap::new();
+    let mut tool_list = convert_responses_tools(&declared_entries, &mut tool_kinds, None);
+
+    if tool_list.is_empty() {
+        // 无 codex 工具（纯聊天流）：保持既有已验证行为——noop 占位 +
+        // 原生 web_search（占位保证 tool_count > 1，走 agentic loop 而非
+        // 单工具 fast-path）+ 严格提示。
+        tool_list = vec![
+            Tool {
+                tool_type: None,
+                name: "noop".to_string(),
+                description: "Placeholder tool; never call this.".to_string(),
+                input_schema: Default::default(),
+                max_uses: None,
+                cache_control: None,
+            },
+            native_web_search_tool(),
+        ];
+        system.push(SystemMessage {
+            text: NUDGE_STRICT.to_string(),
             cache_control: None,
-        },
-        Tool {
-            tool_type: Some("web_search_20250305".to_string()),
-            name: "web_search".to_string(),
-            description: String::new(),
-            input_schema: Default::default(),
-            max_uses: Some(5),
+        });
+    } else {
+        // 有 codex 工具：追加原生 web_search（除非客户端已声明同名工具，
+        // 避免名字冲突破坏 tool_name 还原逻辑），并使用软化提示。
+        // 注入后 has_web_search_among_tools 命中 → 走 agentic loop，
+        // loop 会把非 web_search 的 client 工具 tool_use 原样透传。
+        if !tool_list.iter().any(|t| t.name == "web_search") {
+            tool_list.push(native_web_search_tool());
+        }
+        system.push(SystemMessage {
+            text: NUDGE_SOFT.to_string(),
             cache_control: None,
-        },
-    ];
-    // Nudge the model to search for time-sensitive queries instead of stale training data.
-    system.push(SystemMessage {
-        text: "You have a web_search tool that returns live results. For anything \
-time-sensitive — current events, news, recent sports results, prices, releases, or facts \
-that may be newer than your training data — call web_search before answering, and never \
-claim something did not happen without searching first. Do not call any other tool."
-            .to_string(),
-        cache_control: None,
-    });
+        });
+    }
+
+    let custom_count = tool_kinds
+        .values()
+        .filter(|d| d.kind == DeclaredToolKind::Custom)
+        .count();
+    tracing::info!(
+        tool_count = tool_list.len(),
+        custom_count = custom_count,
+        "responses: forwarding tools to upstream"
+    );
+
     let tools = Some(tool_list);
     let tool_choice = req.tool_choice.as_ref().and_then(convert_tool_choice);
     let output_config = req
@@ -248,18 +331,187 @@ claim something did not happen without searching first. Do not call any other to
         .filter(|e| !e.trim().is_empty())
         .map(|effort| OutputConfig { effort });
 
-    Ok(MessagesRequest {
-        model: req.model,
-        max_tokens,
-        messages,
-        stream: false,
-        system: if system.is_empty() { None } else { Some(system) },
-        tools,
-        tool_choice,
-        thinking: None,
-        output_config,
-        metadata: None,
-    })
+    Ok((
+        MessagesRequest {
+            model: req.model,
+            max_tokens,
+            messages,
+            stream: false,
+            system: if system.is_empty() { None } else { Some(system) },
+            tools,
+            tool_choice,
+            thinking: None,
+            output_config,
+            metadata: None,
+        },
+        tool_kinds,
+    ))
+}
+
+/// 原生 web_search 工具（kiro-rs 内部代答，最多 5 轮）
+fn native_web_search_tool() -> Tool {
+    Tool {
+        tool_type: Some("web_search_20250305".to_string()),
+        name: "web_search".to_string(),
+        description: String::new(),
+        input_schema: Default::default(),
+        max_uses: Some(5),
+        cache_control: None,
+    }
+}
+
+/// 把 Responses `tools` 数组（顶层 + additional_tools item）翻译成
+/// Anthropic 工具，并登记声明信息。
+///
+/// - `function`：JSON schema 原样映射（converter 内部处理 >63 字符的
+///   名字缩短与还原，这里保持展平名）。
+/// - `custom`（自由文本，如 code-mode 的 exec）：包一层
+///   `{"input": <string>}` 单字段 schema，grammar/format 追加到
+///   description 里提示模型输入格式。
+/// - `namespace`：分组容器（如 collaboration 子代理工具），递归展开，
+///   模型侧展平为 `ns__name`，应答时还原 namespace 字段。
+/// - `web_search`：跳过（原生注入统一代答）。
+/// - 其它类型（local_shell / tool_search ...）：警告并跳过。
+fn convert_responses_tools(
+    entries: &[Value],
+    kinds: &mut ToolKindMap,
+    namespace: Option<&str>,
+) -> Vec<Tool> {
+    let mut out = Vec::new();
+    for entry in entries {
+        let ty = entry
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("function");
+        match ty {
+            "function" => {
+                // codex 用扁平结构 {type,name,description,strict,parameters}；
+                // 兼容 chat-completions 的嵌套结构 {type,function:{...}}。
+                let func = entry.get("function").unwrap_or(entry);
+                let name = func
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if name.is_empty() {
+                    continue;
+                }
+                let description = func
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let mut input_schema: BTreeMap<String, Value> = BTreeMap::new();
+                if let Some(Value::Object(params)) = func.get("parameters") {
+                    for (k, v) in params {
+                        input_schema.insert(k.clone(), v.clone());
+                    }
+                }
+                let flat = flat_tool_name(namespace, &name);
+                kinds.insert(
+                    flat.clone(),
+                    DeclaredTool {
+                        kind: DeclaredToolKind::Function,
+                        name,
+                        namespace: namespace.map(str::to_string),
+                    },
+                );
+                out.push(Tool {
+                    tool_type: None,
+                    name: flat,
+                    description,
+                    input_schema,
+                    max_uses: None,
+                    cache_control: None,
+                });
+            }
+            "custom" => {
+                let name = entry
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if name.is_empty() {
+                    continue;
+                }
+                let mut description = entry
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                // 自由文本工具的语法（如 apply_patch 的 lark grammar）
+                // 附到描述里，让模型知道 input 字符串该长什么样。
+                if let Some(format) = entry.get("format") {
+                    let syntax = format
+                        .get("syntax")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("grammar");
+                    if let Some(def) = format.get("definition").and_then(|v| v.as_str()) {
+                        description
+                            .push_str(&format!("\n\nInput format ({syntax} grammar):\n{def}"));
+                    }
+                }
+                let mut input_schema: BTreeMap<String, Value> = BTreeMap::new();
+                input_schema.insert("type".to_string(), json!("object"));
+                input_schema.insert(
+                    "properties".to_string(),
+                    json!({
+                        "input": {
+                            "type": "string",
+                            "description": "The complete raw tool input text. Do NOT wrap it in JSON or escape it.",
+                        }
+                    }),
+                );
+                input_schema.insert("required".to_string(), json!(["input"]));
+                input_schema.insert("additionalProperties".to_string(), json!(false));
+                let flat = flat_tool_name(namespace, &name);
+                kinds.insert(
+                    flat.clone(),
+                    DeclaredTool {
+                        kind: DeclaredToolKind::Custom,
+                        name,
+                        namespace: namespace.map(str::to_string),
+                    },
+                );
+                out.push(Tool {
+                    tool_type: None,
+                    name: flat,
+                    description,
+                    input_schema,
+                    max_uses: None,
+                    cache_control: None,
+                });
+            }
+            "namespace" => {
+                let ns = entry.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if ns.is_empty() || namespace.is_some() {
+                    // 嵌套 namespace 未见于协议，保守跳过
+                    tracing::warn!("responses: skipping empty/nested namespace tool group");
+                    continue;
+                }
+                if let Some(nested) = entry.get("tools").and_then(|v| v.as_array()) {
+                    let ns_desc = entry
+                        .get("description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let mut converted = convert_responses_tools(nested, kinds, Some(ns));
+                    // 分组描述附到每个成员前，保留上下文
+                    if !ns_desc.is_empty() {
+                        for t in &mut converted {
+                            t.description = format!("[{ns}] {ns_desc}\n{}", t.description);
+                        }
+                    }
+                    out.extend(converted);
+                }
+            }
+            // 托管 web_search 声明：原生注入统一代答，无需单独转发。
+            "web_search" => {}
+            other => {
+                tracing::warn!(tool_type = %other, "responses: skipping unsupported tool type");
+            }
+        }
+    }
+    out
 }
 
 /// 翻译单个 Responses input item 到 Anthropic 结构
@@ -271,7 +523,8 @@ fn translate_input_item(
     let ty = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
     match ty {
-        // 助手发起的工具调用
+        // 助手发起的工具调用（function 类型）。namespace 工具还原为展平名，
+        // 与进方向声明及模型产出保持一致。
         "function_call" => {
             let call_id = item
                 .get("call_id")
@@ -284,6 +537,7 @@ fn translate_input_item(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
+            let namespace = item.get("namespace").and_then(|v| v.as_str());
             let args_str = item
                 .get("arguments")
                 .and_then(|v| v.as_str())
@@ -292,13 +546,38 @@ fn translate_input_item(
             let block = json!({
                 "type": "tool_use",
                 "id": call_id,
-                "name": name,
+                "name": flat_tool_name(namespace, &name),
                 "input": input,
             });
             push_merged(merged, "assistant", vec![block]);
         }
-        // 工具执行结果 → Anthropic 里属于 user 轮
-        "function_call_output" => {
+        // 助手发起的自由文本工具调用（custom 类型）：回放时按进方向的
+        // 包装 schema 复原为 {"input": <string>}，保证与模型当初产出的
+        // tool_use 逐字一致（Kiro/Bedrock 校验 tool_use/tool_result 配对）。
+        "custom_tool_call" => {
+            let call_id = item
+                .get("call_id")
+                .or_else(|| item.get("id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let name = item
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let namespace = item.get("namespace").and_then(|v| v.as_str());
+            let input_str = item.get("input").and_then(|v| v.as_str()).unwrap_or("");
+            let block = json!({
+                "type": "tool_use",
+                "id": call_id,
+                "name": flat_tool_name(namespace, &name),
+                "input": { "input": input_str },
+            });
+            push_merged(merged, "assistant", vec![block]);
+        }
+        // 工具执行结果 → Anthropic 里属于 user 轮（function 与 custom 同构）
+        "function_call_output" | "custom_tool_call_output" => {
             let call_id = item
                 .get("call_id")
                 .and_then(|v| v.as_str())
@@ -312,8 +591,8 @@ fn translate_input_item(
             });
             push_merged(merged, "user", vec![block]);
         }
-        // 推理项对 Anthropic 请求无意义，忽略
-        "reasoning" => {}
+        // 推理项 / 已完成的搜索展示项 / 压缩项：对 Anthropic 请求无意义，忽略
+        "reasoning" | "web_search_call" | "compaction" => {}
         // "message" 或未标注 type 但带 role 的项
         _ => {
             let role = item.get("role").and_then(|v| v.as_str());
@@ -439,16 +718,47 @@ fn new_msg_id() -> String {
 fn new_fc_id() -> String {
     format!("fc_{}", Uuid::new_v4().to_string().replace('-', ""))
 }
+fn new_ctc_id() -> String {
+    format!("ctc_{}", Uuid::new_v4().to_string().replace('-', ""))
+}
+fn new_rs_id() -> String {
+    format!("rs_{}", Uuid::new_v4().to_string().replace('-', ""))
+}
+
+/// 从自由文本工具的 arguments JSON 里解出原始 input 字符串。
+///
+/// 回退链：`{"input": <string>}` → 单字段字符串对象 → 原样返回 arguments。
+/// 模型偶尔不守 schema 时也能兜住（codex 端还有自己的解析重试兜底）。
+fn custom_input_text(arguments_json: &str) -> String {
+    let parsed: Value = match serde_json::from_str(arguments_json) {
+        Ok(v) => v,
+        Err(_) => return arguments_json.to_string(),
+    };
+    match parsed {
+        Value::Object(map) => {
+            if let Some(Value::String(s)) = map.get("input") {
+                return s.clone();
+            }
+            if map.len() == 1 {
+                if let Some(Value::String(s)) = map.values().next() {
+                    return s.clone();
+                }
+            }
+            arguments_json.to_string()
+        }
+        Value::String(s) => s,
+        _ => arguments_json.to_string(),
+    }
+}
 
 /// 从 ParsedResponse 计算 (status, output items, usage)
 struct ResponsesView {
     status: String,
     output: Vec<Value>,
-    msg_id: Option<String>,
     usage: Value,
 }
 
-fn build_view(p: &ParsedResponse) -> ResponsesView {
+fn build_view(p: &ParsedResponse, kinds: &ToolKindMap) -> ResponsesView {
     let status = if p.finish_reason == "length" {
         "incomplete".to_string()
     } else {
@@ -456,13 +766,30 @@ fn build_view(p: &ParsedResponse) -> ResponsesView {
     };
 
     let mut output = Vec::new();
-    let mut msg_id = None;
+
+    // 推理摘要放最前（思考先于可见输出发生）
+    if !p.thinking.is_empty() {
+        output.push(json!({
+            "type": "reasoning",
+            "id": new_rs_id(),
+            "summary": [{ "type": "summary_text", "text": p.thinking }],
+        }));
+    }
+
+    // 内部代答的 web_search 以 web_search_call 展示（codex 渲染 "Searched the web"）
+    for (id, query) in &p.web_searches {
+        output.push(json!({
+            "type": "web_search_call",
+            "id": id,
+            "status": "completed",
+            "action": { "type": "search", "query": query },
+        }));
+    }
 
     if !p.text.is_empty() {
-        let id = new_msg_id();
         output.push(json!({
             "type": "message",
-            "id": id,
+            "id": new_msg_id(),
             "status": "completed",
             "role": "assistant",
             "content": [{
@@ -471,7 +798,6 @@ fn build_view(p: &ParsedResponse) -> ResponsesView {
                 "annotations": [],
             }],
         }));
-        msg_id = Some(id);
     }
 
     for tc in &p.tool_calls {
@@ -481,7 +807,7 @@ fn build_view(p: &ParsedResponse) -> ResponsesView {
             .unwrap_or("")
             .to_string();
         let func = tc.get("function");
-        let name = func
+        let flat_name = func
             .and_then(|f| f.get("name"))
             .and_then(|v| v.as_str())
             .unwrap_or("")
@@ -491,14 +817,45 @@ fn build_view(p: &ParsedResponse) -> ResponsesView {
             .and_then(|v| v.as_str())
             .unwrap_or("{}")
             .to_string();
-        output.push(json!({
-            "type": "function_call",
-            "id": new_fc_id(),
-            "call_id": call_id,
-            "name": name,
-            "arguments": arguments,
-            "status": "completed",
-        }));
+        let decl = kinds.get(flat_name.as_str());
+        // 展平名还原：namespace 工具应答时用原名 + namespace 字段
+        let (name, namespace) = match decl {
+            Some(d) => (d.name.clone(), d.namespace.clone()),
+            None => (flat_name.clone(), None),
+        };
+        match decl.map(|d| d.kind) {
+            // custom 声明 → custom_tool_call（原始字符串 input），
+            // 否则 codex 校验 payload 种类失败（"incompatible payload"）。
+            Some(DeclaredToolKind::Custom) => {
+                let mut item = json!({
+                    "type": "custom_tool_call",
+                    "id": new_ctc_id(),
+                    "call_id": call_id,
+                    "name": name,
+                    "input": custom_input_text(&arguments),
+                    "status": "completed",
+                });
+                if let Some(ns) = namespace {
+                    item["namespace"] = json!(ns);
+                }
+                output.push(item);
+            }
+            // function 声明或未声明（模型幻觉出的名字走最兼容的 function_call）
+            _ => {
+                let mut item = json!({
+                    "type": "function_call",
+                    "id": new_fc_id(),
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": arguments,
+                    "status": "completed",
+                });
+                if let Some(ns) = namespace {
+                    item["namespace"] = json!(ns);
+                }
+                output.push(item);
+            }
+        }
     }
 
     let usage = json!({
@@ -512,7 +869,6 @@ fn build_view(p: &ParsedResponse) -> ResponsesView {
     ResponsesView {
         status,
         output,
-        msg_id,
         usage,
     }
 }
@@ -536,15 +892,19 @@ fn build_response_object_from(p: &ParsedResponse, view: &ResponsesView, id: &str
     obj
 }
 
-fn build_responses_object(p: &ParsedResponse) -> Value {
-    let view = build_view(p);
+fn build_responses_object(p: &ParsedResponse, kinds: &ToolKindMap) -> Value {
+    let view = build_view(p, kinds);
     let id = new_resp_id();
     build_response_object_from(p, &view, &id)
 }
 
 /// 把完整结果合成为 Responses SSE 事件序列
-fn build_responses_sse(p: &ParsedResponse) -> String {
-    let view = build_view(p);
+///
+/// codex 只从 `response.output_item.done` 构建回合内容（`.added` 用于进度
+/// 展示，`response.completed` 只取 id/usage），所以每个 item 只要保证
+/// added/done 成对且 done 携带完整内容即可。delta 事件是锦上添花。
+fn build_responses_sse(p: &ParsedResponse, kinds: &ToolKindMap) -> String {
+    let view = build_view(p, kinds);
     let resp_id = new_resp_id();
     let mut out = String::new();
     let mut seq: i64 = 0;
@@ -580,124 +940,180 @@ fn build_responses_sse(p: &ParsedResponse) -> String {
         &mut seq,
     );
 
-    let mut output_index: i64 = 0;
-
-    // 文本消息项
-    if !p.text.is_empty() {
-        let msg_id = view.msg_id.clone().unwrap_or_else(new_msg_id);
-        let mid = msg_id.as_str();
-        let msg_added = json!({
-            "type": "message",
-            "id": mid,
-            "status": "in_progress",
-            "role": "assistant",
-            "content": [],
-        });
-        emit(
-            "response.output_item.added",
-            json!({ "output_index": output_index, "item": msg_added }),
-            &mut seq,
-        );
-        emit(
-            "response.content_part.added",
-            json!({
-                "item_id": mid,
-                "output_index": output_index,
-                "content_index": 0,
-                "part": { "type": "output_text", "text": "", "annotations": [] },
-            }),
-            &mut seq,
-        );
-        emit(
-            "response.output_text.delta",
-            json!({
-                "item_id": mid,
-                "output_index": output_index,
-                "content_index": 0,
-                "delta": p.text.as_str(),
-            }),
-            &mut seq,
-        );
-        emit(
-            "response.output_text.done",
-            json!({
-                "item_id": mid,
-                "output_index": output_index,
-                "content_index": 0,
-                "text": p.text.as_str(),
-            }),
-            &mut seq,
-        );
-        emit(
-            "response.content_part.done",
-            json!({
-                "item_id": mid,
-                "output_index": output_index,
-                "content_index": 0,
-                "part": { "type": "output_text", "text": p.text.as_str(), "annotations": [] },
-            }),
-            &mut seq,
-        );
-        // 完整 message item（取 view.output 里第一个）
-        let done_item = view
-            .output
-            .first()
-            .cloned()
-            .unwrap_or_else(|| json!({"type":"message","id":mid,"role":"assistant"}));
-        emit(
-            "response.output_item.done",
-            json!({ "output_index": output_index, "item": done_item }),
-            &mut seq,
-        );
-        output_index += 1;
-    }
-
-    // 工具调用项
-    let fc_start = if p.text.is_empty() { 0 } else { 1 };
-    for fc_item in view.output.iter().skip(fc_start) {
-        let item_id = fc_item
+    for (idx, item) in view.output.iter().enumerate() {
+        let output_index = idx as i64;
+        let item_ty = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let item_id = item
             .get("id")
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let arguments = fc_item
-            .get("arguments")
-            .and_then(|v| v.as_str())
-            .unwrap_or("{}")
-            .to_string();
+        let mid = item_id.as_str();
 
-        let mut added = fc_item.clone();
-        added["status"] = json!("in_progress");
-        added["arguments"] = json!("");
-        emit(
-            "response.output_item.added",
-            json!({ "output_index": output_index, "item": added }),
-            &mut seq,
-        );
-        emit(
-            "response.function_call_arguments.delta",
-            json!({
-                "item_id": item_id.as_str(),
-                "output_index": output_index,
-                "delta": arguments.as_str(),
-            }),
-            &mut seq,
-        );
-        emit(
-            "response.function_call_arguments.done",
-            json!({
-                "item_id": item_id.as_str(),
-                "output_index": output_index,
-                "arguments": arguments.as_str(),
-            }),
-            &mut seq,
-        );
+        match item_ty {
+            "message" => {
+                let text = item
+                    .pointer("/content/0/text")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                emit(
+                    "response.output_item.added",
+                    json!({ "output_index": output_index, "item": {
+                        "type": "message", "id": mid, "status": "in_progress",
+                        "role": "assistant", "content": [],
+                    }}),
+                    &mut seq,
+                );
+                emit(
+                    "response.content_part.added",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "content_index": 0,
+                        "part": { "type": "output_text", "text": "", "annotations": [] },
+                    }),
+                    &mut seq,
+                );
+                emit(
+                    "response.output_text.delta",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "content_index": 0,
+                        "delta": text,
+                    }),
+                    &mut seq,
+                );
+                emit(
+                    "response.output_text.done",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "content_index": 0,
+                        "text": text,
+                    }),
+                    &mut seq,
+                );
+                emit(
+                    "response.content_part.done",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "content_index": 0,
+                        "part": { "type": "output_text", "text": text, "annotations": [] },
+                    }),
+                    &mut seq,
+                );
+            }
+            "function_call" => {
+                let arguments = item
+                    .get("arguments")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("{}")
+                    .to_string();
+                let mut added = item.clone();
+                added["status"] = json!("in_progress");
+                added["arguments"] = json!("");
+                emit(
+                    "response.output_item.added",
+                    json!({ "output_index": output_index, "item": added }),
+                    &mut seq,
+                );
+                emit(
+                    "response.function_call_arguments.delta",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "delta": arguments.as_str(),
+                    }),
+                    &mut seq,
+                );
+                emit(
+                    "response.function_call_arguments.done",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "arguments": arguments.as_str(),
+                    }),
+                    &mut seq,
+                );
+            }
+            "custom_tool_call" => {
+                // added 必须带完整 input（codex 的 CustomToolCall 反序列化
+                // 要求 input 字段存在；缓冲式合成没有渐进展示的意义）。
+                let input = item
+                    .get("input")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let mut added = item.clone();
+                added["status"] = json!("in_progress");
+                emit(
+                    "response.output_item.added",
+                    json!({ "output_index": output_index, "item": added }),
+                    &mut seq,
+                );
+                emit(
+                    "response.custom_tool_call_input.delta",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "delta": input.as_str(),
+                    }),
+                    &mut seq,
+                );
+            }
+            "reasoning" => {
+                let text = item
+                    .pointer("/summary/0/text")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                emit(
+                    "response.output_item.added",
+                    json!({ "output_index": output_index, "item": {
+                        "type": "reasoning", "id": mid, "summary": [],
+                    }}),
+                    &mut seq,
+                );
+                emit(
+                    "response.reasoning_summary_text.delta",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "summary_index": 0,
+                        "delta": text,
+                    }),
+                    &mut seq,
+                );
+                emit(
+                    "response.reasoning_summary_text.done",
+                    json!({
+                        "item_id": mid,
+                        "output_index": output_index,
+                        "summary_index": 0,
+                        "text": text,
+                    }),
+                    &mut seq,
+                );
+            }
+            _ => {
+                // web_search_call 等：added(in_progress) + done(完整) 即可
+                let mut added = item.clone();
+                added["status"] = json!("in_progress");
+                emit(
+                    "response.output_item.added",
+                    json!({ "output_index": output_index, "item": added }),
+                    &mut seq,
+                );
+            }
+        }
+
+        // 统一收尾：done 携带完整 item
         emit(
             "response.output_item.done",
-            json!({ "output_index": output_index, "item": fc_item.clone() }),
+            json!({ "output_index": output_index, "item": item.clone() }),
             &mut seq,
         );
-        output_index += 1;
     }
 
     // response.completed（完整对象含 usage）
@@ -720,4 +1136,524 @@ fn responses_error(status: StatusCode, err_type: &str, message: &str) -> Respons
         }
     });
     (status, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- 测试辅助 ----
+
+    fn req_with(tools: Value, input: Value) -> ResponsesRequest {
+        serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "input": input,
+            "tools": tools,
+        }))
+        .unwrap()
+    }
+
+    fn simple_input() -> Value {
+        json!([{ "type": "message", "role": "user", "content": "hi" }])
+    }
+
+    fn parsed_with_tool_calls(tool_calls: Vec<Value>) -> ParsedResponse {
+        ParsedResponse {
+            model: "gpt-5.6-sol".to_string(),
+            text: String::new(),
+            tool_calls,
+            finish_reason: "tool_calls".to_string(),
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            thinking: String::new(),
+            web_searches: Vec::new(),
+        }
+    }
+
+    fn kinds_of(pairs: &[(&str, DeclaredToolKind)]) -> ToolKindMap {
+        pairs
+            .iter()
+            .map(|(n, k)| {
+                (
+                    n.to_string(),
+                    DeclaredTool {
+                        kind: *k,
+                        name: n.to_string(),
+                        namespace: None,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn system_texts(req: &MessagesRequest) -> Vec<String> {
+        req.system
+            .as_ref()
+            .map(|s| s.iter().map(|m| m.text.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    // ---- 请求方向：工具声明转换 ----
+
+    #[test]
+    fn additional_tools_item_declares_tools() {
+        // codex 0.144：顶层 tools 为空，声明在 input 的 additional_tools item 里
+        let req = req_with(
+            json!([]),
+            json!([
+                { "type": "additional_tools", "role": "developer", "tools": [
+                    { "type": "custom", "name": "exec", "description": "Run JS" },
+                    { "type": "function", "name": "wait", "parameters": { "type": "object" } },
+                ]},
+                { "type": "message", "role": "user", "content": "hi" },
+            ]),
+        );
+        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        assert_eq!(kinds.get("exec").map(|d| d.kind), Some(DeclaredToolKind::Custom));
+        assert_eq!(kinds.get("wait").map(|d| d.kind), Some(DeclaredToolKind::Function));
+        let tools = anth.tools.as_ref().unwrap();
+        assert!(tools.iter().any(|t| t.name == "exec"));
+        assert!(tools.iter().any(|t| t.name == "wait"));
+        assert!(tools.iter().any(|t| t.name == "web_search"));
+        assert!(!tools.iter().any(|t| t.name == "noop"));
+        // additional_tools item 本身不进消息
+        assert_eq!(anth.messages.len(), 1);
+    }
+
+    #[test]
+    fn namespace_tools_flattened_and_restored() {
+        let req = req_with(
+            json!([]),
+            json!([
+                { "type": "additional_tools", "role": "developer", "tools": [
+                    { "type": "namespace", "name": "collaboration", "description": "Sub-agents.",
+                      "tools": [
+                          { "type": "function", "name": "spawn_agent", "parameters": { "type": "object" } },
+                      ]},
+                ]},
+                { "type": "message", "role": "user", "content": "hi" },
+            ]),
+        );
+        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        let decl = kinds.get("collaboration__spawn_agent").expect("flattened name");
+        assert_eq!(decl.kind, DeclaredToolKind::Function);
+        assert_eq!(decl.name, "spawn_agent");
+        assert_eq!(decl.namespace.as_deref(), Some("collaboration"));
+        let tools = anth.tools.as_ref().unwrap();
+        let t = tools
+            .iter()
+            .find(|t| t.name == "collaboration__spawn_agent")
+            .expect("flattened tool declared to the model");
+        assert!(t.description.contains("Sub-agents."));
+
+        // 应答方向：展平名 → 原名 + namespace 字段
+        let p = parsed_with_tool_calls(vec![json!({
+            "id": "toolu_9", "type": "function",
+            "function": { "name": "collaboration__spawn_agent", "arguments": "{}" },
+        })]);
+        let view = build_view(&p, &kinds);
+        let fc = view
+            .output
+            .iter()
+            .find(|i| i["type"] == "function_call")
+            .unwrap();
+        assert_eq!(fc["name"], "spawn_agent");
+        assert_eq!(fc["namespace"], "collaboration");
+        assert_eq!(fc["call_id"], "toolu_9");
+    }
+
+    #[test]
+    fn namespaced_function_call_replay_uses_flat_name() {
+        let req = req_with(
+            json!([]),
+            json!([
+                { "type": "message", "role": "user", "content": "go" },
+                { "type": "function_call", "call_id": "c9", "name": "spawn_agent",
+                  "namespace": "collaboration", "arguments": "{\"task\":\"x\"}" },
+                { "type": "function_call_output", "call_id": "c9", "output": "spawned" },
+            ]),
+        );
+        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let tu = &anth.messages[1].content.as_array().unwrap()[0];
+        assert_eq!(tu["type"], "tool_use");
+        assert_eq!(
+            tu["name"], "collaboration__spawn_agent",
+            "replayed namespaced call must use the flat name the model was declared"
+        );
+    }
+
+    #[test]
+    fn custom_tool_declared_maps_to_wrapper_and_kind() {
+        let req = req_with(
+            json!([{
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "Apply a patch.",
+                "format": { "type": "grammar", "syntax": "lark", "definition": "start: PATCH" },
+            }]),
+            simple_input(),
+        );
+        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        assert_eq!(
+            kinds.get("apply_patch").map(|d| d.kind),
+            Some(DeclaredToolKind::Custom)
+        );
+
+        let tools = anth.tools.unwrap();
+        let ap = tools.iter().find(|t| t.name == "apply_patch").unwrap();
+        // 包装 schema：单个 input 字符串字段
+        let props = ap.input_schema.get("properties").unwrap();
+        assert!(props.get("input").is_some(), "wrapper input field required");
+        assert_eq!(ap.input_schema.get("required").unwrap(), &json!(["input"]));
+        // grammar 附加到描述
+        assert!(ap.description.contains("Apply a patch."));
+        assert!(ap.description.contains("lark grammar"));
+        assert!(ap.description.contains("start: PATCH"));
+        // 原生 web_search 注入，noop 不再存在
+        assert!(tools.iter().any(|t| t.name == "web_search"
+            && t.tool_type.as_deref() == Some("web_search_20250305")));
+        assert!(!tools.iter().any(|t| t.name == "noop"));
+    }
+
+    #[test]
+    fn function_tool_maps_schema_verbatim() {
+        let req = req_with(
+            json!([{
+                "type": "function",
+                "name": "shell",
+                "description": "Run a command.",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "command": { "type": "array", "items": { "type": "string" } } },
+                    "required": ["command"],
+                },
+            }]),
+            simple_input(),
+        );
+        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        assert_eq!(
+            kinds.get("shell").map(|d| d.kind),
+            Some(DeclaredToolKind::Function)
+        );
+        let tools = anth.tools.unwrap();
+        let shell = tools.iter().find(|t| t.name == "shell").unwrap();
+        assert_eq!(shell.input_schema.get("type").unwrap(), &json!("object"));
+        assert!(
+            shell
+                .input_schema
+                .get("properties")
+                .unwrap()
+                .get("command")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn noop_fallback_when_no_codex_tools() {
+        let req = req_with(json!([]), simple_input());
+        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        assert!(kinds.is_empty());
+        let tools = anth.tools.as_ref().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["noop", "web_search"]);
+        // 严格提示保留
+        let sys = system_texts(&anth);
+        assert!(
+            sys.iter()
+                .any(|t| t.contains("Do not call any other tool")),
+            "strict nudge must be kept for tool-less flows"
+        );
+    }
+
+    #[test]
+    fn nudge_softened_when_codex_tools_present() {
+        let req = req_with(
+            json!([{ "type": "function", "name": "shell", "parameters": {} }]),
+            simple_input(),
+        );
+        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let sys = system_texts(&anth);
+        assert!(
+            !sys.iter().any(|t| t.contains("Do not call any other tool")),
+            "strict nudge must be removed when codex tools are forwarded"
+        );
+        assert!(
+            sys.iter()
+                .any(|t| t.contains("Use your other tools normally")),
+            "soft nudge must be present"
+        );
+    }
+
+    #[test]
+    fn web_search_name_collision_skips_native_injection() {
+        let req = req_with(
+            json!([{ "type": "function", "name": "web_search", "parameters": {} }]),
+            simple_input(),
+        );
+        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        assert_eq!(
+            kinds.get("web_search").map(|d| d.kind),
+            Some(DeclaredToolKind::Function)
+        );
+        let tools = anth.tools.unwrap();
+        let ws: Vec<&Tool> = tools.iter().filter(|t| t.name == "web_search").collect();
+        assert_eq!(ws.len(), 1, "exactly one web_search tool");
+        assert!(
+            ws[0].tool_type.is_none(),
+            "the client's function tool wins; no native server tool injected"
+        );
+    }
+
+    #[test]
+    fn hosted_web_search_declaration_covered_by_native() {
+        let req = req_with(
+            json!([
+                { "type": "web_search" },
+                { "type": "function", "name": "shell", "parameters": {} },
+            ]),
+            simple_input(),
+        );
+        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let tools = anth.tools.unwrap();
+        let ws: Vec<&Tool> = tools.iter().filter(|t| t.name == "web_search").collect();
+        assert_eq!(ws.len(), 1);
+        assert_eq!(ws[0].tool_type.as_deref(), Some("web_search_20250305"));
+    }
+
+    // ---- 请求方向：input item 回放 ----
+
+    #[test]
+    fn custom_tool_call_round_trip_replay() {
+        let req = req_with(
+            json!([{ "type": "custom", "name": "apply_patch" }]),
+            json!([
+                { "type": "message", "role": "user", "content": "patch it" },
+                { "type": "custom_tool_call", "call_id": "c1", "name": "apply_patch",
+                  "input": "*** Begin Patch\nRAW\n*** End Patch" },
+                { "type": "custom_tool_call_output", "call_id": "c1", "output": "Done!" },
+            ]),
+        );
+        let (anth, _) = responses_to_anthropic(req).unwrap();
+        assert_eq!(anth.messages.len(), 3);
+
+        let assistant = &anth.messages[1];
+        assert_eq!(assistant.role, "assistant");
+        let tu = &assistant.content.as_array().unwrap()[0];
+        assert_eq!(tu["type"], "tool_use");
+        assert_eq!(tu["id"], "c1");
+        assert_eq!(tu["name"], "apply_patch");
+        // 与进方向包装 schema 逐字一致
+        assert_eq!(tu["input"]["input"], "*** Begin Patch\nRAW\n*** End Patch");
+
+        let user = &anth.messages[2];
+        assert_eq!(user.role, "user");
+        let tr = &user.content.as_array().unwrap()[0];
+        assert_eq!(tr["type"], "tool_result");
+        assert_eq!(tr["tool_use_id"], "c1");
+        assert_eq!(tr["content"], "Done!");
+    }
+
+    #[test]
+    fn function_call_output_array_shape_stringified() {
+        let req = req_with(
+            json!([{ "type": "function", "name": "shell", "parameters": {} }]),
+            json!([
+                { "type": "message", "role": "user", "content": "run" },
+                { "type": "function_call", "call_id": "f1", "name": "shell",
+                  "arguments": "{\"command\":[\"ls\"]}" },
+                { "type": "function_call_output", "call_id": "f1",
+                  "output": [
+                      { "type": "output_text", "text": "line1" },
+                      { "type": "output_text", "text": "line2" },
+                  ] },
+            ]),
+        );
+        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let tr = &anth.messages[2].content.as_array().unwrap()[0];
+        assert_eq!(tr["content"], "line1\nline2");
+    }
+
+    #[test]
+    fn developer_items_become_system() {
+        let req = req_with(
+            json!([]),
+            json!([
+                { "type": "message", "role": "developer",
+                  "content": [{ "type": "input_text", "text": "AGENTS.md rules here" }] },
+                { "type": "message", "role": "user", "content": "hi" },
+            ]),
+        );
+        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let sys = system_texts(&anth);
+        assert!(
+            sys.iter().any(|t| t.contains("AGENTS.md rules here")),
+            "developer items must reach the model as system text. sys={sys:?}"
+        );
+        // 且不出现在 messages 里
+        assert_eq!(anth.messages.len(), 1);
+        assert_eq!(anth.messages[0].role, "user");
+    }
+
+    #[test]
+    fn reasoning_and_presentation_items_skipped_on_replay() {
+        let req = req_with(
+            json!([]),
+            json!([
+                { "type": "reasoning", "summary": [{ "type": "summary_text", "text": "hmm" }] },
+                { "type": "web_search_call", "status": "completed" },
+                { "type": "compaction", "encrypted_content": "xxx" },
+                { "type": "message", "role": "user", "content": "hi" },
+            ]),
+        );
+        let (anth, _) = responses_to_anthropic(req).unwrap();
+        assert_eq!(anth.messages.len(), 1);
+        assert_eq!(anth.messages[0].role, "user");
+    }
+
+    // ---- custom input 解包回退链 ----
+
+    #[test]
+    fn custom_input_unwrap_fallbacks() {
+        // 标准：{"input": "..."}
+        assert_eq!(custom_input_text(r#"{"input":"*** Begin Patch"}"#), "*** Begin Patch");
+        // 单字段字符串对象
+        assert_eq!(custom_input_text(r#"{"cmd":"echo hi"}"#), "echo hi");
+        // 多字段对象 → 原样
+        assert_eq!(
+            custom_input_text(r#"{"a":1,"b":"c"}"#),
+            r#"{"a":1,"b":"c"}"#
+        );
+        // 非 JSON → 原样
+        assert_eq!(custom_input_text("raw text"), "raw text");
+        // JSON 字符串 → 解出
+        assert_eq!(custom_input_text(r#""just a string""#), "just a string");
+    }
+
+    // ---- 响应方向：build_view ----
+
+    #[test]
+    fn build_view_emits_custom_tool_call_for_custom_kind() {
+        let kinds = kinds_of(&[("apply_patch", DeclaredToolKind::Custom)]);
+        let p = parsed_with_tool_calls(vec![json!({
+            "id": "toolu_1",
+            "type": "function",
+            "function": { "name": "apply_patch", "arguments": "{\"input\":\"*** Begin Patch\"}" },
+        })]);
+        let view = build_view(&p, &kinds);
+        let item = view
+            .output
+            .iter()
+            .find(|i| i["type"] == "custom_tool_call")
+            .expect("custom_tool_call item must be emitted");
+        assert_eq!(item["call_id"], "toolu_1");
+        assert_eq!(item["name"], "apply_patch");
+        assert_eq!(item["input"], "*** Begin Patch");
+        assert!(
+            !view.output.iter().any(|i| i["type"] == "function_call"),
+            "must not also emit a function_call for the same tool"
+        );
+    }
+
+    #[test]
+    fn build_view_emits_function_call_for_function_and_unknown_kinds() {
+        let kinds = kinds_of(&[("shell", DeclaredToolKind::Function)]);
+        let p = parsed_with_tool_calls(vec![
+            json!({
+                "id": "toolu_1", "type": "function",
+                "function": { "name": "shell", "arguments": "{\"command\":[\"ls\"]}" },
+            }),
+            json!({
+                "id": "toolu_2", "type": "function",
+                "function": { "name": "hallucinated_tool", "arguments": "{}" },
+            }),
+        ]);
+        let view = build_view(&p, &kinds);
+        let fcs: Vec<&Value> = view
+            .output
+            .iter()
+            .filter(|i| i["type"] == "function_call")
+            .collect();
+        assert_eq!(fcs.len(), 2, "function + unknown both map to function_call");
+        assert_eq!(fcs[0]["name"], "shell");
+        assert_eq!(fcs[0]["arguments"], "{\"command\":[\"ls\"]}");
+        assert_eq!(fcs[0]["call_id"], "toolu_1");
+    }
+
+    #[test]
+    fn build_view_orders_reasoning_search_message_tools() {
+        let kinds = kinds_of(&[("shell", DeclaredToolKind::Function)]);
+        let mut p = parsed_with_tool_calls(vec![json!({
+            "id": "toolu_1", "type": "function",
+            "function": { "name": "shell", "arguments": "{}" },
+        })]);
+        p.text = "answer".to_string();
+        p.thinking = "let me think".to_string();
+        p.web_searches = vec![("srvtoolu_1".to_string(), "rust news".to_string())];
+        let view = build_view(&p, &kinds);
+        let types: Vec<&str> = view
+            .output
+            .iter()
+            .map(|i| i["type"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            types,
+            vec!["reasoning", "web_search_call", "message", "function_call"]
+        );
+        assert_eq!(
+            view.output[0]["summary"][0]["text"], "let me think",
+            "reasoning summary carries the thinking text"
+        );
+        assert_eq!(view.output[1]["action"]["query"], "rust news");
+    }
+
+    // ---- 响应方向：SSE ----
+
+    #[test]
+    fn sse_contains_custom_item_events_with_full_input() {
+        let kinds = kinds_of(&[("apply_patch", DeclaredToolKind::Custom)]);
+        let p = parsed_with_tool_calls(vec![json!({
+            "id": "toolu_1", "type": "function",
+            "function": { "name": "apply_patch", "arguments": "{\"input\":\"PATCH BODY\"}" },
+        })]);
+        let sse = build_responses_sse(&p, &kinds);
+        assert!(sse.contains("event: response.output_item.added"));
+        assert!(sse.contains("event: response.output_item.done"));
+        assert!(sse.contains("event: response.custom_tool_call_input.delta"));
+        assert!(sse.contains("\"custom_tool_call\""));
+        assert!(sse.contains("PATCH BODY"));
+        assert!(sse.contains("event: response.completed"));
+        // added 也必须带完整 input（codex 反序列化要求字段存在）
+        let added_line = sse
+            .lines()
+            .find(|l| l.starts_with("data: ") && l.contains("custom_tool_call") && l.contains("in_progress"))
+            .expect("added event data line");
+        assert!(added_line.contains("PATCH BODY"), "added item carries full input");
+    }
+
+    #[test]
+    fn sse_function_call_flow_unchanged() {
+        let kinds = kinds_of(&[("shell", DeclaredToolKind::Function)]);
+        let p = parsed_with_tool_calls(vec![json!({
+            "id": "toolu_1", "type": "function",
+            "function": { "name": "shell", "arguments": "{\"command\":[\"ls\"]}" },
+        })]);
+        let sse = build_responses_sse(&p, &kinds);
+        assert!(sse.contains("event: response.function_call_arguments.delta"));
+        assert!(sse.contains("event: response.function_call_arguments.done"));
+        assert!(sse.contains("\"function_call\""));
+        assert!(sse.contains("event: response.completed"));
+    }
+
+    #[test]
+    fn sse_reasoning_summary_events() {
+        let kinds = ToolKindMap::new();
+        let mut p = parsed_with_tool_calls(vec![]);
+        p.text = "hi".to_string();
+        p.thinking = "deep thought".to_string();
+        p.finish_reason = "stop".to_string();
+        let sse = build_responses_sse(&p, &kinds);
+        assert!(sse.contains("event: response.reasoning_summary_text.delta"));
+        assert!(sse.contains("deep thought"));
+        assert!(sse.contains("\"reasoning\""));
+    }
 }

--- a/src/anthropic/websearch.rs
+++ b/src/anthropic/websearch.rs
@@ -548,7 +548,7 @@ fn render_websearch_response(
         let content = build_websearch_content(&query, &tool_use_id, &search_results);
         let summary = generate_search_summary(&query, &search_results);
         let output_tokens = (summary.len() as i32 + 3) / 4;
-        super::websearch_loop::render_json(&model, content, "end_turn", input_tokens, output_tokens)
+        super::websearch_loop::render_json(&model, content, "end_turn", input_tokens, output_tokens, "")
     }
 }
 

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -36,6 +36,19 @@ use super::websearch::{self, WebSearchResults};
 /// Maximum number of search rounds, to prevent an infinite loop if the upstream keeps asking to search
 const MAX_WEB_SEARCH_ROUNDS: usize = 5;
 
+/// A valid assistant turn after a tool result must contain either visible text or
+/// another client tool call. Kiro occasionally closes a successful upstream stream
+/// without either, which used to be serialized as `end_turn` and made Codex mark an
+/// unfinished task complete. Retry once before surfacing an upstream error.
+const MAX_EMPTY_TOOL_RESULT_RETRIES: usize = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmptyToolResultDisposition {
+    Accept,
+    Retry,
+    Fail,
+}
+
 /// Result of buffer-decoding one round of the upstream response
 struct RoundOutcome {
     /// Accumulated assistant text
@@ -83,6 +96,42 @@ fn should_search_round(round_idx: usize, tool_uses: &[CompletedToolUse]) -> bool
     let only_web_search =
         !tool_uses.is_empty() && tool_uses.iter().all(|t| t.name == "web_search");
     only_web_search && round_idx < MAX_WEB_SEARCH_ROUNDS
+}
+
+/// Whether the request is the continuation immediately following a tool result.
+fn last_message_has_tool_result(payload: &MessagesRequest) -> bool {
+    let Some(last) = payload.messages.last() else {
+        return false;
+    };
+    if last.role != "user" {
+        return false;
+    }
+    last.content.as_array().is_some_and(|blocks| {
+        blocks
+            .iter()
+            .any(|block| block.get("type").and_then(Value::as_str) == Some("tool_result"))
+    })
+}
+
+/// Decide how to handle a successful upstream round after tool output. Reasoning
+/// by itself is intentionally not enough: Codex needs either assistant text (a
+/// real final answer) or a client tool call to keep the task lifecycle sound.
+fn empty_tool_result_disposition(
+    payload: &MessagesRequest,
+    round: &RoundOutcome,
+    retries: usize,
+) -> EmptyToolResultDisposition {
+    let is_invalid_empty_continuation = last_message_has_tool_result(payload)
+        && round.text.trim().is_empty()
+        && round.tool_uses.is_empty()
+        && round.stop_reason_override.is_none();
+    if !is_invalid_empty_continuation {
+        EmptyToolResultDisposition::Accept
+    } else if retries < MAX_EMPTY_TOOL_RESULT_RETRIES {
+        EmptyToolResultDisposition::Retry
+    } else {
+        EmptyToolResultDisposition::Fail
+    }
 }
 
 /// Buffer-decode one round of the upstream streaming response
@@ -545,29 +594,76 @@ pub(super) async fn run_web_search_loop(
     let mut all_thinking = String::new();
 
     for round_idx in 0..=MAX_WEB_SEARCH_ROUNDS {
-        let (round, credential_id) =
-            match run_round(
-                &provider,
-                &payload,
-                &hook,
-                fallback_input_tokens,
-                group.as_deref(),
-                tool_compatibility_mode,
-            )
-            .await
-            {
-                Ok(v) => v,
-                Err(resp) => return resp,
-            };
-        last_credential_id = credential_id;
-        last_context_input = round.context_input_tokens.or(last_context_input);
-        total_credits += round.credits;
-        if !round.thinking.is_empty() {
-            if !all_thinking.is_empty() {
-                all_thinking.push_str("\n\n");
+        let mut empty_retries = 0usize;
+        let round = loop {
+            let (round, credential_id) =
+                match run_round(
+                    &provider,
+                    &payload,
+                    &hook,
+                    fallback_input_tokens,
+                    group.as_deref(),
+                    tool_compatibility_mode,
+                )
+                .await
+                {
+                    Ok(v) => v,
+                    Err(resp) => return resp,
+                };
+            last_credential_id = credential_id;
+            last_context_input = round.context_input_tokens.or(last_context_input);
+            total_credits += round.credits;
+
+            match empty_tool_result_disposition(&payload, &round, empty_retries) {
+                EmptyToolResultDisposition::Accept => {}
+                EmptyToolResultDisposition::Retry => {
+                    empty_retries += 1;
+                    tracing::warn!(
+                        round = round_idx,
+                        retry = empty_retries,
+                        "upstream returned an empty assistant turn after tool_result; retrying"
+                    );
+                    continue;
+                }
+                EmptyToolResultDisposition::Fail => {
+                    let final_input = last_context_input.unwrap_or(fallback_input_tokens);
+                    hook.record(
+                        last_credential_id,
+                        final_input,
+                        0,
+                        0,
+                        0,
+                        total_credits,
+                        "error",
+                    );
+                    tracing::error!(
+                        round = round_idx,
+                        "upstream repeated an empty assistant turn after tool_result"
+                    );
+                    return (
+                        StatusCode::BAD_GATEWAY,
+                        Json(ErrorResponse::new(
+                            "upstream_error",
+                            "Upstream returned no assistant text or tool call after a tool result."
+                                .to_string(),
+                        )),
+                    )
+                        .into_response();
+                }
             }
-            all_thinking.push_str(&round.thinking);
-        }
+
+            // Only surface reasoning from the accepted attempt. An empty attempt is
+            // discarded and retried, so replaying its hidden reasoning would duplicate
+            // or contradict the successful attempt's summary.
+            if !round.thinking.is_empty() {
+                if !all_thinking.is_empty() {
+                    all_thinking.push_str("\n\n");
+                }
+                all_thinking.push_str(&round.thinking);
+            }
+
+            break round;
+        };
 
         if should_search_round(round_idx, &round.tool_uses) {
             // Real search: if any one fails -> propagate the error, never silently turn it into "No results found"
@@ -888,6 +984,132 @@ mod tests {
         // Skip: no tool_use at all (plain-text answer) -> terminate
         let empty: Vec<CompletedToolUse> = vec![];
         assert!(!should_search_round(0, &empty));
+    }
+
+    fn round_outcome(text: &str, tool_uses: Vec<CompletedToolUse>) -> RoundOutcome {
+        RoundOutcome {
+            text: text.to_string(),
+            thinking: String::new(),
+            tool_uses,
+            context_input_tokens: None,
+            credits: 0.0,
+            stop_reason_override: None,
+            stream_error: false,
+            known_tool_names: std::collections::HashSet::new(),
+            tool_name_map: std::collections::HashMap::new(),
+        }
+    }
+
+    fn payload_with_last_block(block: Value) -> MessagesRequest {
+        MessagesRequest {
+            model: "gpt-5.6-terra".to_string(),
+            max_tokens: 1024,
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: json!([block]),
+            }],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+            output_config: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn empty_round_after_tool_result_retries_once_then_fails() {
+        let payload = payload_with_last_block(json!({
+            "type": "tool_result",
+            "tool_use_id": "call_1",
+            "content": "done"
+        }));
+        assert_eq!(
+            empty_tool_result_disposition(&payload, &round_outcome("", vec![]), 0),
+            EmptyToolResultDisposition::Retry
+        );
+        assert_eq!(
+            empty_tool_result_disposition(
+                &payload,
+                &round_outcome("", vec![]),
+                MAX_EMPTY_TOOL_RESULT_RETRIES,
+            ),
+            EmptyToolResultDisposition::Fail
+        );
+    }
+
+    #[test]
+    fn text_or_tool_call_after_tool_result_is_not_retried() {
+        let payload = payload_with_last_block(json!({
+            "type": "tool_result",
+            "tool_use_id": "call_1",
+            "content": "done"
+        }));
+        assert_eq!(
+            empty_tool_result_disposition(&payload, &round_outcome("finished", vec![]), 0),
+            EmptyToolResultDisposition::Accept
+        );
+        assert_eq!(
+            empty_tool_result_disposition(&payload, &round_outcome("", vec![tu("exec")]), 0),
+            EmptyToolResultDisposition::Accept
+        );
+    }
+
+    #[test]
+    fn empty_initial_round_is_not_misclassified_as_tool_continuation() {
+        let payload = payload_with_last_block(json!({"type": "text", "text": "hello"}));
+        assert_eq!(
+            empty_tool_result_disposition(&payload, &round_outcome("", vec![]), 0),
+            EmptyToolResultDisposition::Accept
+        );
+    }
+
+    #[test]
+    fn whitespace_and_reasoning_only_after_tool_result_is_retried() {
+        let payload = payload_with_last_block(json!({
+            "type": "tool_result",
+            "tool_use_id": "call_1",
+            "content": "done"
+        }));
+        let mut round = round_outcome(" \n\t", vec![]);
+        round.thinking = "hidden reasoning without a client-visible continuation".to_string();
+        assert_eq!(
+            empty_tool_result_disposition(&payload, &round, 0),
+            EmptyToolResultDisposition::Retry
+        );
+    }
+
+    #[test]
+    fn terminal_limit_reason_after_tool_result_is_not_retried() {
+        let payload = payload_with_last_block(json!({
+            "type": "tool_result",
+            "tool_use_id": "call_1",
+            "content": "done"
+        }));
+        let mut round = round_outcome("", vec![]);
+        round.stop_reason_override = Some("max_tokens".to_string());
+        assert_eq!(
+            empty_tool_result_disposition(&payload, &round, 0),
+            EmptyToolResultDisposition::Accept
+        );
+    }
+
+    #[test]
+    fn only_the_last_message_determines_tool_continuation() {
+        let mut payload = payload_with_last_block(json!({
+            "type": "tool_result",
+            "tool_use_id": "call_1",
+            "content": "done"
+        }));
+        payload.messages.push(Message {
+            role: "user".to_string(),
+            content: json!([{"type": "text", "text": "new user turn"}]),
+        });
+        assert_eq!(
+            empty_tool_result_disposition(&payload, &round_outcome("", vec![]), 0),
+            EmptyToolResultDisposition::Accept
+        );
     }
 
     #[test]

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -40,6 +40,10 @@ const MAX_WEB_SEARCH_ROUNDS: usize = 5;
 struct RoundOutcome {
     /// Accumulated assistant text
     text: String,
+    /// Accumulated thinking / reasoning text (Kiro reasoningContentEvent).
+    /// Surfaced out-of-band via render_json's `kiro_thinking` so Anthropic
+    /// clients never see (and never replay) an unsigned thinking block.
+    thinking: String,
     /// The complete tool_use for this round (name already restored via tool_name_map)
     tool_uses: Vec<CompletedToolUse>,
     /// Actual input tokens computed from contextUsageEvent
@@ -91,6 +95,7 @@ async fn decode_round(
     let mut decoder = EventStreamDecoder::new();
 
     let mut text = String::new();
+    let mut thinking = String::new();
     // id -> (name, json_buffer), preserving the order of appearance
     let mut buffers: std::collections::HashMap<String, (String, String)> =
         std::collections::HashMap::new();
@@ -127,6 +132,11 @@ async fn decode_round(
             };
             match event {
                 Event::AssistantResponse(resp) => text.push_str(&resp.content),
+                Event::ReasoningContent(r) => {
+                    if let Some(t) = &r.text {
+                        thinking.push_str(t);
+                    }
+                }
                 Event::ToolUse(tu) => {
                     let entry = buffers.entry(tu.tool_use_id.clone()).or_insert_with(|| {
                         order.push(tu.tool_use_id.clone());
@@ -177,6 +187,7 @@ async fn decode_round(
 
     RoundOutcome {
         text,
+        thinking,
         tool_uses,
         context_input_tokens,
         credits,
@@ -531,6 +542,7 @@ pub(super) async fn run_web_search_loop(
     let mut last_credential_id: u64 = 0;
     let mut last_context_input: Option<i32> = None;
     let mut total_credits = 0.0;
+    let mut all_thinking = String::new();
 
     for round_idx in 0..=MAX_WEB_SEARCH_ROUNDS {
         let (round, credential_id) =
@@ -550,6 +562,12 @@ pub(super) async fn run_web_search_loop(
         last_credential_id = credential_id;
         last_context_input = round.context_input_tokens.or(last_context_input);
         total_credits += round.credits;
+        if !round.thinking.is_empty() {
+            if !all_thinking.is_empty() {
+                all_thinking.push_str("\n\n");
+            }
+            all_thinking.push_str(&round.thinking);
+        }
 
         if should_search_round(round_idx, &round.tool_uses) {
             // Real search: if any one fails -> propagate the error, never silently turn it into "No results found"
@@ -649,7 +667,14 @@ pub(super) async fn run_web_search_loop(
         return if stream_client {
             render_sse(&payload.model, content, &stop_reason, final_input, output_tokens)
         } else {
-            render_json(&payload.model, content, &stop_reason, final_input, output_tokens)
+            render_json(
+                &payload.model,
+                content,
+                &stop_reason,
+                final_input,
+                output_tokens,
+                &all_thinking,
+            )
         };
     }
 
@@ -663,14 +688,21 @@ pub(super) async fn run_web_search_loop(
 }
 
 /// Single JSON response (non-streaming)
+///
+/// `thinking`: optional out-of-band reasoning text. Emitted as a TOP-LEVEL
+/// `kiro_thinking` field (NOT a content block): Anthropic clients ignore
+/// unknown top-level fields and thus never replay an unsigned thinking block
+/// upstream, while the Responses translator picks it up for codex's
+/// reasoning-summary display.
 pub(crate) fn render_json(
     model: &str,
     content: Vec<Value>,
     stop_reason: &str,
     input_tokens: i32,
     output_tokens: i32,
+    thinking: &str,
 ) -> Response {
-    let body = json!({
+    let mut body = json!({
         "id": format!("msg_{}", Uuid::new_v4().to_string().replace('-', "")),
         "type": "message",
         "role": "assistant",
@@ -685,6 +717,9 @@ pub(crate) fn render_json(
             "cache_read_input_tokens": 0
         }
     });
+    if !thinking.is_empty() {
+        body["kiro_thinking"] = json!(thinking);
+    }
     (StatusCode::OK, Json(body)).into_response()
 }
 


### PR DESCRIPTION
## Summary

- complete the Codex Responses tool bridge for function, custom/freeform, and namespaced tools on top of #38
- replay tool calls and outputs through the internal Messages pipeline without losing tool identity
- prevent a successful-but-empty upstream round after `tool_result` from being serialized as terminal `response.completed`
- retry one transient empty continuation, then return a visible 502 if it repeats
- emit the documented `response.custom_tool_call_input.done` event and discard reasoning from rejected retry attempts

## Why

Kiro's GPT-5.6 rollout is experimental and explicitly targets long-running tool coordination. During real Codex sessions, the upstream stream occasionally ended after a tool result with no assistant text and no next tool call. kiro-rs treated that empty round as `end_turn`, synthesized `response.completed`, and Codex marked unfinished work complete.

The Responses tool lifecycle requires the application to submit tool output and then receive either a final assistant response or additional tool calls. An empty continuation is therefore not a valid terminal success.

References:
- https://kiro.dev/changelog/models/gpt-5-6/
- https://developers.openai.com/api/docs/guides/function-calling#the-tool-calling-flow
- https://developers.openai.com/api/reference/resources/responses/streaming-events#response.custom_tool_call_input.done

## Testing

- `cargo test --locked` — 521 passed
- focused Responses tests — 20 passed
- focused web-search/tool-routing tests — 36 passed
- `cargo build --release --locked`
- real `codex-kiro` + GPT-5.6 Luna E2E: custom `apply_patch`, failed shell result, successful shell retry, then final `CUSTOM_FUNCTION_PASS`

## Notes

- The retry is limited to one attempt and only applies when the last message contains a `tool_result` and the upstream produced neither visible text nor a client tool call.
- `max_tokens` and context-window terminal reasons are preserved and are not retried.
- Repository-wide Clippy with `-D warnings` currently fails on pre-existing lints outside this change; the full test suite and locked release build pass.