### PR TITLE
fix(cache-metering): 解析 JSON 形态的 user_id，修复会话隔离失效

### DIFF
--- a/src/anthropic/cache_metering.rs
+++ b/src/anthropic/cache_metering.rs
@@ -556,9 +556,29 @@ fn isolation_seed(req: &MessagesRequest, key_id: u64) -> Option<String> {
 
 /// 从 Claude Code 的 user_id 中提取 session 标识。
 ///
-/// 格式形如 `user_<hash>_account__session_<uuid>`，取 `_session_` 之后的部分。
-/// 不含该标记时返回 None（交由调用方退回 key_id）。
+/// 支持两种形态：
+/// 1. JSON 对象：`{"device_id":"...","account_uuid":"...","session_id":"<uuid>"}`
+///    —— 新版 Claude Code 实际发送的形态，取 `session_id` 字段。
+/// 2. 字符串：`user_<hash>_account__session_<uuid>` —— 取 `_session_` 之后的部分。
+///
+/// 两者都取不到时返回 None（交由调用方退回 key_id）。
+///
+/// 注意这里**刻意不做 UUID 校验**，与 [`super::converter`] 里同名函数的语义不同：
+/// converter 提取的是发往 Kiro 上游的 `conversationId`，受协议约束必须是合法 UUID；
+/// 而这里只需要一个跨轮稳定、跨会话唯一的隔离标识，任何非空串都能胜任。收紧成
+/// UUID 反而会让使用自定义 session 格式的第三方客户端退化回 key 粒度隔离。
 fn extract_session_id(user_id: &str) -> Option<String> {
+    // JSON 形态优先：非 `{` 开头的串会在 serde_json 第一个字节就失败，开销可忽略。
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(user_id)
+        && let Some(sid) = json
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    {
+        return Some(sid.to_string());
+    }
+
     user_id
         .split_once("_session_")
         .map(|(_, sid)| sid.trim().to_string())
@@ -1170,6 +1190,52 @@ mod tests {
         assert!(c.cache_read > 0, "同一 key_id 应命中自己的前缀");
     }
 
+    /// 端到端回归：JSON 形态的 user_id（新版 Claude Code 实际发送的）必须与字符串
+    /// 形态一样按会话隔离缓存。
+    ///
+    /// 这里刻意用 `key_id == 0`（共享主 Key）——一旦 session 提取失配，
+    /// [`isolation_seed`] 会返回 None、`extract_segments` 直接返回空段，缓存模拟
+    /// **整体关闭**，`cache_read` 恒为 0、token 全部记进 `input_tokens`。
+    /// 所以最后一条 `cache_read > 0` 断言正是这个 bug 的探针。
+    #[test]
+    fn metadata_json_session_scopes_cache() {
+        use super::super::types::{Message, MessagesRequest, Metadata};
+        let body = "conversation prefix that stays stable ".repeat(20);
+        let make = |session: &str| MessagesRequest {
+            model: "claude-opus-4-8".to_string(),
+            max_tokens: 64,
+            messages: vec![
+                Message { role: "user".into(), content: serde_json::json!([{"type":"text","text":body}]) },
+                Message { role: "assistant".into(), content: serde_json::json!([{"type":"text","text":body}]) },
+                Message { role: "user".into(), content: serde_json::json!([{"type":"text","text":body}]) },
+            ],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+            output_config: None,
+            metadata: Some(Metadata {
+                user_id: Some(
+                    serde_json::json!({
+                        "device_id": "2721550240e8e5303fa95053fab0666443ab2b2ea79c2fc67bb6ff336f1297a9",
+                        "account_uuid": "",
+                        "session_id": session,
+                    })
+                    .to_string(),
+                ),
+            }),
+        };
+        let cache = CacheMeter::new(None);
+        let s1a = compute_cache_usage(&cache, &make("c479866d-b846-4e87-807b-a5ed0d84948c"), 0);
+        assert_eq!(s1a.cache_read, 0, "首轮无历史可命中");
+        assert!(s1a.cache_covered_est > 0, "JSON session 应启用缓存模拟");
+        let s2 = compute_cache_usage(&cache, &make("00000000-0000-0000-0000-000000000000"), 0);
+        assert_eq!(s2.cache_read, 0, "不同 session 不应命中");
+        let s1b = compute_cache_usage(&cache, &make("c479866d-b846-4e87-807b-a5ed0d84948c"), 0);
+        assert!(s1b.cache_read > 0, "相同 session 应命中");
+    }
+
     /// 会话隔离：metadata.user_id 里 session 不同 → 不命中；session 相同 → 命中。
     #[test]
     fn metadata_session_scopes_cache() {
@@ -1284,6 +1350,30 @@ mod tests {
         );
         assert_eq!(extract_session_id("no-session-here"), None);
         assert_eq!(extract_session_id("trailing_session_"), None);
+    }
+
+    /// 新版 Claude Code 的 user_id 是 JSON 对象（实测抓包形态）。旧的
+    /// `split_once("_session_")` 对它必然失配——JSON 里是 `,"session_id":`，
+    /// `session` 前面是引号不是下划线——会静默退回 key 隔离，
+    /// 在 `key_id == 0`（共享主 Key）时更是直接关掉整个缓存模拟。
+    #[test]
+    fn extract_session_id_parses_json_format() {
+        let user_id = r#"{"device_id":"2721550240e8e5303fa95053fab0666443ab2b2ea79c2fc67bb6ff336f1297a9","account_uuid":"","session_id":"c479866d-b846-4e87-807b-a5ed0d84948c"}"#;
+        assert_eq!(
+            extract_session_id(user_id),
+            Some("c479866d-b846-4e87-807b-a5ed0d84948c".to_string())
+        );
+    }
+
+    /// JSON 但缺 / 空 session_id：没有可用的会话维度，必须退回 key 隔离而不是
+    /// 拿空串当种子（空串会让所有此类请求落进同一个隔离域，产生跨会话假命中）。
+    #[test]
+    fn extract_session_id_json_without_session_falls_back() {
+        assert_eq!(extract_session_id(r#"{"device_id":"abc"}"#), None);
+        assert_eq!(
+            extract_session_id(r#"{"device_id":"abc","session_id":""}"#),
+            None
+        );
     }
 
     /// token 口径纯净性：cum_tokens 只算原文，不含 role / 签名前缀 / 分隔符噪声。


### PR DESCRIPTION
估算cache命中率需要先拿到session id，但有2个 extract_session_id 函数，一个对的，一个错的。
估算cache命中率这个场景下，使用了错误的 extract_session_id 函数。
此 PR 修正这个问题。

下面是 AI 写的。

## 问题

`cache_metering::extract_session_id` 只认老的字符串形态 `user_<hash>_account__session_<uuid>`，但现在 Claude Code 发的 `metadata.user_id` 是 JSON 对象（实测抓包）：

```json
{"device_id":"2721...","account_uuid":"","session_id":"c479866d-b846-4e87-807b-a5ed0d84948c"}
```

`split_once("_session_")` 对这个串**必然失配** —— JSON 里是 `,"session_id":`，`session` 前面是引号不是下划线。于是 session 被静默丢弃，`isolation_seed()` 退回 `key:{key_id}`。

而当请求走的是共享主 Key（`key_id == 0`）时，退回分支返回 `None`，`extract_segments` 直接返回空段，**整个提示词缓存模拟被关闭**：`cache_read_input_tokens` / `cache_creation_input_tokens` 恒为 0，所有 token 都记进 `input_tokens`。

即使用的是客户端 Key（`key_id != 0`），隔离粒度也从「会话」退化成「Key」——同一个 Key 上并发跑多个会话时前缀链互相覆盖，命中率明显低于真实值。

## 修改

`extract_session_id` 先尝试 JSON 形态取 `session_id`，取不到再回退到原有的 `_session_` 字符串解析。行为对老格式完全不变。

## 为什么不直接复用 `converter::extract_session_id`

`converter` 里那份同名函数**已经支持 JSON**，所以最直觉的修法是把它提成 `pub(crate)`、让 `cache_metering` 直接调。我实际这么试了一遍（改完即弃的实验分支），结果 **2 条既有测试挂掉**：

```
test anthropic::cache_metering::tests::extract_session_id_parses_claude_code_format ... FAILED
  assertion `left == right` failed
    left: None
   right: Some("0b4445e1-uuid")

test anthropic::cache_metering::tests::metadata_session_scopes_cache ... FAILED
  panicked at: 相同 session 应命中
```

两条同源：`converter` 那份带 `is_valid_uuid` 门禁（36 字符 + 4 个 `-`）。第一条的测试数据是截短的假 UUID；**第二条更能说明问题**——它用 `session = "aaa"/"bbb"` 走完整的 `compute_cache_usage`，UUID 校验挡掉后 `isolation_seed` 返回 `None`，缓存模拟整体关闭，于是「相同 session 应命中」失败。

也就是说，直接复用等于给缓存隔离额外加了一条「session 必须是合法 UUID」的硬约束。两个函数要的东西本就不同：

| | 用途 | 是否要求合法 UUID |
|---|---|---|
| `converter::extract_session_id` | 发往 Kiro 上游的 `conversationId` | 要 —— 协议约束 |
| `cache_metering::extract_session_id` | 缓存前缀哈希链的隔离种子 | 不要 —— 任何稳定唯一串即可 |

Claude Code 永远发标准 UUID，所以复用对它无感；但任何使用自定义 session 格式的客户端会**静默**退化回 Key 粒度隔离。把协议层的约束泄漏进缓存层，代价与收益不成比例，所以这里选择各自保留一份。

## 遗留：重复本身没有被消除

需要坦白：本 PR 修的是 bug，**没有修根因**。两份同名私有函数仍然存在，下次 `user_id` 格式再变，还会以完全相同的方式复发。

真正的根治是抽一份共享的、**不做校验**的解析器（只负责认 JSON / 下划线两种形态），由 `converter` 在自己的调用点补 `is_valid_uuid`——格式知识只留一份，UUID 约束回到它真正属于的协议层。

没有放进这个 PR，是因为它要动 `converter`，而且会轻微收窄 `converter` 现有的容错：目前它用 `find("session_")` 取固定 36 字符，能容忍 `_session_<uuid><额外后缀>` 和无前导下划线的 `session_<uuid>`，换成共享解析器后这两种边缘输入会变成 `None`，需要先确认没有调用方依赖。

如果 maintainer 倾向于一并做掉，我可以在本 PR 追加，或者合并后另开一个 follow-up。

## 为什么之前没被测出来

两个模块各有一份**同名私有**函数、各测各的：`converter` 那份测了 JSON（`test_extract_session_id_json_format`），`cache_metering` 那份只测了下划线格式（`extract_session_id_parses_claude_code_format`）。两边测试都绿，但没有任何一条覆盖到出问题的路径。

本 PR 补两条测试：

- `extract_session_id_parses_json_format` —— 提取器层面，用真实抓包 payload
- `metadata_json_session_scopes_cache` —— 端到端，刻意用 `key_id == 0` 钉住上面那个「缓存模拟整体关闭」的回归

两条都先验证过：把实现改回原样时它们精确变红（其余 23 条 `cache_metering` 测试不受影响），改回来即绿。

## 验证

```
cargo test          → 607 passed; 0 failed
cargo clippy        → 183 warnings（与修改前基线持平，未新增）
```

格式沿用了相邻同款测试 `metadata_session_scopes_cache` 的写法，未对文件做无关的 `cargo fmt` 改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
