### PR TITLE
feat(models): 配置驱动的自定义模型映射 (customModels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file. The format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### ✨ 新功能 — 自定义模型支持
+
+- **`config.json` 新增 `customModels` 数组**：把任意客户端模型别名映射到 Kiro 后端模型 ID，并可声明 `displayName` / `contextWindow` / `maxTokens` / `supportsReasoning` / `ownedBy`。自定义条目按 `id`（大小写不敏感）精确匹配，**优先于**内置关键词模糊映射——既能新增模型，也能覆盖内置模型的后端指向。
+- **thinking 后缀回退**：客户端传 `<alias>-thinking` 而无同名精确条目时，自动剥离后缀回退到 `<alias>`，与内置映射对 thinking 变体的处理一致。
+- **`GET /v1/models` 展示**：所有自定义模型追加到列表尾部（保持配置顺序）。
+- **上下文窗口 / reasoning**：设了 `contextWindow` 时以其为准；`supportsReasoning: true` 让对应 backend_id 放行 `additionalModelRequestFields`。
+- **零透传实现**：复用项目既有的 `OnceLock` 全局配置惯例（同 `token.rs`），启动时装载一次只读注册表，`map_model` / `get_context_window_size` / `available_models` 内部查表，未改动任何函数签名。`/v1/chat/completions` 与 `/v1/responses` 因复用同一映射链路自动生效。默认空数组，向后兼容。
+
 ## [0.7.1] - 2026-07-15
 
 主题：**打通 Codex CLI 完整工具链——桥接 function / custom / namespace 工具到 Anthropic 模型，并修复工具结果后空响应导致任务误标记完成的问题**。0.7.0 引入了 Responses 端点使 Codex CLI 能连接 kiro-rs，但此前仅支持纯聊天与 Web 搜索——Codex 的真实工具（shell / apply_patch / view_image / MCP 等）被全部剥离，导致 Codex 无法读写文件、执行命令或编辑代码。本版补全工具桥接的全链路：从 Codex 的工具声明收集、到 Anthropic 模型侧的 schema 翻译、再到响应侧按声明类型正确生成 `function_call` 或 `custom_tool_call`——实现 Codex CLI 与 kiro-rs 的完整能力对齐。

--- a/README.md
+++ b/README.md
@@ -542,13 +542,42 @@ KIRO_API_KEY=ksk_xxx ./kiro-rs
 | `opus` + `4-5` / `4.5` | `claude-opus-4.5` |
 | 任意 `haiku` | `claude-haiku-4.5` |
 
-没有命中上述规则的模型会作为不支持模型处理。
+没有命中上述规则、且不在下文「自定义模型」表中的模型会作为不支持模型处理。
 
 上下文窗口估算：
 
 - `gpt-5.*`：`272_000`（GPT-5.6 静态模型声明最大输出为 `64_000`）
 - `claude-sonnet-4.6`、`claude-sonnet-4.8`、`claude-sonnet-5`、`claude-opus-4.6`、`claude-opus-4.7`、`claude-opus-4.8`、`claude-fable-5`：`1_000_000`
 - 其它模型：`200_000`
+
+### 自定义模型
+
+可在 `config.json` 增加 `customModels` 数组，把任意客户端模型别名映射到 Kiro 后端模型 ID。自定义条目**优先于**上表的内置模糊匹配，既能新增模型，也能覆盖内置映射。
+
+```jsonc
+{
+  "customModels": [
+    {
+      "id": "my-opus",                 // 客户端请求用的模型名（大小写不敏感精确匹配）
+      "backendId": "claude-opus-4.8",  // 实际下发给 Kiro 的后端模型 ID（必填）
+      "displayName": "My Opus",        // 可选，/v1/models 展示名，缺省用 id
+      "contextWindow": 1000000,         // 可选，上下文窗口，缺省 200000
+      "maxTokens": 64000,               // 可选，/v1/models 展示的最大输出，缺省 64000
+      "supportsReasoning": true,        // 可选，是否放行原生 reasoning，缺省 false
+      "ownedBy": "custom"               // 可选，/v1/models 的 owned_by，缺省 "custom"
+    }
+  ]
+}
+```
+
+行为说明：
+
+- **匹配**：按 `id` 大小写不敏感精确匹配；客户端传 `my-opus-thinking` 时，若无同名精确条目，会自动剥离 `-thinking` 后缀回退到 `my-opus`。
+- **优先级**：命中自定义表直接返回其 `backendId`，不再走内置关键词映射，因此可用同名 `id` 覆盖内置模型的后端指向。
+- **展示**：所有 `customModels` 条目会追加到 `GET /v1/models` 列表尾部（保持配置文件顺序）。
+- **上下文窗口**：设了 `contextWindow` 时以其为准，否则回退到内置估算。
+- **reasoning**：`supportsReasoning: true` 会让该 `backendId` 放行 `additionalModelRequestFields`（`output_config` 等）；后端不接受时上游会返回 400，此时置 false 即可。
+- **兼容性**：默认空数组，不配置时行为与之前完全一致；`/v1/chat/completions` 与 `/v1/responses` 因复用同一映射链路自动生效。
 
 <a id="thinking-tools-websearch"></a>
 ## Thinking、工具与 WebSearch

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -196,6 +196,11 @@ Complete all chunked operations without commentary.";
 /// 模型映射：将 Anthropic 模型名映射到 Kiro 模型 ID
 /// 严格对照版本号
 pub fn map_model(model: &str) -> Option<String> {
+    // 自定义模型表优先（大小写不敏感精确匹配），可新增或覆盖内置映射。
+    if let Some(custom) = crate::model::custom_models::lookup(model) {
+        return Some(custom.backend_id.clone());
+    }
+
     let model_lower = model.to_lowercase();
 
     if model_lower.contains("fable") {
@@ -247,6 +252,13 @@ pub fn map_model(model: &str) -> Option<String> {
 /// Kiro 于 2026-03-24 将 Opus 4.6 和 Sonnet 4.6 升级至 1M 上下文。
 /// 4.7 / 4.8 同 1M
 pub fn get_context_window_size(model: &str) -> i32 {
+    // 自定义模型若显式声明了上下文窗口，优先返回。
+    if let Some(custom) = crate::model::custom_models::lookup(model) {
+        if let Some(window) = custom.context_window {
+            return window;
+        }
+    }
+
     match map_model(model) {
         // GPT-5.6 family on Kiro ships a 272K context window.
         Some(mapped) if mapped.starts_with("gpt") => 272_000,
@@ -273,6 +285,10 @@ pub fn get_context_window_size(model: &str) -> i32 {
 /// 不支持——向它们下发会触发上游 400（`additionalModelRequestFields is not supported`）。
 /// 若后续实测某模型 400，从这里去除即可。
 fn model_supports_native_reasoning(model_id: &str) -> bool {
+    // 自定义模型可按 backend_id 声明支持 reasoning。
+    if crate::model::custom_models::backend_supports_reasoning(model_id) {
+        return true;
+    }
     let m = model_id.to_ascii_lowercase();
     matches!(
         m.as_str(),

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -383,7 +383,7 @@ fn resolve_usage_input_tokens(
 }
 
 fn available_models() -> Vec<Model> {
-    vec![
+    let mut models = vec![
         Model {
             id: "gpt-5.6-sol".to_string(),
             object: "model".to_string(),
@@ -591,7 +591,22 @@ fn available_models() -> Vec<Model> {
             model_type: "chat".to_string(),
             max_tokens: 64000,
         },
-    ]
+    ];
+
+    // 追加配置文件里声明的自定义模型（保持原始顺序）。
+    for cm in crate::model::custom_models::all() {
+        models.push(Model {
+            id: cm.id.clone(),
+            object: "model".to_string(),
+            created: 1782000000,
+            owned_by: cm.owned_by.clone().unwrap_or_else(|| "custom".to_string()),
+            display_name: cm.display_name.clone().unwrap_or_else(|| cm.id.clone()),
+            model_type: "chat".to_string(),
+            max_tokens: cm.max_tokens.unwrap_or(64000),
+        });
+    }
+
+    models
 }
 
 /// GET /v1/models

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,9 @@ async fn main() {
         config.default_endpoint.clone(),
     );
 
+    // 初始化自定义模型注册表（启动时装载一次，运行期只读）
+    model::custom_models::init(config.custom_models.clone());
+
     // 初始化 count_tokens 配置
     token::init_config(token::CountTokensConfig {
         api_url: config.count_tokens_api_url.clone(),

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -30,6 +30,43 @@ pub enum ToolCompatibilityMode {
     Raw,
 }
 
+/// 自定义模型定义。
+///
+/// 用户在 `config.json` 的 `customModels` 数组里声明客户端模型别名到 Kiro 后端
+/// 模型 ID 的映射及元数据。运行期由 [`crate::model::custom_models`] 全局注册表按
+/// `id`（大小写不敏感）精确匹配，优先于内置的模糊映射逻辑——既能新增模型，也能
+/// 覆盖内置模型的映射。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomModel {
+    /// 客户端请求时使用的模型名（别名）。匹配大小写不敏感。
+    pub id: String,
+
+    /// 映射到的 Kiro 后端模型 ID（实际下发给上游）。
+    pub backend_id: String,
+
+    /// `/v1/models` 展示名（可选，缺省用 `id`）。
+    #[serde(default)]
+    pub display_name: Option<String>,
+
+    /// 上下文窗口大小（可选，缺省 200000）。
+    #[serde(default)]
+    pub context_window: Option<i32>,
+
+    /// 单次响应最大 token 数，用于 `/v1/models` 展示（可选，缺省 64000）。
+    #[serde(default)]
+    pub max_tokens: Option<i32>,
+
+    /// 是否支持原生 reasoning / `output_config`（可选，缺省 false）。
+    /// 命中的自定义模型置 true 时，会按 backend_id 放行 `additionalModelRequestFields`。
+    #[serde(default)]
+    pub supports_reasoning: Option<bool>,
+
+    /// `/v1/models` 的 `owned_by` 字段（可选，缺省 "custom"）。
+    #[serde(default)]
+    pub owned_by: Option<String>,
+}
+
 /// KNA 应用配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -179,6 +216,14 @@ pub struct Config {
     #[serde(default)]
     pub endpoints: HashMap<String, serde_json::Value>,
 
+    /// 自定义模型映射表。
+    ///
+    /// 每条把一个客户端模型别名映射到 Kiro 后端模型 ID 并附带元数据。默认空数组
+    /// （完全向后兼容）。启动时装入 [`crate::model::custom_models`] 全局注册表，
+    /// 供 `map_model` / `get_context_window_size` / `/v1/models` 查询。
+    #[serde(default)]
+    pub custom_models: Vec<CustomModel>,
+
     /// 配置文件路径（运行时元数据，不写入 JSON）
     #[serde(skip)]
     config_path: Option<PathBuf>,
@@ -292,6 +337,7 @@ impl Default for Config {
             trace_retention_days: default_trace_retention_days(),
             usage_log_retention_days: default_usage_log_retention_days(),
             endpoints: HashMap::new(),
+            custom_models: Vec::new(),
             config_path: None,
         }
     }

--- a/src/model/custom_models.rs
+++ b/src/model/custom_models.rs
@@ -1,0 +1,157 @@
+//! 自定义模型全局注册表
+//!
+//! 启动时由 [`init`] 从 `config.custom_models` 装载一次，运行期只读。仿
+//! `crate::token` / `crate::kiro::machine_id` 的 `OnceLock` 惯例，避免把配置表
+//! 逐层透传进 `map_model` / `get_context_window_size` 等无状态自由函数。
+//!
+//! 匹配规则：按模型 `id` 大小写不敏感精确匹配；找不到时自动剥离 `-thinking`
+//! 后缀再试一次（与内置 `map_model` 对 thinking 变体的处理保持一致）。
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use super::config::CustomModel;
+
+/// 自定义模型注册表：保序原始列表（供 `/v1/models` 展示）+ 小写 id 索引（供查询）。
+struct CustomModelRegistry {
+    /// 原始顺序的完整列表。
+    ordered: Vec<CustomModel>,
+    /// 小写 id -> `ordered` 下标。
+    by_id: HashMap<String, usize>,
+}
+
+static REGISTRY: OnceLock<CustomModelRegistry> = OnceLock::new();
+
+/// 初始化自定义模型注册表。
+///
+/// 应在应用启动时调用一次；重复调用会被忽略（`OnceLock` 语义）。后一条同名 id
+/// 覆盖前一条的索引，但两者都保留在 `ordered` 中（`/v1/models` 会同时展示）。
+pub fn init(models: Vec<CustomModel>) {
+    let mut by_id = HashMap::with_capacity(models.len());
+    for (idx, m) in models.iter().enumerate() {
+        by_id.insert(m.id.to_ascii_lowercase(), idx);
+    }
+    let _ = REGISTRY.set(CustomModelRegistry {
+        ordered: models,
+        by_id,
+    });
+}
+
+/// 按模型名查找自定义模型定义。
+///
+/// 先按大小写不敏感精确匹配；未命中且名字带 `-thinking` 后缀时，剥离后再试一次。
+pub fn lookup(model: &str) -> Option<&'static CustomModel> {
+    let reg = REGISTRY.get()?;
+    let key = model.to_ascii_lowercase();
+    if let Some(&idx) = reg.by_id.get(&key) {
+        return reg.ordered.get(idx);
+    }
+    if let Some(stripped) = key.strip_suffix("-thinking") {
+        if let Some(&idx) = reg.by_id.get(stripped) {
+            return reg.ordered.get(idx);
+        }
+    }
+    None
+}
+
+/// 返回所有已注册的自定义模型（保持配置文件中的原始顺序）。
+pub fn all() -> &'static [CustomModel] {
+    REGISTRY
+        .get()
+        .map(|r| r.ordered.as_slice())
+        .unwrap_or(&[])
+}
+
+/// 是否存在 `backend_id` 等于给定值且声明支持 reasoning 的自定义模型。
+///
+/// `map_model` 把别名映射成 backend_id 后，`model_supports_native_reasoning`
+/// 拿到的是 backend_id；这里按 backend_id 反查，让自定义模型能声明 reasoning 能力。
+pub fn backend_supports_reasoning(backend_id: &str) -> bool {
+    all()
+        .iter()
+        .any(|m| m.backend_id == backend_id && m.supports_reasoning == Some(true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(id: &str, backend: &str) -> CustomModel {
+        CustomModel {
+            id: id.to_string(),
+            backend_id: backend.to_string(),
+            display_name: None,
+            context_window: None,
+            max_tokens: None,
+            supports_reasoning: None,
+            owned_by: None,
+        }
+    }
+
+    // 注册表是进程级 OnceLock，无法在多测试间反复 init；这里直接构造 registry
+    // 实例，单元测试其查询逻辑（lookup / thinking 后缀剥离）。
+    fn build(models: Vec<CustomModel>) -> CustomModelRegistry {
+        let mut by_id = HashMap::new();
+        for (idx, m) in models.iter().enumerate() {
+            by_id.insert(m.id.to_ascii_lowercase(), idx);
+        }
+        CustomModelRegistry {
+            ordered: models,
+            by_id,
+        }
+    }
+
+    fn lookup_in<'a>(reg: &'a CustomModelRegistry, model: &str) -> Option<&'a CustomModel> {
+        let key = model.to_ascii_lowercase();
+        if let Some(&idx) = reg.by_id.get(&key) {
+            return reg.ordered.get(idx);
+        }
+        if let Some(stripped) = key.strip_suffix("-thinking") {
+            if let Some(&idx) = reg.by_id.get(stripped) {
+                return reg.ordered.get(idx);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_lookup_case_insensitive() {
+        let reg = build(vec![sample("My-Opus", "claude-opus-4.8")]);
+        assert_eq!(
+            lookup_in(&reg, "my-opus").map(|m| m.backend_id.as_str()),
+            Some("claude-opus-4.8")
+        );
+        assert_eq!(
+            lookup_in(&reg, "MY-OPUS").map(|m| m.backend_id.as_str()),
+            Some("claude-opus-4.8")
+        );
+    }
+
+    #[test]
+    fn test_lookup_strips_thinking_suffix() {
+        let reg = build(vec![sample("my-opus", "claude-opus-4.8")]);
+        assert_eq!(
+            lookup_in(&reg, "my-opus-thinking").map(|m| m.backend_id.as_str()),
+            Some("claude-opus-4.8")
+        );
+    }
+
+    #[test]
+    fn test_lookup_miss() {
+        let reg = build(vec![sample("my-opus", "claude-opus-4.8")]);
+        assert!(lookup_in(&reg, "unknown-model").is_none());
+    }
+
+    #[test]
+    fn test_explicit_thinking_alias_wins_over_strip() {
+        // 同时存在 my-opus 与 my-opus-thinking 时，精确匹配优先，不走剥离回退。
+        let reg = build(vec![
+            sample("my-opus", "claude-opus-4.8"),
+            sample("my-opus-thinking", "claude-opus-4.7"),
+        ]);
+        assert_eq!(
+            lookup_in(&reg, "my-opus-thinking").map(|m| m.backend_id.as_str()),
+            Some("claude-opus-4.7")
+        );
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod arg;
 pub mod config;
+pub mod custom_models;


### PR DESCRIPTION
## 摘要

新增 `config.json` 的 `customModels` 数组，让用户无需改代码/重编译即可把任意客户端模型别名映射到 Kiro 后端模型 ID，并可覆盖内置映射。

```jsonc
"customModels": [
  {
    "id": "claude-opus-5",
    "backendId": "claude-opus-4.8",
    "displayName": "Claude Opus 5",
    "contextWindow": 1000000,
    "maxTokens": 64000,
    "supportsReasoning": true,
    "ownedBy": "anthropic"
  }
]
```

## 实现

- 新增 `src/model/custom_models.rs`：仿现有 `token.rs` 的 `OnceLock` 惯例，做启动时装载一次的只读注册表（`init` / `lookup` / `all` / `backend_supports_reasoning`）。
- `map_model` / `get_context_window_size` / `model_supports_native_reasoning` / `available_models` 内部查表，**未改动任何函数签名**，避免把配置逐层透传。
- 按 `id` 大小写不敏感精确匹配，优先于内置模糊映射；缺同名精确条目时自动剥离 `-thinking` 后缀回退。
- 自定义模型追加到 `GET /v1/models` 尾部；`/v1/chat/completions` 与 `/v1/responses` 复用同一映射链路自动生效。
- 默认空数组，完全向后兼容。

## 字段说明

| 字段 | 必填 | 缺省 | 说明 |
|---|---|---|---|
| `id` | ✅ | — | 客户端请求用的模型名（大小写不敏感精确匹配） |
| `backendId` | ✅ | — | 实际下发给 Kiro 的后端模型 ID |
| `displayName` | | `id` | `/v1/models` 展示名 |
| `contextWindow` | | 200000 | 上下文窗口 |
| `maxTokens` | | 64000 | `/v1/models` 展示的最大输出 |
| `supportsReasoning` | | false | 是否放行原生 reasoning (`additionalModelRequestFields`) |
| `ownedBy` | | `custom` | `/v1/models` 的 `owned_by` |

## 测试

- `cargo build` 通过；`cargo test` 全部通过（含新增 4 项 `custom_models` 单测：大小写不敏感、`-thinking` 后缀回退、未命中回退、精确条目优先）。
- 端到端：以含 `claude-opus-5` 的配置启动服务，`GET /v1/models` 正确返回、`/v1/messages` 映射到后端并成功出结果、乱名对照正确报「模型不支持」。

## 兼容性

默认空数组，不配置时行为与之前完全一致。仅新增可选功能，无破坏性变更。