### PR TITLE
feat: 单账号每分钟请求次数（RPM）主动限流

### DIFF
--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -448,6 +448,25 @@ export async function setAccountThrottleConfig(
   return data
 }
 
+export interface AccountRpmLimitConfig {
+  enabled: boolean
+  limit: number
+}
+
+// 获取单账号 RPM 限流配置
+export async function getAccountRpmLimitConfig(): Promise<AccountRpmLimitConfig> {
+  const { data } = await api.get<AccountRpmLimitConfig>('/config/account-rpm-limit')
+  return data
+}
+
+// 更新单账号 RPM 限流配置
+export async function setAccountRpmLimitConfig(
+  patch: Partial<AccountRpmLimitConfig>,
+): Promise<AccountRpmLimitConfig> {
+  const { data } = await api.put<AccountRpmLimitConfig>('/config/account-rpm-limit', patch)
+  return data
+}
+
 // 自愈治理配置。suspendedDetectionEnabled/enabled/minIntervalSecs/maxConsecutiveRounds
 // 可写；consecutiveRounds 为凭据最大连续轮数，totalCount 为累计恢复凭据次数。
 export interface SelfHealConfig {

--- a/admin-ui/src/components/topbar-tools.tsx
+++ b/admin-ui/src/components/topbar-tools.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useState, type ComponentPropsWithoutRef } from '
 import {
   Activity, RefreshCw, UploadCloud, Settings, Key, Wand2, Eye, EyeOff, Copy,
   MoreHorizontal, ShieldAlert, ShieldCheck, Boxes, HeartPulse, HeartCrack,
+  Gauge,
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -19,6 +20,7 @@ import {
 import {
   useLoadBalancingMode, useSetLoadBalancingMode,
   useAccountThrottleConfig, useSetAccountThrottleConfig,
+  useAccountRpmLimitConfig, useSetAccountRpmLimitConfig,
   useSelfHealConfig, useSetSelfHealConfig,
 } from '@/hooks/use-credentials'
 import { useUpdateCheck } from '@/hooks/use-update-check'
@@ -260,6 +262,7 @@ function FullTools({ controls }: { controls: ToolControls }) {
         onChangeCooldown={controls.updateCooldown}
       />
       <SelfHealConfigButton />
+      <AccountRpmLimitButton />
       <ModelsButton onOpen={controls.openModels} />
       <RefreshButton onRefresh={controls.handleRefresh} />
       <ImageUpdateButton controls={controls} />
@@ -308,6 +311,7 @@ function CompactTools({ controls }: { controls: ToolControls }) {
         </DropdownMenuItem>
         <ThrottleCompactItems {...throttleProps} />
         <SelfHealCompactItems />
+        <AccountRpmLimitCompactItems />
         <DropdownMenuLabel>密钥管理</DropdownMenuLabel>
         <DropdownMenuItem onSelect={controls.openKeyDialog}>
           <Key />修改登录API密钥（管理面板登录）
@@ -848,6 +852,161 @@ function SelfHealCompactItems() {
           : enabled
             ? `关闭自愈（连续 ${config?.consecutiveRounds ?? 0} 轮）`
             : '开启全账号自愈'}
+      </DropdownMenuItem>
+    </>
+  )
+}
+
+const RPM_LIMIT_PRESETS = [10, 30, 60, 120, 300]
+const MIN_RPM_LIMIT = 1
+const MAX_RPM_LIMIT = 100000
+
+/**
+ * 单账号 RPM 主动限流：开关 + 每分钟上限设置（紧凑下拉）。
+ *
+ * 开启后每个账号独立维护 60 秒滑动窗口，达到上限时该账号被临时排除出候选，
+ * 请求自动故障转移到下一个可用账号；全部超限时返回 429。
+ */
+function AccountRpmLimitButton() {
+  const { data: config, isLoading } = useAccountRpmLimitConfig()
+  const { mutate, isPending } = useSetAccountRpmLimitConfig()
+  const [open, setOpen] = useState(false)
+  const [limitInput, setLimitInput] = useState('')
+
+  useEffect(() => {
+    if (!open) setLimitInput('')
+  }, [open])
+
+  const enabled = config?.enabled ?? false
+  const limit = config?.limit ?? 60
+  const busy = isLoading || isPending
+
+  const save = (patch: { enabled?: boolean; limit?: number }, msg: string) => {
+    mutate(patch, {
+      onSuccess: () => toast.success(msg),
+      onError: (err) => toast.error(`保存失败: ${extractErrorMessage(err)}`),
+    })
+  }
+
+  const submitLimit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const n = parseInt(limitInput, 10)
+    if (Number.isNaN(n) || n < MIN_RPM_LIMIT || n > MAX_RPM_LIMIT) {
+      toast.error(`请输入 ${MIN_RPM_LIMIT}-${MAX_RPM_LIMIT} 之间的次数`)
+      return
+    }
+    save({ limit: n }, `单账号 RPM 上限已设为 ${n} 次/分钟`)
+    setLimitInput('')
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          title={enabled ? `单账号限流：${limit} 次/分钟` : '单账号限流：已关闭'}
+        >
+          <Gauge className={enabled ? 'h-3.5 w-3.5 text-emerald-600' : 'h-3.5 w-3.5 text-muted-foreground'} />
+          <span className="hidden md:inline">
+            {isLoading ? '限流…' : enabled ? `限流 ${limit}/分` : '限流关'}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuLabel>单账号每分钟请求限流</DropdownMenuLabel>
+        <div className="px-2 pb-2">
+          <div className="flex items-center justify-between gap-2 rounded-md bg-secondary/40 px-2.5 py-2">
+            <div className="text-xs">
+              <div className="font-medium">{enabled ? '已启用' : '已关闭'}</div>
+              <div className="text-muted-foreground leading-snug">
+                单账号超过每分钟上限时临时跳过并切换到下一个可用账号
+              </div>
+            </div>
+            <Switch
+              checked={enabled}
+              disabled={busy}
+              onCheckedChange={(v) => save({ enabled: v }, v ? '已开启单账号限流' : '已关闭单账号限流')}
+            />
+          </div>
+        </div>
+
+        <DropdownMenuLabel className="pt-1">每分钟上限</DropdownMenuLabel>
+        <div className={cooldownPanelClassName(enabled)}>
+          <div className="grid grid-cols-3 gap-1.5">
+            {RPM_LIMIT_PRESETS.map((n) => (
+              <Button
+                key={n}
+                size="sm"
+                variant={limit === n ? 'default' : 'outline'}
+                className="h-7 text-xs"
+                disabled={busy || !enabled}
+                onClick={() => save({ limit: n }, `单账号 RPM 上限已设为 ${n} 次/分钟`)}
+              >
+                {n}
+              </Button>
+            ))}
+          </div>
+
+          <DropdownMenuLabel className="px-0 pt-2">自定义（次/分钟）</DropdownMenuLabel>
+          <form onSubmit={submitLimit} className="mt-1 flex items-center gap-1.5">
+            <Input
+              type="number"
+              min={MIN_RPM_LIMIT}
+              max={MAX_RPM_LIMIT}
+              placeholder={`当前 ${limit} 次`}
+              value={limitInput}
+              onChange={(e) => setLimitInput(e.target.value)}
+              disabled={busy || !enabled}
+              className="h-7 text-xs"
+            />
+            <span className="text-xs text-muted-foreground">次</span>
+            <Button
+              type="submit"
+              size="sm"
+              variant="outline"
+              className="h-7 text-xs"
+              disabled={busy || !enabled || !limitInput.trim()}
+            >
+              保存
+            </Button>
+          </form>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/** 紧凑模式（下拉菜单内）的单账号限流开关项 */
+function AccountRpmLimitCompactItems() {
+  const { data: config, isLoading } = useAccountRpmLimitConfig()
+  const { mutate, isPending } = useSetAccountRpmLimitConfig()
+  const enabled = config?.enabled ?? false
+  const limit = config?.limit ?? 60
+  const busy = isLoading || isPending
+
+  return (
+    <>
+      <DropdownMenuLabel>单账号限流</DropdownMenuLabel>
+      <DropdownMenuItem
+        disabled={busy}
+        onSelect={() =>
+          mutate(
+            { enabled: !enabled },
+            {
+              onSuccess: () => toast.success(!enabled ? '已开启单账号限流' : '已关闭单账号限流'),
+              onError: (err) => toast.error(`切换失败: ${extractErrorMessage(err)}`),
+            },
+          )
+        }
+      >
+        <Gauge />
+        {isLoading
+          ? '限流加载中'
+          : enabled
+            ? `关闭限流（${limit} 次/分钟）`
+            : '开启单账号限流'}
       </DropdownMenuItem>
     </>
   )

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -18,6 +18,8 @@ import {
   setLoadBalancingMode,
   getAccountThrottleConfig,
   setAccountThrottleConfig,
+  getAccountRpmLimitConfig,
+  setAccountRpmLimitConfig,
   getSelfHealConfig,
   setSelfHealConfig,
   getLogGovernanceConfig,
@@ -234,6 +236,25 @@ export function useSetAccountThrottleConfig() {
     mutationFn: setAccountThrottleConfig,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['accountThrottleConfig'] })
+    },
+  })
+}
+
+// 获取单账号 RPM 限流配置
+export function useAccountRpmLimitConfig() {
+  return useQuery({
+    queryKey: ['accountRpmLimitConfig'],
+    queryFn: getAccountRpmLimitConfig,
+  })
+}
+
+// 更新单账号 RPM 限流配置
+export function useSetAccountRpmLimitConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: setAccountRpmLimitConfig,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accountRpmLimitConfig'] })
     },
   })
 }

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -23,7 +23,8 @@ use super::{
         BatchAddProxyRequest, BatchImportEvent, BatchImportRequest, BatchImportSummary,
         ClientKeyItem, ClientKeysResponse, CompleteSocialLoginRequest, CreateClientKeyRequest,
         CreateClientKeyResponse, GlobalProxyResponse, ModelTestRequest,
-        SetAccountThrottleConfigRequest, SetDisabledRequest, SetGlobalProxyRequest,
+        SetAccountRpmLimitConfigRequest, SetAccountThrottleConfigRequest, SetDisabledRequest,
+        SetGlobalProxyRequest,
         SetLoadBalancingModeRequest, SetLogGovernanceConfigRequest, SetPriorityRequest,
         SetSelfHealConfigRequest,
         SetUpdateConfigRequest, StartIdcLoginRequest, StartSocialLoginRequest, SuccessResponse,
@@ -559,6 +560,24 @@ pub async fn set_account_throttle_config(
     Json(payload): Json<SetAccountThrottleConfigRequest>,
 ) -> impl IntoResponse {
     match state.service.set_account_throttle_config(payload) {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// GET /api/admin/config/account-rpm-limit
+/// 获取单账号 RPM 限流配置
+pub async fn get_account_rpm_limit_config(State(state): State<AdminState>) -> impl IntoResponse {
+    Json(state.service.get_account_rpm_limit_config())
+}
+
+/// PUT /api/admin/config/account-rpm-limit
+/// 更新单账号 RPM 限流配置
+pub async fn set_account_rpm_limit_config(
+    State(state): State<AdminState>,
+    Json(payload): Json<SetAccountRpmLimitConfigRequest>,
+) -> impl IntoResponse {
+    match state.service.set_account_rpm_limit_config(payload) {
         Ok(response) => Json(response).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -14,13 +14,15 @@ use super::{
         check_proxy, check_rate_limit, check_update, clear_throttle, complete_social_login,
         complete_social_relogin, create_client_key, create_group, delete_client_key,
         delete_credential, delete_group, delete_proxy, disable_quota_exceeded, enable_overage_all,
-        export_credentials, force_refresh_token, get_account_throttle_config, get_all_credentials,
+        export_credentials, force_refresh_token, get_account_rpm_limit_config,
+        get_account_throttle_config, get_all_credentials,
         get_credential_balance, get_credential_models, get_current_models, get_global_proxy,
         get_load_balancing_mode, get_log_governance_config, get_proxy_pool, get_self_heal_config,
         get_update_config, list_client_keys, list_groups, list_traces, poll_idc_login,
         poll_idc_relogin, poll_social_login, poll_social_relogin, pull_update_image,
         reset_all_success_count, reset_client_key_stats, reset_failure_count, reset_success_count,
-        rollback_image_update, rotate_client_key, set_account_throttle_config,
+        rollback_image_update, rotate_client_key, set_account_rpm_limit_config,
+        set_account_throttle_config,
         set_client_key_disabled, set_credential_disabled, set_credential_overage,
         set_credential_priority, set_global_proxy, set_load_balancing_mode,
         set_log_governance_config, set_proxy_enabled, set_self_heal_config, set_update_config,
@@ -107,6 +109,10 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route(
             "/config/account-throttle",
             get(get_account_throttle_config).put(set_account_throttle_config),
+        )
+        .route(
+            "/config/account-rpm-limit",
+            get(get_account_rpm_limit_config).put(set_account_rpm_limit_config),
         )
         .route(
             "/config/self-heal",

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -32,7 +32,8 @@ use crate::model::config::Config;
 use super::error::AdminServiceError;
 use super::proxy_pool::{GetUrlResult, ProxyPoolManager};
 use super::types::{
-    AccountThrottleConfigResponse, AddCredentialRequest, AddCredentialResponse, AssignProxyRequest,
+    AccountRpmLimitConfigResponse, AccountThrottleConfigResponse, AddCredentialRequest,
+    AddCredentialResponse, AssignProxyRequest,
     AssignRoundRobinResponse, AvailableModelItem, AvailableModelsResponse, BalanceResponse,
     BatchAddProxyRequest, BatchImportEvent, CheckRateLimitRequest, CredentialStatusItem,
     CredentialsExportResponse, CredentialsStatusResponse, EnableOverageAllResult, ExportedAccount,
@@ -40,7 +41,8 @@ use super::types::{
     LogGovernanceConfigResponse, ModelSelectionMode, ModelTestRequest, ModelTestResponse,
     PollIdcLoginResponse, ProxyCheckAllResponse, ProxyCheckResponse, ProxyPoolEntry,
     ProxyPoolResponse, QuotaExceededResult, SelfHealConfigResponse,
-    SetAccountThrottleConfigRequest, SetLoadBalancingModeRequest, SetLogGovernanceConfigRequest,
+    SetAccountRpmLimitConfigRequest, SetAccountThrottleConfigRequest, SetLoadBalancingModeRequest,
+    SetLogGovernanceConfigRequest,
     SetSelfHealConfigRequest, SetUpdateConfigRequest, StartIdcLoginRequest, StartIdcLoginResponse,
     StartSocialLoginRequest, StartSocialLoginResponse, UpdateCheckInfo, UpdateConfigResponse,
     UpdateCredentialRequest, UpdateRefreshTokenRequest,
@@ -2065,6 +2067,30 @@ impl AdminService {
             .map_err(|e| AdminServiceError::InvalidCredential(e.to_string()))?;
 
         Ok(self.get_account_throttle_config())
+    }
+
+    /// 获取单账号 RPM 限流配置
+    pub fn get_account_rpm_limit_config(&self) -> AccountRpmLimitConfigResponse {
+        let (enabled, limit) = self.token_manager.get_account_rpm_limit_config();
+        AccountRpmLimitConfigResponse { enabled, limit }
+    }
+
+    /// 更新单账号 RPM 限流配置
+    pub fn set_account_rpm_limit_config(
+        &self,
+        req: SetAccountRpmLimitConfigRequest,
+    ) -> Result<AccountRpmLimitConfigResponse, AdminServiceError> {
+        if req.enabled.is_none() && req.limit.is_none() {
+            return Err(AdminServiceError::InvalidCredential(
+                "至少提供 enabled 或 limit 一个字段".to_string(),
+            ));
+        }
+
+        self.token_manager
+            .set_account_rpm_limit_config(req.enabled, req.limit)
+            .map_err(|e| AdminServiceError::InvalidCredential(e.to_string()))?;
+
+        Ok(self.get_account_rpm_limit_config())
     }
 
     /// 获取自愈治理配置

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -480,6 +480,28 @@ pub struct SetAccountThrottleConfigRequest {
     pub cooldown_secs: Option<u64>,
 }
 
+/// 单账号 RPM 限流配置响应
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountRpmLimitConfigResponse {
+    /// 是否启用单账号 RPM 主动限流
+    pub enabled: bool,
+    /// 每账号每分钟请求次数上限
+    pub limit: u32,
+}
+
+/// 更新单账号 RPM 限流配置
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetAccountRpmLimitConfigRequest {
+    /// 是否启用限流；缺省表示不修改
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// 每分钟上限；缺省表示不修改，1..=100000
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
 /// 自愈治理配置响应
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::{Mutex as TokioMutex, Semaphore};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -898,6 +898,10 @@ struct CredentialEntry {
     /// `Some(t)` 且 `t > now()` 时视为不可用；`t <= now()` 时自动恢复。
     /// 不持久化，进程重启后清空。
     throttled_until: Option<Instant>,
+    /// RPM 主动限流的滑动窗口：最近 60 秒内被选中发起请求的时间戳队列。
+    /// 队列长度达到 `account_rpm_limit` 时该凭据本窗口内被排除出候选。
+    /// 不持久化，进程重启后清空；限流关闭时始终为空。
+    rpm_window: VecDeque<Instant>,
     /// 当前凭据连续执行自愈的轮数。同一凭据成功后清零。
     self_heal_consecutive_rounds: u32,
     /// 当前凭据累计被自愈恢复的次数。
@@ -917,6 +921,7 @@ impl CredentialEntry {
         self.disabled = false;
         self.disabled_reason = None;
         self.throttled_until = None;
+        self.rpm_window.clear();
         self.clear_self_heal_streak();
     }
 }
@@ -1142,6 +1147,10 @@ pub struct MultiTokenManager {
     account_throttle_failover: AtomicBool,
     /// 账号级风控冷却时长（秒，运行时可修改）
     account_throttle_cooldown_secs: AtomicU64,
+    /// 单账号 RPM 主动限流开关（运行时可修改）
+    account_rpm_limit_enabled: AtomicBool,
+    /// 单账号每分钟请求次数上限（运行时可修改）
+    account_rpm_limit: AtomicU32,
     /// 是否识别 403 封禁文案并立即禁用（运行时可修改）
     suspended_detection_enabled: AtomicBool,
     /// 全账号自愈总开关（运行时可修改）
@@ -1168,6 +1177,9 @@ pub struct MultiTokenManager {
 
 /// 每个凭据最大 API 调用失败次数
 const MAX_FAILURES_PER_CREDENTIAL: u32 = 3;
+
+/// 单账号 RPM 限流的滑动窗口长度（秒）。固定 60 秒 = 每分钟。
+const RPM_WINDOW_SECS: u64 = 60;
 /// 统计数据持久化防抖间隔
 const STATS_SAVE_DEBOUNCE: StdDuration = StdDuration::from_secs(30);
 
@@ -1309,6 +1321,7 @@ impl MultiTokenManager {
                     success_count: 0,
                     last_used_at: None,
                     throttled_until: None,
+                    rpm_window: VecDeque::new(),
                     self_heal_consecutive_rounds: cred.self_heal_consecutive_rounds,
                     self_heal_total_count: cred.self_heal_total_count,
                     last_self_heal_at,
@@ -1360,6 +1373,8 @@ impl MultiTokenManager {
         let load_balancing_mode = config.load_balancing_mode.clone();
         let throttle_failover = config.account_throttle_failover;
         let throttle_cooldown_secs = config.account_throttle_cooldown_secs;
+        let rpm_limit_enabled = config.account_rpm_limit_enabled;
+        let rpm_limit = config.account_rpm_limit;
         let suspended_detection_enabled = config.suspended_detection_enabled;
         let self_heal_enabled = config.self_heal_enabled;
         let self_heal_min_interval_secs = config.self_heal_min_interval_secs;
@@ -1379,6 +1394,8 @@ impl MultiTokenManager {
             load_balancing_mode: Mutex::new(load_balancing_mode),
             account_throttle_failover: AtomicBool::new(throttle_failover),
             account_throttle_cooldown_secs: AtomicU64::new(throttle_cooldown_secs),
+            account_rpm_limit_enabled: AtomicBool::new(rpm_limit_enabled),
+            account_rpm_limit: AtomicU32::new(rpm_limit),
             suspended_detection_enabled: AtomicBool::new(suspended_detection_enabled),
             self_heal_enabled: AtomicBool::new(self_heal_enabled),
             self_heal_min_interval_secs: AtomicU64::new(self_heal_min_interval_secs),
@@ -1700,8 +1717,56 @@ impl MultiTokenManager {
                 .throttled_until
                 .map(|until| until > now)
                 .unwrap_or(false)
+            && !self.rpm_exceeded(entry, now)
             && credential_matches_request(&entry.credentials, model, group)
             && self.cached_model_support(entry.id, model) != CachedModelSupport::Unsupported
+    }
+
+    /// 判断凭据在当前 60 秒滑动窗口内是否已达到 RPM 上限。
+    ///
+    /// 限流未开启时恒为 `false`（不参与调度判断）。只读判断，不修改窗口；
+    /// 过期时间戳的实际清理发生在 [`Self::record_request`]。
+    fn rpm_exceeded(&self, entry: &CredentialEntry, now: Instant) -> bool {
+        if !self.account_rpm_limit_enabled.load(Ordering::Relaxed) {
+            return false;
+        }
+        let limit = self.account_rpm_limit.load(Ordering::Relaxed);
+        if limit == 0 {
+            return false;
+        }
+        let window = StdDuration::from_secs(RPM_WINDOW_SECS);
+        let fresh = entry
+            .rpm_window
+            .iter()
+            .filter(|&&ts| now.duration_since(ts) < window)
+            .count();
+        fresh as u32 >= limit
+    }
+
+    /// 记录一次凭据被选中发起请求：先剔除窗口外的旧时间戳，再压入当前时间。
+    ///
+    /// 限流未开启时清空窗口并直接返回，避免关闭期间残留计数在重新开启后误判。
+    fn record_request(&self, id: u64) {
+        let now = Instant::now();
+        let window = StdDuration::from_secs(RPM_WINDOW_SECS);
+        let mut entries = self.entries.lock();
+        let Some(entry) = entries.iter_mut().find(|e| e.id == id) else {
+            return;
+        };
+        if !self.account_rpm_limit_enabled.load(Ordering::Relaxed) {
+            if !entry.rpm_window.is_empty() {
+                entry.rpm_window.clear();
+            }
+            return;
+        }
+        while let Some(&front) = entry.rpm_window.front() {
+            if now.duration_since(front) >= window {
+                entry.rpm_window.pop_front();
+            } else {
+                break;
+            }
+        }
+        entry.rpm_window.push_back(now);
     }
 
     fn has_available_for_request(
@@ -1829,6 +1894,7 @@ impl MultiTokenManager {
                     let confirmed_available = entries.iter().any(|e| {
                         !e.disabled
                             && !e.throttled_until.map(|t| t > now).unwrap_or(false)
+                            && !self.rpm_exceeded(e, now)
                             && credential_matches_request(&e.credentials, model, group)
                             && self.cached_model_support(e.id, model)
                                 == CachedModelSupport::Confirmed
@@ -1840,6 +1906,7 @@ impl MultiTokenManager {
                             e.id == current_id
                                 && !e.disabled
                                 && !e.throttled_until.map(|t| t > now).unwrap_or(false)
+                                && !self.rpm_exceeded(e, now)
                                 && credential_matches_request(&e.credentials, model, group)
                                 && model_support != CachedModelSupport::Unsupported
                                 && (!confirmed_available
@@ -1882,6 +1949,10 @@ impl MultiTokenManager {
             // 尝试获取/刷新 Token
             match self.try_ensure_token(id, &credentials).await {
                 Ok(ctx) => {
+                    // 仅真实业务请求计入 RPM 窗口；Admin 只读模型发现不消耗额度。
+                    if update_current {
+                        self.record_request(id);
+                    }
                     return Ok((ctx, is_balanced));
                 }
                 Err(e) => {
@@ -3676,6 +3747,7 @@ impl MultiTokenManager {
                 success_count: 0,
                 last_used_at: None,
                 throttled_until: None,
+                rpm_window: VecDeque::new(),
                 self_heal_consecutive_rounds: 0,
                 self_heal_total_count: 0,
                 last_self_heal_at: None,
@@ -4156,6 +4228,74 @@ impl MultiTokenManager {
         })
     }
 
+    /// 获取单账号 RPM 限流配置（Admin API）。返回：(是否启用, 每分钟上限)。
+    pub fn get_account_rpm_limit_config(&self) -> (bool, u32) {
+        (
+            self.account_rpm_limit_enabled.load(Ordering::Relaxed),
+            self.account_rpm_limit.load(Ordering::Relaxed),
+        )
+    }
+
+    /// 设置单账号 RPM 限流配置（Admin API）。
+    ///
+    /// 任一参数传 `None` 表示不修改该字段。关闭限流时会清空所有凭据的窗口计数，
+    /// 避免下次开启时残留旧时间戳造成误判。
+    pub fn set_account_rpm_limit_config(
+        &self,
+        enabled: Option<bool>,
+        limit: Option<u32>,
+    ) -> anyhow::Result<()> {
+        if let Some(value) = limit {
+            // 限定合理范围：1..=100000。0 会被视为"不限"，故不接受，避免与关闭开关语义混淆。
+            if !(1..=100_000).contains(&value) {
+                anyhow::bail!("RPM 上限必须在 1..=100000 内: {}", value);
+            }
+        }
+
+        let _update_guard = self.runtime_config_update_lock.lock();
+
+        let (prev_enabled, prev_limit) = self.get_account_rpm_limit_config();
+        let new_enabled = enabled.unwrap_or(prev_enabled);
+        let new_limit = limit.unwrap_or(prev_limit);
+
+        if new_enabled == prev_enabled && new_limit == prev_limit {
+            return Ok(());
+        }
+
+        self.account_rpm_limit_enabled
+            .store(new_enabled, Ordering::Relaxed);
+        self.account_rpm_limit.store(new_limit, Ordering::Relaxed);
+
+        if let Err(err) = self.persist_account_rpm_limit_config(new_enabled, new_limit) {
+            // 回滚内存值
+            self.account_rpm_limit_enabled
+                .store(prev_enabled, Ordering::Relaxed);
+            self.account_rpm_limit.store(prev_limit, Ordering::Relaxed);
+            return Err(err);
+        }
+
+        // 关闭限流时清空窗口，避免重新开启后残留旧计数误判。
+        if !new_enabled {
+            for entry in self.entries.lock().iter_mut() {
+                entry.rpm_window.clear();
+            }
+        }
+
+        tracing::info!(
+            "单账号 RPM 限流配置已更新: enabled={}, limit={}",
+            new_enabled,
+            new_limit
+        );
+        Ok(())
+    }
+
+    fn persist_account_rpm_limit_config(&self, enabled: bool, limit: u32) -> anyhow::Result<()> {
+        self.update_config_file(move |config| {
+            config.account_rpm_limit_enabled = enabled;
+            config.account_rpm_limit = limit;
+        })
+    }
+
     /// 获取自愈治理配置（Admin API）。
     ///
     /// 返回：(封禁识别开关, 自愈开关, 自愈冷却秒, 连续自愈上限, 当前连续自愈轮数,
@@ -4288,6 +4428,80 @@ impl Drop for MultiTokenManager {
 mod tests {
     use super::*;
     use std::sync::Arc;
+
+    /// 构造一个仅含单凭据、可配置 RPM 限流的测试用 manager。
+    fn rpm_test_manager(enabled: bool, limit: u32) -> MultiTokenManager {
+        let mut config = Config::default();
+        config.account_rpm_limit_enabled = enabled;
+        config.account_rpm_limit = limit;
+        let cred = KiroCredentials {
+            id: Some(1),
+            refresh_token: Some("refresh-token-".repeat(4)),
+            access_token: Some("access-token".to_string()),
+            ..KiroCredentials::default()
+        };
+        MultiTokenManager::new(config, vec![cred], None, None, true).unwrap()
+    }
+
+    #[test]
+    fn rpm_disabled_never_exceeds() {
+        let mgr = rpm_test_manager(false, 1);
+        // 即使反复记录也不应触发限流（关闭时 record 直接清空窗口）
+        for _ in 0..10 {
+            mgr.record_request(1);
+        }
+        let entries = mgr.entries.lock();
+        let entry = &entries[0];
+        assert!(!mgr.rpm_exceeded(entry, Instant::now()));
+        assert!(entry.rpm_window.is_empty());
+    }
+
+    #[test]
+    fn rpm_blocks_at_limit_and_recovers_after_window() {
+        let limit = 3;
+        let mgr = rpm_test_manager(true, limit);
+
+        // 恰好未达上限：limit-1 次后仍可用
+        for _ in 0..(limit - 1) {
+            mgr.record_request(1);
+        }
+        {
+            let entries = mgr.entries.lock();
+            assert!(!mgr.rpm_exceeded(&entries[0], Instant::now()));
+        }
+
+        // 第 limit 次后达到上限：应拦截
+        mgr.record_request(1);
+        {
+            let entries = mgr.entries.lock();
+            assert!(mgr.rpm_exceeded(&entries[0], Instant::now()));
+        }
+
+        // 手动把窗口内时间戳伪造成 61 秒前，模拟窗口滑出 → 恢复可用
+        {
+            let mut entries = mgr.entries.lock();
+            let old = Instant::now() - StdDuration::from_secs(RPM_WINDOW_SECS + 1);
+            for ts in entries[0].rpm_window.iter_mut() {
+                *ts = old;
+            }
+            assert!(!mgr.rpm_exceeded(&entries[0], Instant::now()));
+        }
+    }
+
+    #[test]
+    fn rpm_record_prunes_expired_timestamps() {
+        let mgr = rpm_test_manager(true, 100);
+        // 注入一个过期时间戳，record 时应被剔除，只留新压入的一个
+        {
+            let mut entries = mgr.entries.lock();
+            entries[0]
+                .rpm_window
+                .push_back(Instant::now() - StdDuration::from_secs(RPM_WINDOW_SECS + 5));
+        }
+        mgr.record_request(1);
+        let entries = mgr.entries.lock();
+        assert_eq!(entries[0].rpm_window.len(), 1);
+    }
 
     #[test]
     fn test_is_token_expired_with_expired_token() {

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -178,6 +178,19 @@ pub struct Config {
     #[serde(default = "default_account_throttle_cooldown_secs")]
     pub account_throttle_cooldown_secs: u64,
 
+    /// 是否启用单账号每分钟请求次数（RPM）主动限流（默认 false）。
+    ///
+    /// 开启后：每个凭据独立维护最近 60 秒的滑动窗口计数，达到 `account_rpm_limit`
+    /// 上限时，该凭据在窗口内被临时排除出候选，请求自动故障转移到下一个可用凭据；
+    /// 所有凭据都超限时返回 429。窗口计数不持久化，进程重启后清空。
+    /// 关闭时（默认）完全不计数、不影响调度，存量用户无感知。
+    #[serde(default = "default_account_rpm_limit_enabled")]
+    pub account_rpm_limit_enabled: bool,
+
+    /// 单账号每分钟请求次数上限（默认 60）。仅在 `account_rpm_limit_enabled` 为 true 时生效。
+    #[serde(default = "default_account_rpm_limit")]
+    pub account_rpm_limit: u32,
+
     /// 是否识别 403 账号封禁文案并立即禁用凭据（默认 true）。
     ///
     /// 开启后：某凭据收到 403 且响应体命中明确封禁文案（同时含 "suspended" 与
@@ -310,6 +323,14 @@ fn default_account_throttle_cooldown_secs() -> u64 {
     30 * 60
 }
 
+fn default_account_rpm_limit_enabled() -> bool {
+    false
+}
+
+fn default_account_rpm_limit() -> u32 {
+    60
+}
+
 fn default_suspended_detection_enabled() -> bool {
     true
 }
@@ -387,6 +408,8 @@ impl Default for Config {
             load_balancing_mode: default_load_balancing_mode(),
             account_throttle_failover: default_account_throttle_failover(),
             account_throttle_cooldown_secs: default_account_throttle_cooldown_secs(),
+            account_rpm_limit_enabled: default_account_rpm_limit_enabled(),
+            account_rpm_limit: default_account_rpm_limit(),
             suspended_detection_enabled: default_suspended_detection_enabled(),
             self_heal_enabled: default_self_heal_enabled(),
             self_heal_min_interval_secs: default_self_heal_min_interval_secs(),
@@ -513,5 +536,29 @@ mod tests {
         assert!(!config.self_heal_enabled);
         assert_eq!(config.self_heal_min_interval_secs, 60);
         assert_eq!(config.self_heal_max_consecutive_rounds, 0);
+    }
+
+    #[test]
+    fn account_rpm_limit_defaults_for_existing_configs() {
+        let config: Config = serde_json::from_str("{}").unwrap();
+        assert!(!config.account_rpm_limit_enabled);
+        assert_eq!(config.account_rpm_limit, 60);
+
+        let default = Config::default();
+        assert!(!default.account_rpm_limit_enabled);
+        assert_eq!(default.account_rpm_limit, 60);
+    }
+
+    #[test]
+    fn account_rpm_limit_accepts_explicit_values() {
+        let config: Config = serde_json::from_str(
+            r#"{
+                "accountRpmLimitEnabled": true,
+                "accountRpmLimit": 120
+            }"#,
+        )
+        .unwrap();
+        assert!(config.account_rpm_limit_enabled);
+        assert_eq!(config.account_rpm_limit, 120);
     }
 }


### PR DESCRIPTION
## 背景

现有账号级限流全部是**被动**的——只在上游返回 `429 + suspicious activity` 后才触发冷却与故障转移（`account-throttle`），本地不做任何请求计数。缺少「主动按每分钟次数给单账号设上限」的能力。

本 PR 新增**主动 RPM 限流**：为每个账号设每分钟请求次数上限，超限即在窗口内跳过该账号、自动换号。

## 设计

- **算法**：每账号独立维护 60 秒滑动窗口（`VecDeque<Instant>`），精确计数，无固定窗口的边界突刺。
- **超限行为**：复用现有 failover 链路——超限账号从候选中排除，请求自动切到下一个可用账号；全部超限时复用 `UpstreamRateLimitError` 返回 429。
- **配置粒度**：全局统一上限，照 `account-throttle` 的 Admin API/UI 模式。
- **默认关闭**：`account_rpm_limit_enabled=false`，存量用户完全无感知。

## 改动

- `config.rs`：`account_rpm_limit_enabled`（默认 false）、`account_rpm_limit`（默认 60）
- `token_manager.rs`：`CredentialEntry.rpm_window` 字段；`rpm_exceeded`（只读判断）/ `record_request`（计数+剔除过期）；筛选点（`entry_available_for_request` 与 priority 模式 `current_id` 命中分支）接入；运行时 atomic 字段 + get/set/persist
- Admin API：`GET|PUT /api/admin/config/account-rpm-limit`
- admin-ui：顶栏限流卡片（开关 + 预设/自定义每分钟上限）+ 紧凑模式菜单项

## 两个实现细节

1. **计数在凭据选中时递增，而非请求成功时**——限流要管住发出速率，不论成败；token 刷新失败被跳过的凭据不白占额度。
2. **只对真实业务请求计数**——Admin 只读模型发现（`update_current=false`）不消耗 RPM 预算。

## 测试

- 后端 `cargo test`：596 passed（含 config 默认值、RPM 边界：达上限拦截 / 窗口滑出恢复 / 过期剔除）
- 前端 `npm run build`：类型检查 + vite 构建通过