### PR TITLE
feat(admin-ui): trace 展开详情加计费与缓存效率面板

### DIFF
--- a/admin-ui/src/components/trace-log-page.tsx
+++ b/admin-ui/src/components/trace-log-page.tsx
@@ -302,10 +302,65 @@ function ExpandedTraceRow({ rec }: { rec: TraceRecord }) {
   )
 }
 
-/** 展开后的链路详情：错误摘要 + 每跳时间线 */
+/**
+ * 计费面板：以 credit（上游 meteringEvent 的真实计费）为核心，直观体现缓存省钱效果。
+ *
+ * 关键指标「每千输入 token 的 credit」：Kiro 后端对命中缓存的输入按更低费率计费，
+ * 所以同规模输入下，该比值越低 = 缓存命中越多 = 越省钱。冷启动请求（大前缀首次进
+ * 缓存）该比值偏高，之后重复内容命中后明显下降——对比同类请求的这个值即可看出缓存
+ * 有没有帮你省钱。
+ *
+ * 注：input token 为 contextUsage 推算的粗粒度估算；credit 是上游真实计费口径，
+ * 是判断成本的可信信号（缓存的 cache_read token 为中转层估算，仅供参考）。
+ */
+function CacheBillingPanel({ rec }: { rec: TraceRecord }) {
+  const credit = rec.credits ?? 0
+  if (credit <= 0) return null
+  const input = rec.inputTokens ?? 0
+  const perK = input > 0 ? credit / (input / 1000) : null
+
+  const items: Array<{ label: string; value: string; hint?: string }> = [
+    { label: '真实计费', value: credit.toFixed(4), hint: 'credit（上游 metering）' },
+    { label: '输入 Token', value: formatTokens(input), hint: '估算' },
+  ]
+  if (perK != null) {
+    items.push({
+      label: '每千输入 credit',
+      value: perK.toFixed(4),
+      hint: '越低=缓存命中越多',
+    })
+  }
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-secondary/30 p-3">
+      <div className="mb-2 flex items-center gap-2 text-[12px] font-medium text-muted-foreground">
+        <span>计费与缓存效率</span>
+        <span className="text-[11px] font-normal text-muted-foreground/70">
+          credit 为上游真实计费，是判断缓存省钱的可信信号
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-3">
+        {items.map((it) => (
+          <div key={it.label} className="min-w-0">
+            <div className="text-[11px] text-muted-foreground">{it.label}</div>
+            <div className="font-mono tabular-nums text-[15px] font-semibold text-pink-600 dark:text-pink-400">
+              {it.value}
+            </div>
+            {it.hint && (
+              <div className="text-[10px] text-muted-foreground/70">{it.hint}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** 展开后的链路详情：计费/缓存效率 + 错误摘要 + 每跳时间线 */
 function ExpandedDetail({ rec }: { rec: TraceRecord }) {
   return (
     <div className="space-y-3">
+      <CacheBillingPanel rec={rec} />
       {rec.errorMessage && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-[13px] text-destructive">
           {rec.errorMessage}

--- a/admin-ui/src/components/trace-log-page.tsx
+++ b/admin-ui/src/components/trace-log-page.tsx
@@ -316,18 +316,32 @@ function ExpandedTraceRow({ rec }: { rec: TraceRecord }) {
 function CacheBillingPanel({ rec }: { rec: TraceRecord }) {
   const credit = rec.credits ?? 0
   if (credit <= 0) return null
-  const input = rec.inputTokens ?? 0
-  const perK = input > 0 ? credit / (input / 1000) : null
+  // 总输入 = 未缓存输入 + 缓存创建 + 缓存读取。
+  // 这是缓存拆分的不变量（split_against_total 保证三者之和 == 总 prompt），
+  // 用作分母才稳定；rec.inputTokens 在有缓存拆分时只剩「未缓存那部分」，不能当分母。
+  const freshInput = rec.inputTokens ?? 0
+  const cacheCreation = rec.cacheCreationTokens ?? 0
+  const cacheRead = rec.cacheReadTokens ?? 0
+  const promptTotal = freshInput + cacheCreation + cacheRead
+  const perK = promptTotal > 0 ? credit / (promptTotal / 1000) : null
 
   const items: Array<{ label: string; value: string; hint?: string }> = [
     { label: '真实计费', value: credit.toFixed(4), hint: 'credit（上游 metering）' },
-    { label: '输入 Token', value: formatTokens(input), hint: '估算' },
+    { label: '总输入 Token', value: formatTokens(promptTotal), hint: '含缓存命中·估算' },
   ]
   if (perK != null) {
     items.push({
       label: '每千输入 credit',
       value: perK.toFixed(4),
       hint: '越低=缓存命中越多',
+    })
+  }
+  // 有缓存拆分时，额外展示「未缓存输入」（真正按全价计费的部分）
+  if (cacheRead > 0 || cacheCreation > 0) {
+    items.push({
+      label: '未缓存输入',
+      value: formatTokens(freshInput),
+      hint: '按全价计费部分·估算',
     })
   }
 


### PR DESCRIPTION
## 概述

在请求链路（trace）的单条记录展开详情里，新增「计费与缓存效率」面板，让用户能直观看到**每个请求的真实计费**、以及**缓存到底有没有帮你省钱**。

## 背景（实测依据）

用真实 KIRO POWER 账号（ide 端点）做了三组对照实验，关键结论：
- **credit（上游 meteringEvent）是唯一可信的成本信号**——实测 credit 严格随未命中输入 token 变化（4190 tok→0.0198，44188 tok→0.184）。
- **`cache_read`/`cache_creation` token 不可靠**——是中转层 `cache_metering` 的估算，主 apiKey 无 session 场景常为 0。
- Kiro 的 prefix cache 按**内容**共享（与 conversationId 无关），命中后 credit 显著下降。

所以面板刻意**以 credit 为核心**，不突出估算的 cache token。

## 改动

`admin-ui/src/components/trace-log-page.tsx`：`ExpandedDetail` 顶部新增 `CacheBillingPanel`：
- **真实计费**：credit（上游 metering）
- **输入 Token**：标注「估算」
- **每千输入 credit** = `credit / (input/1000)`：**该比值越低 = 缓存命中越多 = 越省钱**，对比同类请求即可看出缓存效果。

纯前端展示，复用 trace 已记录的 `credits` / `inputTokens` 字段，无后端改动。

## 测试

`admin-ui` `bun run build`（tsc + vite）通过。