### PR TITLE
feat(admin-ui): 凭据列表支持字段排序与按状态隐藏

### DIFF
--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -71,6 +71,8 @@ interface CredentialCardProps {
   failureStats?: { auth: number; throttle: number; other: number };
   /** 展示形态：卡片（默认）或紧凑列表行 */
   view?: "card" | "list";
+  /** 字段排序开启时禁用拖拽调优先级（隐藏拖拽手柄） */
+  dragDisabled?: boolean;
 }
 
 function formatLastUsed(lastUsedAt: string | null): string {
@@ -198,6 +200,7 @@ export function CredentialCard({
   onRefreshBalance,
   failureStats,
   view = "card",
+  dragDisabled = false,
 }: CredentialCardProps) {
   const [editingPriority, setEditingPriority] = useState(false);
   const [priorityValue, setPriorityValue] = useState(
@@ -228,7 +231,7 @@ export function CredentialCard({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: credential.id });
+  } = useSortable({ id: credential.id, disabled: dragDisabled });
   const dragStyle: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     // 拖拽中关掉过渡，避免 Card 基类的 transition-all 把每帧 transform 动画化导致"不跟手"；
@@ -555,19 +558,21 @@ export function CredentialCard({
           : "hover:bg-accent/40 hover:shadow-apple-sm"
       } ${stateClasses}`}
     >
-      {/* 拖拽手柄 */}
-      <Button
-        ref={setActivatorNodeRef}
-        size="icon"
-        variant="ghost"
-        data-no-rect-select
-        className="h-8 w-8 shrink-0 cursor-grab touch-none active:cursor-grabbing"
-        title="拖拽调整优先级"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="h-4 w-4 text-muted-foreground" />
-      </Button>
+      {/* 拖拽手柄（字段排序开启时隐藏，此时拖拽无意义） */}
+      {!dragDisabled && (
+        <Button
+          ref={setActivatorNodeRef}
+          size="icon"
+          variant="ghost"
+          data-no-rect-select
+          className="h-8 w-8 shrink-0 cursor-grab touch-none active:cursor-grabbing"
+          title="拖拽调整优先级"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      )}
 
       {/* 选择框 */}
       <label
@@ -1060,19 +1065,23 @@ export function CredentialCard({
           {/* 操作区 */}
           <div className="mt-auto flex flex-col gap-2 border-t border-border/50 pt-3 min-[420px]:flex-row min-[420px]:items-center min-[420px]:justify-between">
             <div className="grid grid-cols-3 gap-1 min-[420px]:flex min-[420px]:items-center">
-              <Button
-                ref={setActivatorNodeRef}
-                size="icon"
-                variant="ghost"
-                data-no-rect-select
-                className="w-full cursor-grab touch-none active:cursor-grabbing min-[420px]:w-9"
-                title="拖拽调整优先级"
-                {...attributes}
-                {...listeners}
-              >
-                <GripVertical className="h-4 w-4 text-muted-foreground" />
-              </Button>
-              <span className="mx-1 hidden h-5 w-px bg-border/70 min-[420px]:inline-block" />
+              {!dragDisabled && (
+                <>
+                  <Button
+                    ref={setActivatorNodeRef}
+                    size="icon"
+                    variant="ghost"
+                    data-no-rect-select
+                    className="w-full cursor-grab touch-none active:cursor-grabbing min-[420px]:w-9"
+                    title="拖拽调整优先级"
+                    {...attributes}
+                    {...listeners}
+                  >
+                    <GripVertical className="h-4 w-4 text-muted-foreground" />
+                  </Button>
+                  <span className="mx-1 hidden h-5 w-px bg-border/70 min-[420px]:inline-block" />
+                </>
+              )}
               <Button
                 size="sm"
                 variant="ghost"

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -37,6 +37,7 @@ import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
+  Loader2,
 } from "lucide-react";
 
 function GithubIcon({ className }: { className?: string }) {
@@ -268,6 +269,11 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const [verifyResults, setVerifyResults] = useState<Map<number, VerifyResult>>(
     new Map(),
   );
+  const [batchDeleting, setBatchDeleting] = useState(false);
+  const [deleteProgress, setDeleteProgress] = useState({
+    current: 0,
+    total: 0,
+  });
   const [balanceMap, setBalanceMap] = useState<Map<number, BalanceResponse>>(
     new Map(),
   );
@@ -680,9 +686,13 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
       }))
     )
       return;
+
+    setBatchDeleting(true);
+    setDeleteProgress({ current: 0, total: ids.length });
     let s = 0,
       f = 0;
-    for (const id of ids) {
+    for (let i = 0; i < ids.length; i++) {
+      const id = ids[i];
       try {
         await new Promise<void>((resolve, reject) => {
           deleteCredential(id, {
@@ -697,7 +707,9 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           });
         });
       } catch {}
+      setDeleteProgress({ current: i + 1, total: ids.length });
     }
+    setBatchDeleting(false);
     if (f === 0) toast.success(`成功删除 ${s} 个凭据`);
     else toast.warning(`删除凭据：成功 ${s} 个，失败 ${f} 个`);
     deselectAll();
@@ -1522,6 +1534,12 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 验活中… {verifyProgress.current}/{verifyProgress.total}
               </Button>
             )}
+            {batchDeleting && (
+              <Button size="sm" variant="secondary" disabled>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                删除中… {deleteProgress.current}/{deleteProgress.total}
+              </Button>
+            )}
           </div>
 
           {/* 第二行：筛选（左） + 操作（右） */}
@@ -1780,9 +1798,13 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                     size="sm"
                     variant="destructive"
                     className="w-full sm:w-auto"
-                    disabled={selectedIds.size === 0}
+                    disabled={selectedIds.size === 0 || batchDeleting}
                   >
-                    <Trash2 className="h-3.5 w-3.5" />
+                    {batchDeleting ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-3.5 w-3.5" />
+                    )}
                     删除
                   </Button>
                   <span className="mx-1 hidden h-5 w-px bg-border/70 sm:inline-block" />

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -34,6 +34,9 @@ import {
   List,
   Search,
   X,
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
 } from "lucide-react";
 
 function GithubIcon({ className }: { className?: string }) {
@@ -136,7 +139,7 @@ import {
   formatNumber,
   overageFailureMessage,
 } from "@/lib/utils";
-import type { BalanceResponse } from "@/types/api";
+import type { BalanceResponse, CredentialStatusItem } from "@/types/api";
 
 interface DashboardProps {
   onLogout: () => void;
@@ -162,6 +165,81 @@ const TIER_LABELS: Record<Tier, string> = {
 
 // 每页数量可选项；另有“全部”（pageSize = 0）由下拉单独追加
 const PAGE_SIZE_OPTIONS = [12, 24, 48, 96] as const;
+
+// 字段排序：'manual' = 服务端顺序（保留拖拽调优先级）；其余字段选中后拖拽自动禁用
+type SortField =
+  | "manual"
+  | "priority"
+  | "successCount"
+  | "totalFailureCount"
+  | "lastUsedAt"
+  | "id";
+type SortDir = "asc" | "desc";
+const SORT_OPTIONS: { value: Exclude<SortField, "manual">; label: string }[] = [
+  { value: "priority", label: "优先级" },
+  { value: "successCount", label: "成功次数" },
+  { value: "totalFailureCount", label: "累计失败" },
+  { value: "lastUsedAt", label: "最后使用" },
+  { value: "id", label: "ID" },
+];
+const SORT_LABELS: Record<SortField, string> = {
+  manual: "手动顺序",
+  priority: "优先级",
+  successCount: "成功次数",
+  totalFailureCount: "累计失败",
+  lastUsedAt: "最后使用",
+  id: "ID",
+};
+
+// 按状态隐藏：勾选即隐藏对应状态的凭据。状态含义与卡片徽章一致。
+type StatusKey =
+  | "current"
+  | "enabled"
+  | "disabled"
+  | "throttled"
+  | "quotaExceeded";
+const STATUS_OPTIONS: { value: StatusKey; label: string }[] = [
+  { value: "current", label: "当前优先" },
+  { value: "enabled", label: "已启用" },
+  { value: "disabled", label: "已禁用" },
+  { value: "throttled", label: "冷却中" },
+  { value: "quotaExceeded", label: "已超额" },
+];
+
+/**
+ * 判断凭据是否命中某个隐藏状态。
+ *
+ * `enabled` 指“正常启用且无异常态”（非禁用 / 非冷却 / 非超额）；`current` 与
+ * 主状态正交（一个当前优先的凭据同时也可能是 enabled），勾选任一命中即隐藏。
+ * 超额判定优先用本地验活/缓存余额，回落到 disabledReason。
+ */
+function credentialHasStatus(
+  c: CredentialStatusItem,
+  key: StatusKey,
+  balance: BalanceResponse | undefined,
+): boolean {
+  const quotaByBalance = balance
+    ? balance.remaining <= 0 || balance.usagePercentage >= 100
+    : false;
+  const quotaExceeded =
+    (!c.disabled && quotaByBalance) ||
+    (c.disabled && c.disabledReason === "QuotaExceeded");
+  const throttled = !c.disabled && (c.throttledRemainingSecs ?? 0) > 0;
+  switch (key) {
+    case "current":
+      return c.isCurrent;
+    case "disabled":
+      return c.disabled;
+    case "throttled":
+      return throttled;
+    case "quotaExceeded":
+      return quotaExceeded;
+    case "enabled":
+      return !c.disabled && !throttled && !quotaExceeded;
+    default:
+      return false;
+  }
+}
 
 export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const confirm = useConfirm();
@@ -251,6 +329,35 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const [tierFilter, setTierFilter] = useState<Set<Tier>>(new Set());
   // 模糊搜索：按来源渠道（备注）/ 邮箱做大小写不敏感的子串匹配；空串 = 不限
   const [searchQuery, setSearchQuery] = useState("");
+  // 字段排序：'manual' 保留服务端顺序与拖拽调优先级；其余字段按方向排序并禁用拖拽
+  const [sortField, setSortField] = useState<SortField>("manual");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  // 按状态隐藏（多选）：集合内的状态对应的凭据不显示；空集合 = 不隐藏任何状态
+  const [hiddenStatuses, setHiddenStatuses] = useState<Set<StatusKey>>(
+    new Set(),
+  );
+  // 选中排序字段：点已选字段则切换升/降序；换字段时用该字段的直观默认方向
+  const applySort = (field: SortField) => {
+    if (field === "manual") {
+      setSortField("manual");
+      return;
+    }
+    if (sortField === field) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortField(field);
+    // 成功次数/最后使用默认降序（大/新在前），其余默认升序
+    setSortDir(field === "successCount" || field === "lastUsedAt" ? "desc" : "asc");
+  };
+  const toggleStatus = (s: StatusKey) => {
+    setHiddenStatuses((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return next;
+    });
+  };
   const toggleTier = (t: Tier) => {
     setTierFilter((prev) => {
       const next = new Set(prev);
@@ -283,13 +390,55 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           (c.email ?? "").toLowerCase().includes(q),
       );
     }
+    // 按状态隐藏：命中任一被勾选状态的凭据不显示
+    if (hiddenStatuses.size > 0) {
+      out = out.filter(
+        (c) =>
+          ![...hiddenStatuses].some((s) =>
+            credentialHasStatus(c, s, balanceMap.get(c.id) || c.balance),
+          ),
+      );
+    }
+    // 字段排序（'manual' 保留服务端顺序）。复制后排序，不修改筛选中间数组。
+    if (sortField !== "manual") {
+      const dir = sortDir === "asc" ? 1 : -1;
+      out = [...out].sort((a, b) => {
+        let cmp = 0;
+        switch (sortField) {
+          case "lastUsedAt": {
+            // 从未使用（null）恒排在最后，不受升降序影响
+            const ta = a.lastUsedAt ? Date.parse(a.lastUsedAt) : null;
+            const tb = b.lastUsedAt ? Date.parse(b.lastUsedAt) : null;
+            if (ta === null && tb === null) cmp = 0;
+            else if (ta === null) return 1;
+            else if (tb === null) return -1;
+            else cmp = ta - tb;
+            break;
+          }
+          case "priority":
+            cmp = a.priority - b.priority;
+            break;
+          case "successCount":
+            cmp = a.successCount - b.successCount;
+            break;
+          case "totalFailureCount":
+            cmp = a.totalFailureCount - b.totalFailureCount;
+            break;
+          case "id":
+            cmp = a.id - b.id;
+            break;
+        }
+        // 主键相等时用 id 稳定兜底，避免同值行顺序抖动
+        return cmp !== 0 ? cmp * dir : a.id - b.id;
+      });
+    }
     return out;
   })();
 
-  // 切换分组 / 分级筛选 / 搜索时复位到第 1 页，避免空页
+  // 切换分组 / 分级筛选 / 搜索 / 状态隐藏 / 排序时复位到第 1 页，避免空页
   useEffect(() => {
     setCurrentPage(1);
-  }, [groupFilter, tierFilter, searchQuery]);
+  }, [groupFilter, tierFilter, searchQuery, hiddenStatuses, sortField, sortDir]);
 
   // pageSize === 0 表示“全部”：单页容纳全部已筛选凭据
   const effectivePageSize =
@@ -335,7 +484,11 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
 
+  // 字段排序开启时禁止拖拽调优先级（拖拽只在“手动顺序”下有意义）
+  const dragDisabled = sortField !== "manual";
+
   const handleDragEnd = (event: DragEndEvent) => {
+    if (dragDisabled) return;
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const ids = currentCredentials.map((c) => c.id);
@@ -1465,6 +1618,117 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 </DropdownMenuContent>
               </DropdownMenu>
 
+              {/* 字段排序 */}
+              <DropdownMenu modal={false}>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    title="按字段排序凭据（再次点击同一字段切换升 / 降序）"
+                    className="inline-flex h-8 w-full items-center justify-between gap-1 rounded-full border border-border bg-card/60 px-3 text-sm backdrop-blur hover:bg-accent sm:w-[136px]"
+                  >
+                    <span className="inline-flex min-w-0 items-center gap-1">
+                      {sortField === "manual" ? (
+                        <ArrowUpDown className="h-3.5 w-3.5 shrink-0 opacity-70" />
+                      ) : sortDir === "asc" ? (
+                        <ArrowUp className="h-3.5 w-3.5 shrink-0 text-primary" />
+                      ) : (
+                        <ArrowDown className="h-3.5 w-3.5 shrink-0 text-primary" />
+                      )}
+                      <span className="truncate">{SORT_LABELS[sortField]}</span>
+                    </span>
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-60" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[11rem]">
+                  <DropdownMenuLabel>排序字段</DropdownMenuLabel>
+                  <DropdownMenuItem
+                    onSelect={(e) => {
+                      e.preventDefault();
+                      applySort("manual");
+                    }}
+                    className="gap-2"
+                  >
+                    <ArrowUpDown className="h-3.5 w-3.5 opacity-70" />
+                    <span>手动顺序（可拖拽）</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  {SORT_OPTIONS.map((o) => {
+                    const active = sortField === o.value;
+                    return (
+                      <DropdownMenuItem
+                        key={o.value}
+                        onSelect={(e) => {
+                          e.preventDefault();
+                          applySort(o.value);
+                        }}
+                        className="justify-between gap-2"
+                      >
+                        <span>{o.label}</span>
+                        {active &&
+                          (sortDir === "asc" ? (
+                            <ArrowUp className="h-3.5 w-3.5 text-primary" />
+                          ) : (
+                            <ArrowDown className="h-3.5 w-3.5 text-primary" />
+                          ))}
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              {/* 按状态隐藏（多选） */}
+              <DropdownMenu modal={false}>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    title="隐藏指定状态的凭据（可多选）"
+                    className="inline-flex h-8 w-full items-center justify-between gap-1 rounded-full border border-border bg-card/60 px-3 text-sm backdrop-blur hover:bg-accent sm:w-[128px]"
+                  >
+                    <span className="inline-flex min-w-0 items-center gap-1">
+                      <EyeOff
+                        className={`h-3.5 w-3.5 shrink-0 ${hiddenStatuses.size > 0 ? "text-primary" : "opacity-70"}`}
+                      />
+                      <span className="truncate">
+                        {hiddenStatuses.size > 0
+                          ? `隐藏 ·${hiddenStatuses.size}`
+                          : "隐藏状态"}
+                      </span>
+                    </span>
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-60" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[10rem]">
+                  <DropdownMenuLabel>隐藏这些状态</DropdownMenuLabel>
+                  {STATUS_OPTIONS.map((s) => (
+                    <DropdownMenuItem
+                      key={s.value}
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        toggleStatus(s.value);
+                      }}
+                      className="gap-2"
+                    >
+                      <Checkbox checked={hiddenStatuses.has(s.value)} />
+                      <span>{s.label}</span>
+                    </DropdownMenuItem>
+                  ))}
+                  {hiddenStatuses.size > 0 && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onSelect={(e) => {
+                          e.preventDefault();
+                          setHiddenStatuses(new Set());
+                        }}
+                        className="text-muted-foreground"
+                      >
+                        显示全部状态
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
               {/* 卡片 / 列表 视图切换（iOS 分段控件） */}
               <div className="col-span-2 inline-flex h-8 shrink-0 items-center justify-self-start rounded-full border border-border bg-card/60 p-0.5 backdrop-blur sm:col-span-1">
                 <button
@@ -1789,6 +2053,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                         handleRefreshBalance(credential.id)
                       }
                       failureStats={failureStatsMap?.[String(credential.id)]}
+                      dragDisabled={dragDisabled}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## 背景

凭据列表此前只有拖拽调优先级 + 分组/订阅分级/搜索筛选。账号多时缺少两个常用能力：按字段排序、按状态过滤视图。本 PR 补齐，批量删除已有故不动。

## 改动

### 字段排序
工具栏新增排序下拉：优先级 / 成功次数 / 累计失败 / 最后使用 / ID。

- 默认「手动顺序」——保留服务端顺序与拖拽调优先级。
- 再次点击同一字段切换升 / 降序；触发按钮箭头图标编码当前方向（`↑`/`↓`/`⇅`）。
- 成功次数、最后使用默认降序（大/新在前），其余升序。
- 「从未使用」恒排末尾，不受升降序影响；主键相等用 id 稳定兜底，避免同值行抖动。

### 按状态隐藏（多选）
新增「隐藏状态」下拉（勾选即隐藏）：当前优先 / 已启用 / 已禁用 / 冷却中 / 已超额。

- 有隐藏时显示「隐藏 ·N」胶囊 + 「显示全部状态」清除项。
- 超额判定优先用本地验活/缓存余额，回落 `disabledReason`，与卡片徽章口径一致。

### 交互一致性
- **字段排序与拖拽互斥**：选中任意排序字段后 `useSortable` 禁用、卡片/列表两处视图的拖拽手柄隐藏（否则手柄在但拖不动会困惑）；回到「手动顺序」恢复拖拽。
- 切换任一筛选 / 排序复位到第 1 页，避免空页。

沿用现有 iOS 风格设计语言（圆角胶囊控件、`bg-card/60 backdrop-blur`、`DropdownMenu + Checkbox` 多选模式，与订阅分级筛选完全对齐）。

## 测试

- `tsc -b` 类型检查通过
- `npm run build`（vite）构建通过