### PR TITLE
fix(responses): preserve GPT-5.6 reasoning in Codex turns

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -267,7 +267,7 @@ pub fn get_context_window_size(model: &str) -> i32 {
 
 /// 是否为已确认接受 `additionalModelRequestFields.output_config` 的模型。
 ///
-/// Kiro `ListAvailableModels`（2026-06）确认：Opus 4.6/4.7/4.8、Sonnet 4.6 接受
+/// Kiro `ListAvailableModels`（2026-06）确认：Opus 4.6/4.7/4.8、Sonnet 4.6、GPT 5.6 接受
 /// `output_config`。Claude 5 系（fable-5 / mythos-5 / sonnet-5 / opus-5 / claude-5）
 /// 与 xhigh 能力一致，一并视为支持。其余（4.5 系、haiku、sonnet-4.8 等）保守视为
 /// 不支持——向它们下发会触发上游 400（`additionalModelRequestFields is not supported`）。
@@ -282,6 +282,7 @@ fn model_supports_native_reasoning(model_id: &str) -> bool {
         || m.contains("sonnet-5")
         || m.contains("opus-5")
         || m.contains("claude-5")
+        || m.starts_with("gpt-5.6-")
 }
 
 /// 本次请求是否请求了原生 reasoning。
@@ -2237,6 +2238,18 @@ mod tests {
             .expect("fable-5 显式 effort 应下发");
         // fable-5 支持 xhigh（model_supports_xhigh_effort），不降级。
         assert_eq!(fields.output_config.unwrap().effort, "xhigh");
+    }
+
+    #[test]
+    fn explicit_effort_emits_for_gpt_5_6_family() {
+        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            let req = minimal_request_with_effort(model, "high");
+            let result = convert_request(&req).unwrap();
+            let fields = result.additional_model_request_fields.unwrap_or_else(|| {
+                panic!("{model} should forward explicit reasoning effort")
+            });
+            assert_eq!(fields.output_config.unwrap().effort, "high");
+        }
     }
 
     // ---- normalize_json_schema: 顶层 type / 组合关键字（PR#6）----

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -291,6 +291,17 @@ fn count_image_budget(payload: &super::types::MessagesRequest) -> ImageBudget {
     }
 }
 
+fn reasoning_enabled(payload: &MessagesRequest) -> bool {
+    payload
+        .thinking
+        .as_ref()
+        .is_some_and(|thinking| thinking.is_enabled())
+        || payload
+            .output_config
+            .as_ref()
+            .is_some_and(|config| !config.effort.trim().is_empty())
+}
+
 /// 将 KiroProvider 错误映射为 HTTP 响应
 pub(super) fn map_provider_error(err: Error) -> Response {
     if let Some(rate_limit) = err.downcast_ref::<crate::kiro::error::UpstreamRateLimitError>() {
@@ -750,11 +761,7 @@ pub async fn post_messages(
     ) as i32;
 
     // 检查是否启用了thinking
-    let thinking_enabled = payload
-        .thinking
-        .as_ref()
-        .map(|t| t.is_enabled())
-        .unwrap_or(false);
+    let thinking_enabled = reasoning_enabled(&payload);
 
     let tool_name_map = conversion_result.tool_name_map;
     let known_tool_names = conversion_result.known_tool_names;
@@ -1541,11 +1548,7 @@ pub async fn post_messages_cc(
     ) as i32;
 
     // 检查是否启用了thinking
-    let thinking_enabled = payload
-        .thinking
-        .as_ref()
-        .map(|t| t.is_enabled())
-        .unwrap_or(false);
+    let thinking_enabled = reasoning_enabled(&payload);
 
     let tool_name_map = conversion_result.tool_name_map;
     let known_tool_names = conversion_result.known_tool_names;
@@ -1927,6 +1930,19 @@ mod tests {
         assert_eq!(content.len(), 1);
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[0]["text"], "native thinking fallback");
+    }
+
+    #[test]
+    fn explicit_effort_enables_reasoning_extraction() {
+        let req: MessagesRequest = serde_json::from_str(r#"{
+            "model": "gpt-5.6-sol",
+            "max_tokens": 100,
+            "messages": [],
+            "output_config": {"effort": "high"}
+        }"#)
+        .unwrap();
+
+        assert!(reasoning_enabled(&req));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- forward Codex `reasoning.effort` to Kiro for the complete `gpt-5.6-*` family
- treat explicit `output_config.effort` as enabling reasoning extraction in both message handlers
- keep native scratch reasoning in reasoning items instead of exposing it as terminal assistant text

## Regression

Before the fix:

```text
test anthropic::converter::tests::explicit_effort_emits_for_gpt_5_6_family ... FAILED
gpt-5.6-sol should forward explicit reasoning effort
```

The regression test covers `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.

## Testing

- `cargo test` — 523 passed
- `git diff --check` — passed
- `cargo fmt -- --check` — blocked by pre-existing formatting differences in untouched files
- `cargo clippy --all-targets -- -D warnings` — blocked by 175 pre-existing warnings in untouched files