### PR TITLE
feat(responses): pass through meteringEvent credit fields

### DIFF
--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -1106,6 +1106,10 @@ async fn handle_non_stream_request(
     // meteringEvent 上报的 credit 计费量（上游真实下发）；
     // input/cache_* 的互斥分摊在拿到 total 真值后由 cache_usage 完成。
     let mut credits: f64 = 0.0;
+    // 最近一次 meteringEvent 的完整 payload，用于在响应体 usage 中透传
+    // credit_usage / credit_unit / credit_unit_plural 字段，与 /v1/messages
+    // 流式（message_delta）行为一致；如果上游多次下发则取最后一次。
+    let mut metering: Option<crate::kiro::model::events::MeteringEvent> = None;
 
     // 工具调用参数 JSON 累积器：按 tool_use_id 缓冲分片，stop 时整体解析。
     // 半截 / 非法 JSON 显式暴露为错误（返回 502），不再静默回退 {} 或丢弃。
@@ -1167,10 +1171,16 @@ async fn handle_non_stream_request(
                                 actual_input_tokens
                             );
                         }
-                        Event::Metering(metering) => {
+                        Event::Metering(event_metering) => {
                             // 上游只下发 credit；token / cache 字段不存在
-                            credits += metering.usage;
-                            tracing::debug!("metering credits +{:.6}", metering.usage);
+                            credits += event_metering.usage;
+                            tracing::debug!(
+                                usage = event_metering.usage,
+                                unit = %event_metering.unit,
+                                unit_plural = %event_metering.unit_plural,
+                                "metering credits +{:.6}", event_metering.usage
+                            );
+                            metering = Some(event_metering);
                         }
                         Event::Exception { exception_type, .. } => {
                             if exception_type == "ContentLengthExceededException" {
@@ -1243,6 +1253,19 @@ async fn handle_non_stream_request(
         cache_usage.split_against_total(total_input_tokens);
 
     // 构建 Anthropic 响应
+    let mut usage_json = json!({
+        "input_tokens": final_input_tokens,
+        "output_tokens": output_tokens,
+        "cache_creation_input_tokens": cache_creation_tokens,
+        "cache_read_input_tokens": cache_read_tokens
+    });
+    // 透传上游 meteringEvent 的 credit_* 字段，让客户端拿到与 Kiro
+    // 后端口径一致的计费元数据；只在收到过 meteringEvent 时才追加。
+    if let Some(m) = &metering {
+        usage_json["credit_usage"] = json!(m.usage);
+        usage_json["credit_unit"] = json!(m.unit);
+        usage_json["credit_unit_plural"] = json!(m.unit_plural);
+    }
     let response_body = json!({
         "id": format!("msg_{}", Uuid::new_v4().to_string().replace('-', "")),
         "type": "message",
@@ -1251,12 +1274,7 @@ async fn handle_non_stream_request(
         "model": model,
         "stop_reason": stop_reason,
         "stop_sequence": null,
-        "usage": {
-            "input_tokens": final_input_tokens,
-            "output_tokens": output_tokens,
-            "cache_creation_input_tokens": cache_creation_tokens,
-            "cache_read_input_tokens": cache_read_tokens
-        }
+        "usage": usage_json
     });
 
     hook.record(

--- a/src/anthropic/openai.rs
+++ b/src/anthropic/openai.rs
@@ -405,6 +405,12 @@ pub(super) struct ParsedResponse {
     /// 内部代答的 web_search 展示（server_tool_use 块）：(id, query)。
     /// Responses 路径渲染为 web_search_call item。
     pub(super) web_searches: Vec<(String, String)>,
+    /// 上游 meteringEvent 透传的 credit_usage，未下发时为 None。
+    /// 与 kiro-rs /v1/chat/completions 行为对齐：仅在拿到 meteringEvent 时
+    /// 才把 credit_usage / credit_unit / credit_unit_plural 写入响应 usage。
+    pub(super) credit_usage: Option<f64>,
+    pub(super) credit_unit: Option<String>,
+    pub(super) credit_unit_plural: Option<String>,
 }
 
 pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedResponse {
@@ -494,6 +500,18 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
 
+    let credit_usage = usage
+        .and_then(|u| u.get("credit_usage"))
+        .and_then(|v| v.as_f64());
+    let credit_unit = usage
+        .and_then(|u| u.get("credit_unit"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let credit_unit_plural = usage
+        .and_then(|u| u.get("credit_unit_plural"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
     ParsedResponse {
         model: model.to_string(),
         text,
@@ -503,6 +521,9 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
         completion_tokens,
         thinking,
         web_searches,
+        credit_usage,
+        credit_unit,
+        credit_unit_plural,
     }
 }
 
@@ -545,11 +566,7 @@ fn build_completion_json(p: &ParsedResponse) -> Value {
             "message": message,
             "finish_reason": p.finish_reason,
         }],
-        "usage": {
-            "prompt_tokens": p.prompt_tokens,
-            "completion_tokens": p.completion_tokens,
-            "total_tokens": p.prompt_tokens + p.completion_tokens,
-        }
+        "usage": build_usage_json(p),
     })
 }
 
@@ -608,11 +625,7 @@ fn build_stream_sse(p: &ParsedResponse) -> String {
             "delta": {},
             "finish_reason": p.finish_reason,
         }],
-        "usage": {
-            "prompt_tokens": p.prompt_tokens,
-            "completion_tokens": p.completion_tokens,
-            "total_tokens": p.prompt_tokens + p.completion_tokens,
-        }
+        "usage": build_usage_json(p),
     });
     out.push_str("data: ");
     out.push_str(&final_chunk.to_string());
@@ -620,6 +633,26 @@ fn build_stream_sse(p: &ParsedResponse) -> String {
     out.push_str("data: [DONE]\n\n");
 
     out
+}
+
+/// 构造 OpenAI usage 对象，并按需透传 upstream meteringEvent 写入的
+/// credit_usage / credit_unit / credit_unit_plural 字段。
+fn build_usage_json(p: &ParsedResponse) -> Value {
+    let mut usage = json!({
+        "prompt_tokens": p.prompt_tokens,
+        "completion_tokens": p.completion_tokens,
+        "total_tokens": p.prompt_tokens + p.completion_tokens,
+    });
+    if let Some(credit_usage) = p.credit_usage {
+        usage["credit_usage"] = json!(credit_usage);
+    }
+    if let Some(credit_unit) = &p.credit_unit {
+        usage["credit_unit"] = json!(credit_unit);
+    }
+    if let Some(credit_unit_plural) = &p.credit_unit_plural {
+        usage["credit_unit_plural"] = json!(credit_unit_plural);
+    }
+    usage
 }
 
 fn openai_error(status: StatusCode, err_type: &str, message: &str) -> Response {
@@ -630,4 +663,126 @@ fn openai_error(status: StatusCode, err_type: &str, message: &str) -> Response {
         }
     });
     (status, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_parsed() -> ParsedResponse {
+        ParsedResponse {
+            model: "gpt-5.6-sol".to_string(),
+            text: "hi".to_string(),
+            tool_calls: Vec::new(),
+            finish_reason: "stop".to_string(),
+            prompt_tokens: 7,
+            completion_tokens: 11,
+            thinking: String::new(),
+            web_searches: Vec::new(),
+            credit_usage: None,
+            credit_unit: None,
+            credit_unit_plural: None,
+        }
+    }
+
+    #[test]
+    fn build_completion_omits_credit_fields_without_metering() {
+        let p = base_parsed();
+        let out = build_completion_json(&p);
+        let usage = &out["usage"];
+        assert!(usage.get("credit_usage").is_none());
+        assert!(usage.get("credit_unit").is_none());
+        assert!(usage.get("credit_unit_plural").is_none());
+        // 原有字段保持原样
+        assert_eq!(usage["prompt_tokens"], json!(7));
+        assert_eq!(usage["completion_tokens"], json!(11));
+        assert_eq!(usage["total_tokens"], json!(18));
+    }
+
+    #[test]
+    fn build_completion_carries_credit_fields_when_metering_present() {
+        let mut p = base_parsed();
+        p.credit_usage = Some(0.5);
+        p.credit_unit = Some("credit".to_string());
+        p.credit_unit_plural = Some("credits".to_string());
+        let out = build_completion_json(&p);
+        let usage = &out["usage"];
+        assert_eq!(usage["credit_usage"], json!(0.5));
+        assert_eq!(usage["credit_unit"], json!("credit"));
+        assert_eq!(usage["credit_unit_plural"], json!("credits"));
+    }
+
+    #[test]
+    fn build_stream_sse_carries_credit_fields_in_final_chunk() {
+        let mut p = base_parsed();
+        p.credit_usage = Some(0.33);
+        p.credit_unit = Some("credit".to_string());
+        p.credit_unit_plural = Some("credits".to_string());
+        let sse = build_stream_sse(&p);
+        assert!(sse.contains("\"credit_usage\":0.33"));
+        assert!(sse.contains("\"credit_unit\":\"credit\""));
+        assert!(sse.contains("\"credit_unit_plural\":\"credits\""));
+        // 结束帧的 usage 必须出现在最后一个 data 块里
+        assert!(sse.contains("\"usage\""));
+    }
+
+    #[test]
+    fn build_stream_sse_omits_credit_fields_without_metering() {
+        let p = base_parsed();
+        let sse = build_stream_sse(&p);
+        assert!(!sse.contains("credit_usage"));
+        assert!(!sse.contains("credit_unit"));
+        assert!(!sse.contains("credit_unit_plural"));
+    }
+
+    #[test]
+    fn parse_anthropic_message_extracts_credit_fields() {
+        let anthropic = json!({
+            "id": "msg_x",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "model": "claude-opus-4-7",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 5,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "credit_usage": 0.6,
+                "credit_unit": "credit",
+                "credit_unit_plural": "credits",
+            }
+        });
+        let p = parse_anthropic_message(&anthropic, "claude-opus-4-7");
+        assert_eq!(p.prompt_tokens, 3);
+        assert_eq!(p.completion_tokens, 5);
+        assert_eq!(p.credit_usage, Some(0.6));
+        assert_eq!(p.credit_unit.as_deref(), Some("credit"));
+        assert_eq!(p.credit_unit_plural.as_deref(), Some("credits"));
+    }
+
+    #[test]
+    fn parse_anthropic_message_without_credit_fields_leaves_them_none() {
+        let anthropic = json!({
+            "id": "msg_x",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "model": "claude-opus-4-7",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 5,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            }
+        });
+        let p = parse_anthropic_message(&anthropic, "claude-opus-4-7");
+        assert!(p.credit_usage.is_none());
+        assert!(p.credit_unit.is_none());
+        assert!(p.credit_unit_plural.is_none());
+    }
 }

--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -858,13 +858,23 @@ fn build_view(p: &ParsedResponse, kinds: &ToolKindMap) -> ResponsesView {
         }
     }
 
-    let usage = json!({
+    let mut usage = json!({
         "input_tokens": p.prompt_tokens,
         "input_tokens_details": { "cached_tokens": 0 },
         "output_tokens": p.completion_tokens,
         "output_tokens_details": { "reasoning_tokens": 0 },
         "total_tokens": p.prompt_tokens + p.completion_tokens,
     });
+    // 透传上游 meteringEvent 写入的 credit_* 字段（仅在拿到 meteringEvent 时）。
+    if let Some(credit_usage) = p.credit_usage {
+        usage["credit_usage"] = json!(credit_usage);
+    }
+    if let Some(credit_unit) = &p.credit_unit {
+        usage["credit_unit"] = json!(credit_unit);
+    }
+    if let Some(credit_unit_plural) = &p.credit_unit_plural {
+        usage["credit_unit_plural"] = json!(credit_unit_plural);
+    }
 
     ResponsesView {
         status,
@@ -1176,6 +1186,9 @@ mod tests {
             completion_tokens: 5,
             thinking: String::new(),
             web_searches: Vec::new(),
+            credit_usage: None,
+            credit_unit: None,
+            credit_unit_plural: None,
         }
     }
 
@@ -1684,5 +1697,48 @@ mod tests {
         assert!(sse.contains("event: response.reasoning_summary_text.delta"));
         assert!(sse.contains("deep thought"));
         assert!(sse.contains("\"reasoning\""));
+    }
+
+    // ---- credit_usage 透传 ----
+
+    #[test]
+    fn response_object_omits_credit_fields_without_metering() {
+        let kinds = ToolKindMap::new();
+        let p = parsed_with_tool_calls(vec![]);
+        let obj = build_responses_object(&p, &kinds);
+        let usage = &obj["usage"];
+        assert!(usage.get("credit_usage").is_none());
+        assert!(usage.get("credit_unit").is_none());
+        assert!(usage.get("credit_unit_plural").is_none());
+    }
+
+    #[test]
+    fn response_object_carries_credit_fields_when_metering_present() {
+        let kinds = ToolKindMap::new();
+        let mut p = parsed_with_tool_calls(vec![]);
+        p.credit_usage = Some(0.25);
+        p.credit_unit = Some("credit".to_string());
+        p.credit_unit_plural = Some("credits".to_string());
+        let obj = build_responses_object(&p, &kinds);
+        let usage = &obj["usage"];
+        assert_eq!(usage["credit_usage"], json!(0.25));
+        assert_eq!(usage["credit_unit"], json!("credit"));
+        assert_eq!(usage["credit_unit_plural"], json!("credits"));
+        // 原有字段保持原样
+        assert_eq!(usage["input_tokens"], json!(10));
+        assert_eq!(usage["output_tokens"], json!(5));
+    }
+
+    #[test]
+    fn response_completed_sse_event_contains_credit_fields() {
+        let kinds = ToolKindMap::new();
+        let mut p = parsed_with_tool_calls(vec![]);
+        p.credit_usage = Some(0.99);
+        p.credit_unit = Some("credit".to_string());
+        p.credit_unit_plural = Some("credits".to_string());
+        let sse = build_responses_sse(&p, &kinds);
+        assert!(sse.contains("\"credit_usage\":0.99"));
+        assert!(sse.contains("\"credit_unit\":\"credit\""));
+        assert!(sse.contains("\"credit_unit_plural\":\"credits\""));
     }
 }

--- a/src/anthropic/stream.rs
+++ b/src/anthropic/stream.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::kiro::model::events::Event;
+use crate::kiro::model::events::{Event, MeteringEvent};
 
 /// thinking 块的 signature 占位字符串
 ///
@@ -1273,6 +1273,7 @@ impl SseStateManager {
         output_tokens: i32,
         cache_creation_input_tokens: i32,
         cache_read_input_tokens: i32,
+        metering: Option<&MeteringEvent>,
     ) -> Vec<SseEvent> {
         let mut events = Vec::new();
 
@@ -1293,6 +1294,19 @@ impl SseStateManager {
         // 发送 message_delta
         if !self.message_delta_sent {
             self.message_delta_sent = true;
+            let mut usage_json = json!({
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": cache_creation_input_tokens,
+                "cache_read_input_tokens": cache_read_input_tokens
+            });
+            // 透传上游 meteringEvent 的 credit_* 字段，让客户端拿到与 Kiro
+            // 后端口径一致的计费元数据；只在收到过 meteringEvent 时才追加。
+            if let Some(m) = metering {
+                usage_json["credit_usage"] = json!(m.usage);
+                usage_json["credit_unit"] = json!(m.unit);
+                usage_json["credit_unit_plural"] = json!(m.unit_plural);
+            }
             events.push(SseEvent::new(
                 "message_delta",
                 json!({
@@ -1301,12 +1315,7 @@ impl SseStateManager {
                         "stop_reason": self.get_stop_reason(),
                         "stop_sequence": null
                     },
-                    "usage": {
-                        "input_tokens": input_tokens,
-                        "output_tokens": output_tokens,
-                        "cache_creation_input_tokens": cache_creation_input_tokens,
-                        "cache_read_input_tokens": cache_read_input_tokens
-                    }
+                    "usage": usage_json
                 }),
             ));
         }
@@ -1377,8 +1386,12 @@ pub struct StreamContext {
     /// 做互斥分摊：`input + cache_creation + cache_read == total`，避免把被缓存
     /// 覆盖的前缀重复计进 input_tokens。
     pub cache_usage: super::cache_metering::CacheUsage,
-    /// meteringEvent 上报的 credit 计费量（上游真实下发）
+    /// meteringEvent 上报的 credit 计费量（上游真实下发，多次事件累加得到本次总量）
     pub credits: f64,
+    /// 最近一次 meteringEvent 完整 payload（含 unit / unit_plural / usage）。
+    /// 透传到 message_delta.usage 的 `credit_usage` / `credit_unit` / `credit_unit_plural`
+    /// 字段，与 kiro-rs /v1/messages 行为对齐；上游只下发一次则取该次。
+    pub metering: Option<MeteringEvent>,
     /// 复读熔断：最近一次作为文本吐出的「尾行」内容（去空白）。
     /// Opus 长上下文退化时会把同一个 stray token（call/count/card）一行一行无限复读，
     /// 我们在文本出口处统计「同一短行连续重复了多少次」。
@@ -1444,6 +1457,7 @@ impl StreamContext {
             strip_thinking_leading_newline: false,
             cache_usage: super::cache_metering::CacheUsage::default(),
             credits: 0.0,
+            metering: None,
             repeat_guard_last_line: String::new(),
             repeat_guard_run: 0,
             repeat_guard_tripped: false,
@@ -1541,7 +1555,15 @@ impl StreamContext {
             Event::Metering(metering) => {
                 // 上游 meteringEvent 只下发 credit；token / cache 字段不存在。
                 self.credits += metering.usage;
-                tracing::debug!("metering credits +{:.6}", metering.usage);
+                tracing::debug!(
+                    usage = metering.usage,
+                    unit = %metering.unit,
+                    unit_plural = %metering.unit_plural,
+                    "metering credits +{:.6}", metering.usage
+                );
+                // 保留最近一次完整 payload，用于在 message_delta 里透传 credit_*
+                // 字段；如果上游真的多次下发，则以最后一次为准（与 kiro-rs 一致）。
+                self.metering = Some(metering.clone());
                 Vec::new()
             }
             Event::Error {
@@ -2459,6 +2481,7 @@ impl StreamContext {
             self.output_tokens,
             cache_creation,
             cache_read,
+            self.metering.as_ref(),
         ));
 
         // 工具调用 JSON 错误：在最终事件之后补一个 Anthropic `error` 事件，明确告知
@@ -4687,5 +4710,106 @@ mod tests {
                 && e.data["content_block"]["type"] == "redacted_thinking"
                 && e.data["content_block"]["data"] == "encrypted-thinking"
         }));
+    }
+
+    // ---- credit_usage 透传 ----
+
+    fn parse_metering(payload: &str) -> MeteringEvent {
+        serde_json::from_str(payload).unwrap()
+    }
+
+    #[test]
+    fn test_generate_final_events_omits_credit_fields_without_metering() {
+        // 没有 meteringEvent 时不应在 usage 里写 credit_* 字段。
+        let mut manager = SseStateManager::new();
+        let events = manager.generate_final_events(10, 5, 0, 0, None);
+        let delta = events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("must have message_delta");
+        let usage = &delta.data["usage"];
+        assert!(usage.get("credit_usage").is_none());
+        assert!(usage.get("credit_unit").is_none());
+        assert!(usage.get("credit_unit_plural").is_none());
+    }
+
+    #[test]
+    fn test_generate_final_events_carries_credit_fields_when_metering_present() {
+        let mut manager = SseStateManager::new();
+        let metering = parse_metering(
+            r#"{"unit":"credit","unitPlural":"credits","usage":0.75}"#,
+        );
+        let events = manager.generate_final_events(10, 5, 0, 0, Some(&metering));
+        let delta = events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("must have message_delta");
+        let usage = &delta.data["usage"];
+        assert_eq!(usage["credit_usage"], json!(0.75));
+        assert_eq!(usage["credit_unit"], json!("credit"));
+        assert_eq!(usage["credit_unit_plural"], json!("credits"));
+        // 既有字段保持原样
+        assert_eq!(usage["input_tokens"], json!(10));
+        assert_eq!(usage["output_tokens"], json!(5));
+    }
+
+    #[test]
+    fn test_stream_context_keeps_latest_metering_in_message_delta() {
+        use crate::kiro::model::events::MeteringEvent;
+
+        let mut ctx = StreamContext::new_with_thinking(
+            "claude-opus-4-7",
+            100,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
+        let _ = ctx.generate_initial_events();
+
+        // 第一次下发（异常：上游几乎只会下发一次）
+        ctx.process_kiro_event(&Event::Metering(MeteringEvent {
+            unit: "credit".into(),
+            unit_plural: "credits".into(),
+            usage: 0.10,
+        }));
+        // 第二次下发（应覆盖）
+        ctx.process_kiro_event(&Event::Metering(MeteringEvent {
+            unit: "credit".into(),
+            unit_plural: "credits".into(),
+            usage: 0.42,
+        }));
+
+        let final_events = ctx.generate_final_events();
+        let delta = final_events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("must have message_delta");
+        let usage = &delta.data["usage"];
+        assert_eq!(usage["credit_usage"], json!(0.42));
+        assert_eq!(usage["credit_unit"], json!("credit"));
+        assert_eq!(usage["credit_unit_plural"], json!("credits"));
+        // 累计 credit 仍然是两次之和
+        assert!((ctx.credits - 0.52).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_stream_context_omits_credit_fields_without_metering() {
+        let mut ctx = StreamContext::new_with_thinking(
+            "claude-opus-4-7",
+            100,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
+        let _ = ctx.generate_initial_events();
+        let final_events = ctx.generate_final_events();
+        let delta = final_events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("must have message_delta");
+        let usage = &delta.data["usage"];
+        assert!(usage.get("credit_usage").is_none());
+        assert!(usage.get("credit_unit").is_none());
+        assert!(usage.get("credit_unit_plural").is_none());
     }
 }

--- a/src/anthropic/websearch.rs
+++ b/src/anthropic/websearch.rs
@@ -548,7 +548,8 @@ fn render_websearch_response(
         let content = build_websearch_content(&query, &tool_use_id, &search_results);
         let summary = generate_search_summary(&query, &search_results);
         let output_tokens = (summary.len() as i32 + 3) / 4;
-        super::websearch_loop::render_json(&model, content, "end_turn", input_tokens, output_tokens, "")
+        // 本地 WebSearch 不走上游，不会收到 meteringEvent，因此也不带 credit_* 字段。
+        super::websearch_loop::render_json(&model, content, "end_turn", input_tokens, output_tokens, "", None)
     }
 }
 

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -20,7 +20,7 @@ use futures::{StreamExt, stream};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::kiro::model::events::Event;
+use crate::kiro::model::events::{Event, MeteringEvent};
 use crate::kiro::model::requests::kiro::KiroRequest;
 use crate::kiro::parser::decoder::EventStreamDecoder;
 use crate::kiro::provider::KiroProvider;
@@ -61,8 +61,12 @@ struct RoundOutcome {
     tool_uses: Vec<CompletedToolUse>,
     /// Actual input tokens computed from contextUsageEvent
     context_input_tokens: Option<i32>,
-    /// Cumulative credits from meteringEvent
+    /// Cumulative credits from meteringEvent (sum of usage across rounds)
     credits: f64,
+    /// 最近一次 meteringEvent 完整 payload（含 unit / unit_plural / usage）。
+    /// 在 run_web_search_loop 出口处透传到响应 usage 字段；如果上游多次下发
+    /// 则取最后一次（与 /v1/messages 非流 / 流式路径一致）。
+    last_metering: Option<MeteringEvent>,
     /// stop_reason override (max_tokens / model_context_window_exceeded)
     stop_reason_override: Option<String>,
     /// True if the upstream stream ended due to a read error, so the decoded
@@ -152,6 +156,7 @@ async fn decode_round(
     let mut tool_uses: Vec<CompletedToolUse> = Vec::new();
     let mut context_input_tokens: Option<i32> = None;
     let mut credits = 0.0;
+    let mut last_metering: Option<MeteringEvent> = None;
     let mut stop_reason_override: Option<String> = None;
     let mut stream_error = false;
 
@@ -204,7 +209,10 @@ async fn decode_round(
                         stop_reason_override = Some("model_context_window_exceeded".to_string());
                     }
                 }
-                Event::Metering(m) => credits += m.usage,
+                Event::Metering(m) => {
+                    credits += m.usage;
+                    last_metering = Some(m.clone());
+                }
                 Event::Exception { exception_type, .. } => {
                     if exception_type == "ContentLengthExceededException" {
                         stop_reason_override = Some("max_tokens".to_string());
@@ -240,6 +248,7 @@ async fn decode_round(
         tool_uses,
         context_input_tokens,
         credits,
+        last_metering,
         stop_reason_override,
         stream_error,
         // Populated by the caller (run_round), which holds ConversionResult::known_tool_names.
@@ -591,6 +600,7 @@ pub(super) async fn run_web_search_loop(
     let mut last_credential_id: u64 = 0;
     let mut last_context_input: Option<i32> = None;
     let mut total_credits = 0.0;
+    let mut latest_metering: Option<MeteringEvent> = None;
     let mut all_thinking = String::new();
 
     for round_idx in 0..=MAX_WEB_SEARCH_ROUNDS {
@@ -613,6 +623,11 @@ pub(super) async fn run_web_search_loop(
             last_credential_id = credential_id;
             last_context_input = round.context_input_tokens.or(last_context_input);
             total_credits += round.credits;
+            // 跨 round 保留最近一次 meteringEvent，多 round 时取最后一次
+            // (clone 以避免与 empty_tool_result_disposition 后续对 round 的借用冲突)。
+            if let Some(ref m) = round.last_metering {
+                latest_metering = Some(m.clone());
+            }
 
             match empty_tool_result_disposition(&payload, &round, empty_retries) {
                 EmptyToolResultDisposition::Accept => {}
@@ -761,7 +776,14 @@ pub(super) async fn run_web_search_loop(
         );
 
         return if stream_client {
-            render_sse(&payload.model, content, &stop_reason, final_input, output_tokens)
+            render_sse(
+                &payload.model,
+                content,
+                &stop_reason,
+                final_input,
+                output_tokens,
+                latest_metering.as_ref(),
+            )
         } else {
             render_json(
                 &payload.model,
@@ -770,6 +792,7 @@ pub(super) async fn run_web_search_loop(
                 final_input,
                 output_tokens,
                 &all_thinking,
+                latest_metering.as_ref(),
             )
         };
     }
@@ -797,7 +820,21 @@ pub(crate) fn render_json(
     input_tokens: i32,
     output_tokens: i32,
     thinking: &str,
+    metering: Option<&MeteringEvent>,
 ) -> Response {
+    let mut usage = json!({
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0
+    });
+    // 透传上游 meteringEvent 的 credit_* 字段，让客户端拿到与 Kiro 后端口径
+    // 一致的计费元数据；只在收到过 meteringEvent 时才追加。
+    if let Some(m) = metering {
+        usage["credit_usage"] = json!(m.usage);
+        usage["credit_unit"] = json!(m.unit);
+        usage["credit_unit_plural"] = json!(m.unit_plural);
+    }
     let mut body = json!({
         "id": format!("msg_{}", Uuid::new_v4().to_string().replace('-', "")),
         "type": "message",
@@ -806,12 +843,7 @@ pub(crate) fn render_json(
         "model": model,
         "stop_reason": stop_reason,
         "stop_sequence": null,
-        "usage": {
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0
-        }
+        "usage": usage
     });
     if !thinking.is_empty() {
         body["kiro_thinking"] = json!(thinking);
@@ -826,8 +858,9 @@ pub(crate) fn render_sse(
     stop_reason: &str,
     input_tokens: i32,
     output_tokens: i32,
+    metering: Option<&MeteringEvent>,
 ) -> Response {
-    let events = build_sse_events(model, content, stop_reason, input_tokens, output_tokens);
+    let events = build_sse_events(model, content, stop_reason, input_tokens, output_tokens, metering);
     let stream = stream::iter(
         events
             .into_iter()
@@ -849,6 +882,7 @@ fn build_sse_events(
     stop_reason: &str,
     input_tokens: i32,
     output_tokens: i32,
+    metering: Option<&MeteringEvent>,
 ) -> Vec<SseEvent> {
     let mut events = Vec::new();
     let message_id = format!(
@@ -926,10 +960,17 @@ fn build_sse_events(
         }
     }
 
+    let mut message_delta_usage = json!({ "output_tokens": output_tokens });
+    // 透传上游 meteringEvent 的 credit_* 字段（仅在拿到 meteringEvent 时）。
+    if let Some(m) = metering {
+        message_delta_usage["credit_usage"] = json!(m.usage);
+        message_delta_usage["credit_unit"] = json!(m.unit);
+        message_delta_usage["credit_unit_plural"] = json!(m.unit_plural);
+    }
     events.push(SseEvent::new("message_delta", json!({
         "type": "message_delta",
         "delta": {"stop_reason": stop_reason},
-        "usage": {"output_tokens": output_tokens}
+        "usage": message_delta_usage
     })));
     events.push(SseEvent::new("message_stop", json!({"type": "message_stop"})));
 
@@ -993,6 +1034,7 @@ mod tests {
             tool_uses,
             context_input_tokens: None,
             credits: 0.0,
+            last_metering: None,
             stop_reason_override: None,
             stream_error: false,
             known_tool_names: std::collections::HashSet::new(),
@@ -1180,7 +1222,7 @@ mod tests {
             json!({"type": "text", "text": "done"}),
             json!({"type": "tool_use", "id": "toolu_exec", "name": "exec", "input": {"cmd": "ls"}}),
         ];
-        let events = build_sse_events("claude-sonnet-4-8", content, "tool_use", 10, 5);
+        let events = build_sse_events("claude-sonnet-4-8", content, "tool_use", 10, 5, None);
 
         // Must contain message_start / message_delta(stop_reason) / message_stop
         assert_eq!(events.first().unwrap().event, "message_start");
@@ -1683,5 +1725,111 @@ mod tests {
             "distinct inputs must both be kept. content={:?}",
             content
         );
+    }
+
+    // ---- credit_usage 透传：run_web_search_loop 路径 ----
+
+    fn metering_event(usage: f64) -> MeteringEvent {
+        MeteringEvent {
+            unit: "credit".to_string(),
+            unit_plural: "credits".to_string(),
+            usage,
+        }
+    }
+
+    #[test]
+    fn render_json_carries_credit_fields_when_metering_present() {
+        let content = vec![json!({"type": "text", "text": "ok"})];
+        let metering = metering_event(0.42);
+        let resp = render_json(
+            "claude-opus-4-7",
+            content,
+            "end_turn",
+            10,
+            5,
+            "",
+            Some(&metering),
+        );
+        // 把 Response 的 body 序列化为 JSON 再断言。
+        let body = resp.into_body();
+        let bytes = futures::executor::block_on(async {
+            axum::body::to_bytes(body, 64 * 1024).await.unwrap()
+        });
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        let usage = &v["usage"];
+        assert_eq!(usage["credit_usage"], json!(0.42));
+        assert_eq!(usage["credit_unit"], json!("credit"));
+        assert_eq!(usage["credit_unit_plural"], json!("credits"));
+        // 原有字段保持原样
+        assert_eq!(usage["input_tokens"], json!(10));
+        assert_eq!(usage["output_tokens"], json!(5));
+    }
+
+    #[test]
+    fn render_json_omits_credit_fields_without_metering() {
+        let content = vec![json!({"type": "text", "text": "ok"})];
+        let resp = render_json(
+            "claude-opus-4-7",
+            content,
+            "end_turn",
+            10,
+            5,
+            "",
+            None,
+        );
+        let body = resp.into_body();
+        let bytes = futures::executor::block_on(async {
+            axum::body::to_bytes(body, 64 * 1024).await.unwrap()
+        });
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        let usage = &v["usage"];
+        assert!(usage.get("credit_usage").is_none());
+        assert!(usage.get("credit_unit").is_none());
+        assert!(usage.get("credit_unit_plural").is_none());
+    }
+
+    #[test]
+    fn build_sse_events_carries_credit_fields_in_message_delta() {
+        let content = vec![json!({"type": "text", "text": "ok"})];
+        let metering = metering_event(0.99);
+        let events = build_sse_events(
+            "claude-opus-4-7",
+            content,
+            "end_turn",
+            10,
+            5,
+            Some(&metering),
+        );
+        let delta = events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("must have message_delta");
+        let usage = &delta.data["usage"];
+        assert_eq!(usage["credit_usage"], json!(0.99));
+        assert_eq!(usage["credit_unit"], json!("credit"));
+        assert_eq!(usage["credit_unit_plural"], json!("credits"));
+        // 原有字段保持原样
+        assert_eq!(usage["output_tokens"], json!(5));
+    }
+
+    #[test]
+    fn build_sse_events_omits_credit_fields_without_metering() {
+        let content = vec![json!({"type": "text", "text": "ok"})];
+        let events = build_sse_events(
+            "claude-opus-4-7",
+            content,
+            "end_turn",
+            10,
+            5,
+            None,
+        );
+        let delta = events
+            .iter()
+            .find(|e| e.event == "message_delta")
+            .expect("must have message_delta");
+        let usage = &delta.data["usage"];
+        assert!(usage.get("credit_usage").is_none());
+        assert!(usage.get("credit_unit").is_none());
+        assert!(usage.get("credit_unit_plural").is_none());
     }
 }

--- a/src/kiro/model/events/metering.rs
+++ b/src/kiro/model/events/metering.rs
@@ -1,10 +1,12 @@
 //! 计费事件
 //!
 //! Kiro 上游 meteringEvent payload 形如 `{"unit":"credit","unitPlural":"credits","usage":<f64>}`，
-//! `usage` 是本次请求消耗的 credit 数。中转层据此累计每个时间窗的 credit 总量。
+//! `usage` 是本次请求消耗的 credit 数。中转层据此累计每个时间窗的 credit 总量，
+//! 并把最近一次事件原样透传到 Anthropic / OpenAI 响应的 usage 字段（`credit_usage` /
+//! `credit_unit` / `credit_unit_plural`），让客户端拿到与 Kiro 后端口径一致的计费元数据。
 //!
-//! 上游 **不下发** token / cache 字段（实测确认），所以这里**只**解析 `usage`，
-//! 不做任何字段名候选兼容；解析失败直接由 ParseError 上抛。
+//! 上游 **不下发** token / cache 字段（实测确认），所以这里**只**解析 unit / unitPlural /
+//! usage，不做任何字段名候选兼容；解析失败直接由 ParseError 上抛。
 
 use serde::Deserialize;
 
@@ -17,6 +19,12 @@ use super::base::EventPayload;
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MeteringEvent {
+    /// 计费单位，当前固定为 `credit`
+    #[serde(default)]
+    pub unit: String,
+    /// 计费单位复数，当前固定为 `credits`
+    #[serde(default)]
+    pub unit_plural: String,
     /// 本次请求消耗的 credit 数（与计费单位一致，浮点）
     #[serde(default)]
     pub usage: f64,
@@ -39,6 +47,8 @@ mod tests {
             r#"{"unit":"credit","unitPlural":"credits","usage":0.0169543708291874}"#,
         )
         .unwrap();
+        assert_eq!(v.unit, "credit");
+        assert_eq!(v.unit_plural, "credits");
         assert!((v.usage - 0.0169543708291874).abs() < 1e-12);
     }
 
@@ -46,6 +56,16 @@ mod tests {
     fn missing_usage_is_zero() {
         let v: MeteringEvent =
             serde_json::from_str(r#"{"unit":"credit"}"#).unwrap();
+        assert_eq!(v.unit, "credit");
+        assert_eq!(v.unit_plural, "");
+        assert_eq!(v.usage, 0.0);
+    }
+
+    #[test]
+    fn empty_payload_defaults_all_fields() {
+        let v: MeteringEvent = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(v.unit, "");
+        assert_eq!(v.unit_plural, "");
         assert_eq!(v.usage, 0.0);
     }
 }


### PR DESCRIPTION
Forward the upstream meteringEvent's usage / unit / unitPlural into the Anthropic and OpenAI response usage object (credit_usage / credit_unit / credit_unit_plural), so clients get billing metadata consistent with the Kiro backend, matching kiro-rs behavior.

Wired through all four exits: handlers (non-stream), stream (streaming), openai, and websearch_loop. Fields are only appended when a meteringEvent was actually received.

usage field in response is like this:
```json
    "usage": {
      "credit_unit": "credit",
      "credit_unit_plural": "credits",
      "credit_usage": 0.00415129960199005,
      "input_tokens": 1753,
      "input_tokens_details": {
        "cached_tokens": 0
      },
      "output_tokens": 10,
      "output_tokens_details": {
        "reasoning_tokens": 0
      },
      "total_tokens": 1763
    }
```