### PR TITLE
feat(admin): 显示凭据添加时间

### DIFF
--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -87,6 +87,26 @@ function formatLastUsed(lastUsedAt: string | null): string {
   return `${Math.floor(h / 24)} 天前`;
 }
 
+/** 添加时间用绝对日期展示（凭据的创建时刻是固定事实，相对时间意义不大） */
+function formatCreatedAt(createdAt: string | null | undefined): string {
+  if (!createdAt) return "未知";
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return "未知";
+  return date.toLocaleDateString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+/** 完整时间戳，用于 hover 提示 */
+function formatCreatedAtFull(createdAt: string | null | undefined): string {
+  if (!createdAt) return "添加时间未知（该凭据在此功能上线前导入）";
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return "添加时间未知";
+  return `添加于 ${date.toLocaleString("zh-CN")}`;
+}
+
 function formatNumber(n: number): string {
   return n.toLocaleString("zh-CN", {
     minimumFractionDigits: 2,
@@ -745,9 +765,17 @@ export function CredentialCard({
         )}
       </div>
 
-      {/* 最后调用（中大屏） */}
-      <div className="hidden w-24 shrink-0 truncate text-right text-xs text-muted-foreground md:block">
-        {formatLastUsed(credential.lastUsedAt)}
+      {/* 最后调用 + 添加时间（中大屏） */}
+      <div className="hidden w-24 shrink-0 truncate text-right text-xs md:block">
+        <div className="truncate text-muted-foreground">
+          {formatLastUsed(credential.lastUsedAt)}
+        </div>
+        <div
+          className="truncate text-[11px] tabular-nums text-muted-foreground/60"
+          title={formatCreatedAtFull(credential.createdAt)}
+        >
+          添加 {formatCreatedAt(credential.createdAt)}
+        </div>
       </div>
 
       {/* 操作区 */}
@@ -966,6 +994,15 @@ export function CredentialCard({
               <dt className="shrink-0 text-muted-foreground">最后调用</dt>
               <dd className="min-w-0 truncate text-right font-medium">
                 {formatLastUsed(credential.lastUsedAt)}
+              </dd>
+            </div>
+            <div className="flex min-w-0 items-center justify-between gap-2 min-[420px]:col-span-2">
+              <dt className="shrink-0 text-muted-foreground">添加时间</dt>
+              <dd
+                className="min-w-0 truncate text-right font-medium tabular-nums"
+                title={formatCreatedAtFull(credential.createdAt)}
+              >
+                {formatCreatedAt(credential.createdAt)}
               </dd>
             </div>
             {credential.maskedApiKey && (

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -42,6 +42,8 @@ export interface CredentialStatusItem {
   balance?: BalanceResponse
   /** 余额缓存的更新时间（Unix 秒） */
   balanceUpdatedAt?: number
+  /** 凭据添加（创建）时间（RFC3339 格式）；旧凭据缺失时为 undefined */
+  createdAt?: string
 }
 
 // 余额响应

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -658,6 +658,7 @@ impl AdminService {
                     source_channel: entry.source_channel,
                     balance,
                     balance_updated_at,
+                    created_at: entry.created_at,
                 }
             })
             .collect();
@@ -1290,6 +1291,8 @@ impl AdminService {
             endpoint: req.endpoint,
             groups: req.groups,
             source_channel: req.source_channel,
+            // 创建时间由 token_manager.add_credential 在入库时统一写入
+            created_at: None,
         };
 
         // 调用 token_manager 添加凭据

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -80,6 +80,9 @@ pub struct CredentialStatusItem {
     /// 余额缓存的更新时间（Unix 秒，仅在 balance 有值时返回）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_updated_at: Option<f64>,
+    /// 凭据添加（创建）时间（RFC3339 格式）；旧凭据缺失时为 None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 // ============ 操作请求 ============

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -176,6 +176,14 @@ pub struct KiroCredentials {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_channel: Option<String>,
+
+    /// 凭据添加（创建）时间（RFC3339 格式）
+    ///
+    /// 由 `add_credential` 在首次入库时写入，此后随凭据一起持久化。
+    /// 旧配置文件缺失该字段时为 `None`，前端展示为"未知"。
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 /// 判断是否为零（用于跳过序列化）
@@ -236,6 +244,7 @@ impl std::fmt::Debug for KiroCredentials {
             .field("endpoint", &self.endpoint)
             .field("groups", &self.groups)
             .field("source_channel", &self.source_channel)
+            .field("created_at", &self.created_at)
             .finish()
     }
 }
@@ -654,6 +663,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            created_at: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -878,6 +888,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            created_at: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -921,6 +932,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            created_at: None,
         };
 
         let json = creds.to_pretty_json().unwrap();
@@ -1047,6 +1059,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            created_at: None,
         };
 
         let json = original.to_pretty_json().unwrap();

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1071,6 +1071,9 @@ pub struct CredentialEntrySnapshot {
     /// 账号来源渠道（纯备注）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_channel: Option<String>,
+    /// 凭据添加（创建）时间（RFC3339 格式）；旧凭据缺失时为 None
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 /// 凭据管理器状态快照
@@ -2936,6 +2939,7 @@ impl MultiTokenManager {
                     endpoint: e.credentials.endpoint.clone(),
                     groups: e.credentials.groups.clone(),
                     source_channel: e.credentials.source_channel.clone(),
+                    created_at: e.credentials.created_at.clone(),
                 })
                 .collect(),
             current_id,
@@ -3640,6 +3644,13 @@ impl MultiTokenManager {
         validated_cred.proxy_username = new_cred.proxy_username;
         validated_cred.proxy_password = new_cred.proxy_password;
         validated_cred.kiro_api_key = new_cred.kiro_api_key;
+        // 记录添加时间：保留导入时携带的原值（如 KAM 迁移），否则以当前时间入库。
+        // 此处为所有添加路径（单条添加 / 批量导入 / 登录回调）的唯一收口。
+        if validated_cred.created_at.is_none() {
+            validated_cred.created_at = new_cred
+                .created_at
+                .or_else(|| Some(Utc::now().to_rfc3339()));
+        }
 
         {
             let mut entries = self.entries.lock();
@@ -4528,6 +4539,31 @@ mod tests {
         assert!(id > 0);
         assert_eq!(manager.snapshot().total, 1);
         assert_eq!(manager.available_count(), 1);
+    }
+
+    /// add_credential 应在入库时为新凭据写入 created_at（RFC3339），
+    /// 且值可被解析。旧凭据（未携带该字段）由调用方决定是否补齐。
+    #[tokio::test]
+    async fn test_add_credential_sets_created_at() {
+        let config = Config::default();
+        let manager = MultiTokenManager::new(config, vec![], None, None, false).unwrap();
+
+        let mut api_key_cred = KiroCredentials::default();
+        api_key_cred.kiro_api_key = Some("ksk_created_at_probe".to_string());
+        api_key_cred.auth_method = Some("api_key".to_string());
+
+        manager.add_credential(api_key_cred).await.unwrap();
+
+        let snapshot = manager.snapshot();
+        let entry = snapshot.entries.first().expect("凭据应已入库");
+        let created_at = entry
+            .created_at
+            .as_deref()
+            .expect("新凭据应写入 created_at");
+        assert!(
+            DateTime::parse_from_rfc3339(created_at).is_ok(),
+            "created_at 应为合法 RFC3339: {created_at}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 概述

凭据管理面板此前无法看到每个凭据是「什么时候加进来的」——因为后端根本没有记录创建时间。本 PR 补齐从持久化到前端展示的**全链路**。

## 改动

### 后端
- `KiroCredentials` 新增 `created_at: Option<String>`（RFC3339），`#[serde(default)]` 保证旧 `credentials.json` **无需迁移**即可加载。
- 在 `token_manager.add_credential` 这一**唯一收口处**写入创建时间，覆盖单条添加 / 批量导入 / Social·IdC 登录回调所有路径；导入自带时间（如 KAM 迁移）则保留，否则取 `Utc::now()`。
- 字段贯穿 `CredentialEntrySnapshot` → `CredentialStatusItem` 至 API 响应。

### 前端
沿用现有设计语言，未引入新视觉风格：
- **卡片模式**：在「最后调用」行下新增「添加时间」行（绝对日期，hover 显示完整时间戳）。
- **列表模式**：将「最后调用」列改为两行堆叠，副行以弱化字重显示添加日期。
- 旧凭据（本功能上线前导入）无值时统一显示「未知」。

## 兼容性
- 旧配置文件缺失 `created_at` 时按 `None` 处理，前端显示「未知」，无回填（无可靠历史时间）。此后新增/重新导入的凭据均会记录。

## 测试
- 新增 `test_add_credential_sets_created_at`，验证入库时写入合法 RFC3339。
- `cargo build` + `cargo test`（9 个凭据相关测试）通过。
- `admin-ui` `bun run build`（tsc + vite）通过。