### PR TITLE
fix(openai): 修复 GPT-5.6 effort、上游缓存与用量统计

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -11,7 +11,9 @@ use crate::kiro::model::requests::conversation::{
     AssistantMessage, ConversationState, CurrentMessage, HistoryAssistantMessage,
     HistoryUserMessage, KiroImage, Message, UserInputMessage, UserInputMessageContext, UserMessage,
 };
-use crate::kiro::model::requests::kiro::{AdditionalModelRequestFields, KiroOutputConfig};
+use crate::kiro::model::requests::kiro::{
+    AdditionalModelRequestFields, KiroOutputConfig, KiroReasoningConfig,
+};
 use crate::kiro::model::requests::tool::{
     InputSchema, Tool, ToolResult, ToolSpecification, ToolUseEntry,
 };
@@ -327,14 +329,18 @@ pub fn get_context_window_size(model: &str) -> i32 {
     }
 }
 
-/// 是否为已确认接受 `additionalModelRequestFields.output_config` 的模型。
-///
-/// Kiro `ListAvailableModels`（2026-06）确认：Opus 4.6/4.7/4.8、Sonnet 4.6 接受
-/// `output_config`。Claude 5 系（fable-5 / mythos-5 / sonnet-5 / opus-5 / claude-5）
-/// 与 xhigh 能力一致，一并视为支持。其余（4.5 系、haiku、sonnet-4.8 等）保守视为
-/// 不支持——向它们下发会触发上游 400（`additionalModelRequestFields is not supported`）。
-/// 若后续实测某模型 400，从这里去除即可。
+fn model_uses_gpt_reasoning_effort(model_id: &str) -> bool {
+    matches!(
+        model_id.to_ascii_lowercase().as_str(),
+        "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+    )
+}
+
+/// 是否为已确认接受原生 reasoning effort 字段的模型。
 fn model_supports_native_reasoning(model_id: &str) -> bool {
+    if model_uses_gpt_reasoning_effort(model_id) {
+        return true;
+    }
     // 自定义模型可按 backend_id 声明支持 reasoning。
     if crate::model::custom_models::backend_supports_reasoning(model_id) {
         return true;
@@ -403,6 +409,7 @@ fn select_native_reasoning_effort(req: &MessagesRequest, model_id: &str) -> Stri
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EffortTier {
+    None,
     Low,
     Medium,
     High,
@@ -413,6 +420,7 @@ enum EffortTier {
 impl EffortTier {
     fn parse(raw: &str) -> Option<Self> {
         match raw.trim().to_ascii_lowercase().as_str() {
+            "none" => Some(Self::None),
             "low" => Some(Self::Low),
             "medium" => Some(Self::Medium),
             "high" => Some(Self::High),
@@ -424,6 +432,7 @@ impl EffortTier {
 
     fn as_str(self) -> &'static str {
         match self {
+            Self::None => "none",
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
@@ -456,7 +465,11 @@ fn normalize_effort_for_model(model_id: &str, raw_effort: &str) -> Option<String
     // it with `Invalid additionalModelRequestFields`, so map to the nearest
     // lower tier instead of failing the request. Unknown/future models keep
     // recognized values intact to avoid maintaining a brittle full allow-list.
-    let normalized = if requested == EffortTier::XHigh && !model_supports_xhigh_effort(model_id) {
+    let normalized = if requested == EffortTier::None
+        && !model_uses_gpt_reasoning_effort(model_id)
+    {
+        EffortTier::High
+    } else if requested == EffortTier::XHigh && !model_supports_xhigh_effort(model_id) {
         EffortTier::High
     } else {
         requested
@@ -511,14 +524,14 @@ fn build_additional_model_request_fields(
         return None;
     }
 
-    // 仅对确认接受 output_config 的模型下发，避免上游 400。
+    // 仅对确认支持 effort 的模型下发，避免上游 schema 校验 400。
     if !model_supports_native_reasoning(model_id) {
         if let Some(oc) = &req.output_config
             && !oc.effort.trim().is_empty()
         {
             tracing::debug!(
                 model_id = %model_id,
-                "skipping unsupported additionalModelRequestFields.output_config for model"
+                "skipping unsupported reasoning effort for model"
             );
         }
         return None;
@@ -530,9 +543,17 @@ fn build_additional_model_request_fields(
     }
 
     let effort = select_native_reasoning_effort(req, model_id);
-    Some(AdditionalModelRequestFields {
-        output_config: Some(KiroOutputConfig { effort }),
-    })
+    if model_uses_gpt_reasoning_effort(model_id) {
+        Some(AdditionalModelRequestFields {
+            output_config: None,
+            reasoning: Some(KiroReasoningConfig { effort }),
+        })
+    } else {
+        Some(AdditionalModelRequestFields {
+            output_config: Some(KiroOutputConfig { effort }),
+            reasoning: None,
+        })
+    }
 }
 
 /// 转换结果
@@ -2332,6 +2353,9 @@ mod tests {
     #[test]
     fn model_supports_native_reasoning_allows_confirmed_and_5_family() {
         for m in [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
             "claude-opus-4.6",
             "claude-opus-4.7",
             "claude-opus-4.8",
@@ -2352,6 +2376,29 @@ mod tests {
                 "{m} 未确认支持，不应下发 output_config"
             );
         }
+    }
+
+    #[test]
+    fn gpt_5_6_effort_uses_reasoning_wire_field() {
+        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            for effort in ["none", "low", "medium", "high", "xhigh", "max"] {
+                let req = minimal_request_with_effort(model, effort);
+                let fields = convert_request(&req)
+                    .unwrap()
+                    .additional_model_request_fields
+                    .expect("GPT-5.6 effort should be forwarded");
+                assert!(fields.output_config.is_none());
+                assert_eq!(fields.reasoning.unwrap().effort, effort);
+            }
+        }
+    }
+
+    #[test]
+    fn none_effort_falls_back_for_claude() {
+        assert_eq!(
+            normalize_effort_for_model("claude-opus-4.7", "none").as_deref(),
+            Some("high")
+        );
     }
 
     #[test]

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -10,7 +10,7 @@ use crate::admin::trace_db::{
 };
 use crate::admin::usage_stats::{SharedAggregator, SharedRecorder, UsageRecord};
 use crate::kiro::model::available_models::{TokenLimits, UpstreamModel};
-use crate::kiro::model::events::Event;
+use crate::kiro::model::events::{Event, TokenUsage};
 use crate::kiro::model::requests::kiro::KiroRequest;
 use crate::kiro::parser::decoder::EventStreamDecoder;
 use crate::kiro::token_manager::ModelDiscoveryError;
@@ -388,12 +388,35 @@ pub(super) fn map_provider_error(err: Error) -> Response {
         .into_response()
 }
 
-/// 计算 Anthropic usage 口径的 input_tokens
-fn resolve_usage_input_tokens(
+/// 解析普通非流式响应的最终 Anthropic usage。
+///
+/// 返回 `(uncached_input, output, cache_write, cache_read)`。精确 provider 快照优先；
+/// 缺失时才使用 contextUsage/输入估算和本地 CacheMeter 分摊。
+fn resolve_non_stream_usage(
     fallback_total_input_tokens: i32,
     context_total_input_tokens: Option<i32>,
-) -> i32 {
-    context_total_input_tokens.unwrap_or(fallback_total_input_tokens)
+    fallback_output_tokens: i32,
+    cache_usage: super::cache_metering::CacheUsage,
+    provider_usage: Option<TokenUsage>,
+) -> (i32, i32, i32, i32) {
+    if let Some(usage) = provider_usage {
+        let usage = usage.sanitized();
+        return (
+            usage.uncached_input_tokens,
+            usage.output_tokens,
+            usage.cache_write_input_tokens,
+            usage.cache_read_input_tokens,
+        );
+    }
+
+    let total_input = context_total_input_tokens.unwrap_or(fallback_total_input_tokens);
+    let (input, cache_write, cache_read) = cache_usage.split_against_total(total_input);
+    (
+        input,
+        fallback_output_tokens.max(0),
+        cache_write,
+        cache_read,
+    )
 }
 
 fn validate_max_tokens(max_tokens: i32) -> Result<(), ErrorResponse> {
@@ -1010,7 +1033,7 @@ fn record_stream_usage(
     hook.record(
         credential_id,
         input,
-        ctx.output_tokens,
+        ctx.resolved_output_tokens(),
         cache_creation,
         cache_read,
         ctx.credits,
@@ -1023,7 +1046,7 @@ fn stream_trace_usage(ctx: &StreamContext) -> TraceUsage {
     let (input, cache_creation, cache_read) = ctx.resolved_usage();
     TraceUsage {
         input_tokens: input.max(0) as u64,
-        output_tokens: ctx.output_tokens.max(0) as u64,
+        output_tokens: ctx.resolved_output_tokens() as u64,
         cache_creation_tokens: cache_creation.max(0) as u64,
         cache_read_tokens: cache_read.max(0) as u64,
         credits: if ctx.credits.is_finite() && ctx.credits > 0.0 {
@@ -1112,6 +1135,8 @@ async fn handle_non_stream_request(
     let mut stop_reason = "end_turn".to_string();
     // 从 contextUsageEvent 计算的实际输入 tokens
     let mut context_input_tokens: Option<i32> = None;
+    // metadataEvent.tokenUsage 是本次 provider 调用的精确最终快照。
+    let mut provider_token_usage: Option<TokenUsage> = None;
     // meteringEvent 上报的 credit 计费量（上游真实下发）；
     // input/cache_* 的互斥分摊在拿到 total 真值后由 cache_usage 完成。
     let mut credits: f64 = 0.0;
@@ -1161,6 +1186,20 @@ async fn handle_non_stream_request(
                                     tracing::error!("{}", e);
                                     tool_json_error = Some(e);
                                 }
+                            }
+                        }
+                        Event::Metadata(metadata) => {
+                            if let Some(usage) = metadata.token_usage {
+                                let usage = usage.sanitized();
+                                tracing::debug!(
+                                    uncached_input_tokens = usage.uncached_input_tokens,
+                                    cache_write_input_tokens = usage.cache_write_input_tokens,
+                                    cache_read_input_tokens = usage.cache_read_input_tokens,
+                                    output_tokens = usage.output_tokens,
+                                    "收到 metadataEvent.tokenUsage 精确用量"
+                                );
+                                // 单条 provider 流内是最终快照，重复事件取最后一份。
+                                provider_token_usage = Some(usage);
                             }
                         }
                         Event::ContextUsage(context_usage) => {
@@ -1219,14 +1258,46 @@ async fn handle_non_stream_request(
     // 明确暴露上游问题，而不是把无法解析的参数当成完整调用返回。
     if let Some(err) = tool_json_error {
         let message = err.message();
-        hook.record(credential_id, input_tokens, 0, 0, 0, 0.0, "error");
-        tracer.finalize(
-            "error",
-            Some(outcome::BAD_REQUEST),
-            Some(&message),
-            None,
-            TraceUsage::zero(),
-        );
+        if let Some(usage) = provider_token_usage {
+            let usage = usage.sanitized();
+            let trace_usage = TraceUsage {
+                input_tokens: usage.uncached_input_tokens as u64,
+                output_tokens: usage.output_tokens as u64,
+                cache_creation_tokens: usage.cache_write_input_tokens as u64,
+                cache_read_tokens: usage.cache_read_input_tokens as u64,
+                credits: if credits.is_finite() && credits > 0.0 {
+                    credits
+                } else {
+                    0.0
+                },
+            };
+            hook.record(
+                credential_id,
+                usage.uncached_input_tokens,
+                usage.output_tokens,
+                usage.cache_write_input_tokens,
+                usage.cache_read_input_tokens,
+                credits,
+                "error",
+            );
+            tracer.finalize(
+                "error",
+                Some(outcome::BAD_REQUEST),
+                Some(&message),
+                None,
+                trace_usage,
+            );
+        } else {
+            // metadata 缺失时保留原有错误口径，不把不完整工具输出估算成已消费量。
+            hook.record(credential_id, input_tokens, 0, 0, 0, 0.0, "error");
+            tracer.finalize(
+                "error",
+                Some(outcome::BAD_REQUEST),
+                Some(&message),
+                None,
+                TraceUsage::zero(),
+            );
+        }
         return (
             StatusCode::BAD_GATEWAY,
             Json(ErrorResponse::new("upstream_tool_json_error", message)),
@@ -1252,14 +1323,16 @@ async fn handle_non_stream_request(
     );
     content.extend(tool_uses);
 
-    // 估算输出 tokens（上游不下发 token，全部走估算）
-    let output_tokens = token::estimate_output_tokens(&content);
-
-    // 输入 tokens：contextUsage 真实值优先，否则用客户端估算
-    let total_input_tokens = resolve_usage_input_tokens(input_tokens, context_input_tokens);
-    // 互斥分摊：input + cache_creation + cache_read == total
-    let (final_input_tokens, cache_creation_tokens, cache_read_tokens) =
-        cache_usage.split_against_total(total_input_tokens);
+    // provider 未下发 metadataEvent 时才使用本地输出估算。
+    let fallback_output_tokens = token::estimate_output_tokens(&content);
+    let (final_input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens) =
+        resolve_non_stream_usage(
+            input_tokens,
+            context_input_tokens,
+            fallback_output_tokens,
+            cache_usage,
+            provider_token_usage,
+        );
 
     // 构建 Anthropic 响应
     let mut usage_json = json!({
@@ -2118,6 +2191,44 @@ mod tests {
         assert_eq!(models[0].display_name, "Configured GPT");
         assert_eq!(models[0].owned_by, "configured-owner");
         assert_eq!(models[0].max_tokens, 12_345);
+    }
+
+    #[test]
+    fn non_stream_usage_prefers_sanitized_provider_snapshot() {
+        let fallback_cache = super::super::cache_metering::CacheUsage {
+            cache_read: 25,
+            cache_covered_est: 50,
+            prompt_total_est: 100,
+        };
+        let provider = TokenUsage {
+            uncached_input_tokens: 3,
+            output_tokens: 11,
+            cache_read_input_tokens: 7,
+            cache_write_input_tokens: 4,
+        };
+
+        assert_eq!(
+            resolve_non_stream_usage(100, Some(80), 9, fallback_cache, Some(provider)),
+            (3, 11, 4, 7)
+        );
+    }
+
+    #[test]
+    fn non_stream_usage_falls_back_to_context_and_cache_split() {
+        let cache_usage = super::super::cache_metering::CacheUsage {
+            cache_read: 25,
+            cache_covered_est: 50,
+            prompt_total_est: 100,
+        };
+
+        assert_eq!(
+            resolve_non_stream_usage(100, Some(80), 9, cache_usage, None),
+            (40, 9, 20, 20)
+        );
+        assert_eq!(
+            resolve_non_stream_usage(100, None, -9, Default::default(), None),
+            (100, 0, 0, 0)
+        );
     }
 
     #[test]

--- a/src/anthropic/openai.rs
+++ b/src/anthropic/openai.rs
@@ -18,7 +18,7 @@ use axum::{
     Json,
     body::{Body, to_bytes},
     extract::{Extension, State},
-    http::{StatusCode, header},
+    http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use serde::Deserialize;
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 use super::handlers::post_messages;
 use super::middleware::{AppState, KeyContext};
-use super::types::{Message, MessagesRequest, OutputConfig, SystemMessage, Tool};
+use super::types::{Message, MessagesRequest, Metadata, OutputConfig, SystemMessage, Tool};
 
 /// 读取内部响应体时的上限（64MB，与请求体上限对齐）
 const MAX_INNER_BODY: usize = 64 * 1024 * 1024;
@@ -54,6 +54,35 @@ pub struct ChatCompletionRequest {
     pub tool_choice: Option<Value>,
     #[serde(default)]
     pub reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub prompt_cache_key: Option<String>,
+}
+
+/// 从 OpenAI 请求体或会话亲和请求头中提取并规范化 Kiro 会话 UUID。
+pub(super) fn resolve_session_metadata(
+    prompt_cache_key: Option<&str>,
+    headers: &HeaderMap,
+) -> Option<Metadata> {
+    let candidates = [
+        prompt_cache_key,
+        headers
+            .get("x-session-affinity")
+            .and_then(|value| value.to_str().ok()),
+        headers
+            .get("x-client-request-id")
+            .and_then(|value| value.to_str().ok()),
+        headers
+            .get("session_id")
+            .and_then(|value| value.to_str().ok()),
+    ];
+
+    candidates.into_iter().flatten().find_map(|candidate| {
+        let raw_uuid = candidate.strip_prefix("session_").unwrap_or(candidate);
+        let uuid = Uuid::parse_str(raw_uuid).ok()?;
+        Some(Metadata {
+            user_id: Some(format!("session_{uuid}")),
+        })
+    })
 }
 
 // ============================ Handler ============================
@@ -62,10 +91,12 @@ pub struct ChatCompletionRequest {
 pub async fn post_chat_completions(
     State(state): State<AppState>,
     Extension(key_ctx): Extension<KeyContext>,
+    headers: HeaderMap,
     Json(req): Json<ChatCompletionRequest>,
 ) -> Response {
     let want_stream = req.stream;
     let model = req.model.clone();
+    let metadata = resolve_session_metadata(req.prompt_cache_key.as_deref(), &headers);
 
     tracing::info!(
         model = %model,
@@ -75,7 +106,7 @@ pub async fn post_chat_completions(
     );
 
     // 1. OpenAI -> Anthropic 请求翻译
-    let anthropic_req = match openai_to_anthropic(req) {
+    let anthropic_req = match openai_to_anthropic(req, metadata) {
         Ok(r) => r,
         Err(msg) => {
             return openai_error(StatusCode::BAD_REQUEST, "invalid_request_error", &msg);
@@ -136,7 +167,10 @@ pub async fn post_chat_completions(
 
 // ============================ 请求翻译 ============================
 
-fn openai_to_anthropic(req: ChatCompletionRequest) -> Result<MessagesRequest, String> {
+fn openai_to_anthropic(
+    req: ChatCompletionRequest,
+    metadata: Option<Metadata>,
+) -> Result<MessagesRequest, String> {
     let max_tokens = req
         .max_tokens
         .or(req.max_completion_tokens)
@@ -238,12 +272,16 @@ fn openai_to_anthropic(req: ChatCompletionRequest) -> Result<MessagesRequest, St
         max_tokens,
         messages,
         stream: false, // 内部始终非流式
-        system: if system.is_empty() { None } else { Some(system) },
+        system: if system.is_empty() {
+            None
+        } else {
+            Some(system)
+        },
         tools,
         tool_choice,
         thinking: None,
         output_config,
-        metadata: None,
+        metadata,
     })
 }
 
@@ -397,6 +435,7 @@ pub(super) struct ParsedResponse {
     pub(super) tool_calls: Vec<Value>, // OpenAI tool_calls
     pub(super) finish_reason: String,
     pub(super) prompt_tokens: i64,
+    pub(super) cached_tokens: i64,
     pub(super) completion_tokens: i64,
     /// 思考文本（content 里的 thinking 块 + web_search loop 的顶层
     /// `kiro_thinking` 带外字段）。chat/completions 路径不消费，
@@ -491,14 +530,29 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
     let finish_reason = map_finish_reason(stop_reason, !tool_calls.is_empty()).to_string();
 
     let usage = anthropic.get("usage");
-    let prompt_tokens = usage
+    let uncached_input_tokens = usage
         .and_then(|u| u.get("input_tokens"))
         .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(0);
+    let cache_creation_tokens = usage
+        .and_then(|u| u.get("cache_creation_input_tokens"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0)
+        .max(0);
+    let cached_tokens = usage
+        .and_then(|u| u.get("cache_read_input_tokens"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0)
+        .max(0);
+    let prompt_tokens = uncached_input_tokens
+        .saturating_add(cache_creation_tokens)
+        .saturating_add(cached_tokens);
     let completion_tokens = usage
         .and_then(|u| u.get("output_tokens"))
         .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(0);
 
     let credit_usage = usage
         .and_then(|u| u.get("credit_usage"))
@@ -518,6 +572,7 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
         tool_calls,
         finish_reason,
         prompt_tokens,
+        cached_tokens,
         completion_tokens,
         thinking,
         web_searches,
@@ -669,6 +724,123 @@ fn openai_error(status: StatusCode, err_type: &str, message: &str) -> Response {
 mod tests {
     use super::*;
 
+    const UUID_A: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const UUID_B: &str = "67e55044-10b1-426f-9247-bb680e5fe0c8";
+    const UUID_C: &str = "123e4567-e89b-12d3-a456-426614174000";
+    const UUID_D: &str = "123e4567-e89b-12d3-a456-426614174001";
+
+    fn metadata_user_id(metadata: Option<Metadata>) -> Option<String> {
+        metadata.and_then(|value| value.user_id)
+    }
+
+    fn chat_request(prompt_cache_key: Option<&str>) -> ChatCompletionRequest {
+        let mut value = json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "low",
+            "max_completion_tokens": 12
+        });
+        if let Some(key) = prompt_cache_key {
+            value["prompt_cache_key"] = json!(key);
+        }
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn session_metadata_accepts_and_normalizes_uuid_forms() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            metadata_user_id(resolve_session_metadata(
+                Some("550E8400-E29B-41D4-A716-446655440000"),
+                &headers,
+            ))
+            .as_deref(),
+            Some("session_550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            metadata_user_id(resolve_session_metadata(
+                Some("session_67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                &headers,
+            ))
+            .as_deref(),
+            Some("session_67e55044-10b1-426f-9247-bb680e5fe0c8")
+        );
+    }
+
+    #[test]
+    fn session_metadata_uses_body_then_header_priority_with_invalid_fallback() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-session-affinity",
+            format!("session_{UUID_B}").parse().unwrap(),
+        );
+        headers.insert("x-client-request-id", UUID_C.parse().unwrap());
+        headers.insert("session_id", UUID_D.parse().unwrap());
+
+        assert_eq!(
+            metadata_user_id(resolve_session_metadata(Some(UUID_A), &headers)).as_deref(),
+            Some("session_550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            metadata_user_id(resolve_session_metadata(Some("invalid"), &headers)).as_deref(),
+            Some("session_67e55044-10b1-426f-9247-bb680e5fe0c8")
+        );
+
+        headers.insert("x-session-affinity", "invalid".parse().unwrap());
+        assert_eq!(
+            metadata_user_id(resolve_session_metadata(None, &headers)).as_deref(),
+            Some("session_123e4567-e89b-12d3-a456-426614174000")
+        );
+
+        headers.insert("x-client-request-id", "invalid".parse().unwrap());
+        assert_eq!(
+            metadata_user_id(resolve_session_metadata(None, &headers)).as_deref(),
+            Some("session_123e4567-e89b-12d3-a456-426614174001")
+        );
+    }
+
+    #[test]
+    fn session_metadata_skips_non_utf8_and_invalid_candidates() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-session-affinity",
+            axum::http::HeaderValue::from_bytes(&[0xff]).unwrap(),
+        );
+        headers.insert("x-client-request-id", "not-a-uuid".parse().unwrap());
+        headers.insert("session_id", "session_not-a-uuid".parse().unwrap());
+
+        assert!(resolve_session_metadata(Some("invalid"), &headers).is_none());
+        assert!(resolve_session_metadata(None, &HeaderMap::new()).is_none());
+    }
+
+    #[test]
+    fn chat_conversion_forwards_resolved_metadata_without_other_regressions() {
+        let req = chat_request(Some(UUID_A));
+        let metadata = resolve_session_metadata(req.prompt_cache_key.as_deref(), &HeaderMap::new());
+        let anthropic = openai_to_anthropic(req, metadata).unwrap();
+
+        assert_eq!(
+            anthropic
+                .metadata
+                .and_then(|value| value.user_id)
+                .as_deref(),
+            Some("session_550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(anthropic.model, "gpt-5.6-sol");
+        assert_eq!(anthropic.max_tokens, 12);
+        assert_eq!(anthropic.messages.len(), 1);
+        assert_eq!(
+            anthropic
+                .output_config
+                .as_ref()
+                .map(|config| config.effort.as_str()),
+            Some("low")
+        );
+
+        let anthropic = openai_to_anthropic(chat_request(None), None).unwrap();
+        assert!(anthropic.metadata.is_none());
+    }
+
     fn base_parsed() -> ParsedResponse {
         ParsedResponse {
             model: "gpt-5.6-sol".to_string(),
@@ -676,6 +848,7 @@ mod tests {
             tool_calls: Vec::new(),
             finish_reason: "stop".to_string(),
             prompt_tokens: 7,
+            cached_tokens: 0,
             completion_tokens: 11,
             thinking: String::new(),
             web_searches: Vec::new(),
@@ -761,6 +934,40 @@ mod tests {
         assert_eq!(p.credit_usage, Some(0.6));
         assert_eq!(p.credit_unit.as_deref(), Some("credit"));
         assert_eq!(p.credit_unit_plural.as_deref(), Some("credits"));
+    }
+
+    #[test]
+    fn parse_anthropic_message_combines_all_input_categories() {
+        let anthropic = json!({
+            "content": [],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 3,
+                "cache_creation_input_tokens": 4,
+                "cache_read_input_tokens": 7,
+                "output_tokens": 5
+            }
+        });
+        let p = parse_anthropic_message(&anthropic, "gpt-5.6-sol");
+        assert_eq!(p.prompt_tokens, 14);
+        assert_eq!(p.cached_tokens, 7);
+        assert_eq!(p.completion_tokens, 5);
+    }
+
+    #[test]
+    fn parse_anthropic_message_sanitizes_negative_and_missing_usage() {
+        let anthropic = json!({
+            "content": [],
+            "usage": {
+                "input_tokens": -3,
+                "cache_read_input_tokens": -7,
+                "output_tokens": -5
+            }
+        });
+        let p = parse_anthropic_message(&anthropic, "gpt-5.6-sol");
+        assert_eq!(p.prompt_tokens, 0);
+        assert_eq!(p.cached_tokens, 0);
+        assert_eq!(p.completion_tokens, 0);
     }
 
     #[test]

--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -37,7 +37,7 @@ use axum::{
     Json,
     body::{Body, to_bytes},
     extract::{Extension, State},
-    http::{StatusCode, header},
+    http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use serde::Deserialize;
@@ -48,8 +48,9 @@ use super::handlers::post_messages;
 use super::middleware::{AppState, KeyContext};
 use super::openai::{
     ParsedResponse, collect_text_strings, now_ts, parse_anthropic_message, push_merged,
+    resolve_session_metadata,
 };
-use super::types::{Message, MessagesRequest, OutputConfig, SystemMessage, Tool};
+use super::types::{Message, MessagesRequest, Metadata, OutputConfig, SystemMessage, Tool};
 
 /// 读取内部响应体时的上限（64MB，与请求体上限对齐）
 const MAX_INNER_BODY: usize = 64 * 1024 * 1024;
@@ -126,6 +127,8 @@ pub struct ResponsesRequest {
     pub tool_choice: Option<Value>,
     #[serde(default)]
     pub reasoning: Option<ReasoningConfig>,
+    #[serde(default)]
+    pub prompt_cache_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -140,10 +143,12 @@ pub struct ReasoningConfig {
 pub async fn post_responses(
     State(state): State<AppState>,
     Extension(key_ctx): Extension<KeyContext>,
+    headers: HeaderMap,
     Json(req): Json<ResponsesRequest>,
 ) -> Response {
     let want_stream = req.stream;
     let model = req.model.clone();
+    let metadata = resolve_session_metadata(req.prompt_cache_key.as_deref(), &headers);
 
     tracing::info!(
         model = %model,
@@ -152,7 +157,7 @@ pub async fn post_responses(
     );
 
     // 1. Responses -> Anthropic 请求翻译（同时得到工具声明类型表）
-    let (anthropic_req, tool_kinds) = match responses_to_anthropic(req) {
+    let (anthropic_req, tool_kinds) = match responses_to_anthropic(req, metadata) {
         Ok(r) => r,
         Err(msg) => {
             return responses_error(StatusCode::BAD_REQUEST, "invalid_request_error", &msg);
@@ -215,6 +220,7 @@ pub async fn post_responses(
 
 fn responses_to_anthropic(
     req: ResponsesRequest,
+    metadata: Option<Metadata>,
 ) -> Result<(MessagesRequest, ToolKindMap), String> {
     let max_tokens = req
         .max_output_tokens
@@ -337,12 +343,16 @@ fn responses_to_anthropic(
             max_tokens,
             messages,
             stream: false,
-            system: if system.is_empty() { None } else { Some(system) },
+            system: if system.is_empty() {
+                None
+            } else {
+                Some(system)
+            },
             tools,
             tool_choice,
             thinking: None,
             output_config,
-            metadata: None,
+            metadata,
         },
         tool_kinds,
     ))
@@ -860,7 +870,7 @@ fn build_view(p: &ParsedResponse, kinds: &ToolKindMap) -> ResponsesView {
 
     let mut usage = json!({
         "input_tokens": p.prompt_tokens,
-        "input_tokens_details": { "cached_tokens": 0 },
+        "input_tokens_details": { "cached_tokens": p.cached_tokens },
         "output_tokens": p.completion_tokens,
         "output_tokens_details": { "reasoning_tokens": 0 },
         "total_tokens": p.prompt_tokens + p.completion_tokens,
@@ -1176,6 +1186,54 @@ mod tests {
         json!([{ "type": "message", "role": "user", "content": "hi" }])
     }
 
+    #[test]
+    fn responses_body_session_metadata_is_forwarded() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "input": simple_input(),
+            "prompt_cache_key": "550e8400-e29b-41d4-a716-446655440000"
+        }))
+        .unwrap();
+        let metadata = resolve_session_metadata(req.prompt_cache_key.as_deref(), &HeaderMap::new());
+        let (anthropic, _) = responses_to_anthropic(req, metadata).unwrap();
+
+        assert_eq!(
+            anthropic
+                .metadata
+                .and_then(|value| value.user_id)
+                .as_deref(),
+            Some("session_550e8400-e29b-41d4-a716-446655440000")
+        );
+    }
+
+    #[test]
+    fn responses_header_session_fallback_and_invalid_candidates_are_tolerated() {
+        let req = req_with(json!([]), simple_input());
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-client-request-id",
+            "session_67e55044-10b1-426f-9247-bb680e5fe0c8"
+                .parse()
+                .unwrap(),
+        );
+        let metadata = resolve_session_metadata(req.prompt_cache_key.as_deref(), &headers);
+        let (anthropic, _) = responses_to_anthropic(req, metadata).unwrap();
+        assert_eq!(
+            anthropic
+                .metadata
+                .and_then(|value| value.user_id)
+                .as_deref(),
+            Some("session_67e55044-10b1-426f-9247-bb680e5fe0c8")
+        );
+
+        let req = req_with(json!([]), simple_input());
+        headers.insert("x-client-request-id", "invalid".parse().unwrap());
+        let metadata = resolve_session_metadata(Some("also-invalid"), &headers);
+        assert!(metadata.is_none());
+        let (anthropic, _) = responses_to_anthropic(req, metadata).unwrap();
+        assert!(anthropic.metadata.is_none());
+    }
+
     fn parsed_with_tool_calls(tool_calls: Vec<Value>) -> ParsedResponse {
         ParsedResponse {
             model: "gpt-5.6-sol".to_string(),
@@ -1183,6 +1241,7 @@ mod tests {
             tool_calls,
             finish_reason: "tool_calls".to_string(),
             prompt_tokens: 10,
+            cached_tokens: 0,
             completion_tokens: 5,
             thinking: String::new(),
             web_searches: Vec::new(),
@@ -1230,9 +1289,15 @@ mod tests {
                 { "type": "message", "role": "user", "content": "hi" },
             ]),
         );
-        let (anth, kinds) = responses_to_anthropic(req).unwrap();
-        assert_eq!(kinds.get("exec").map(|d| d.kind), Some(DeclaredToolKind::Custom));
-        assert_eq!(kinds.get("wait").map(|d| d.kind), Some(DeclaredToolKind::Function));
+        let (anth, kinds) = responses_to_anthropic(req, None).unwrap();
+        assert_eq!(
+            kinds.get("exec").map(|d| d.kind),
+            Some(DeclaredToolKind::Custom)
+        );
+        assert_eq!(
+            kinds.get("wait").map(|d| d.kind),
+            Some(DeclaredToolKind::Function)
+        );
         let tools = anth.tools.as_ref().unwrap();
         assert!(tools.iter().any(|t| t.name == "exec"));
         assert!(tools.iter().any(|t| t.name == "wait"));
@@ -1256,8 +1321,10 @@ mod tests {
                 { "type": "message", "role": "user", "content": "hi" },
             ]),
         );
-        let (anth, kinds) = responses_to_anthropic(req).unwrap();
-        let decl = kinds.get("collaboration__spawn_agent").expect("flattened name");
+        let (anth, kinds) = responses_to_anthropic(req, None).unwrap();
+        let decl = kinds
+            .get("collaboration__spawn_agent")
+            .expect("flattened name");
         assert_eq!(decl.kind, DeclaredToolKind::Function);
         assert_eq!(decl.name, "spawn_agent");
         assert_eq!(decl.namespace.as_deref(), Some("collaboration"));
@@ -1295,7 +1362,7 @@ mod tests {
                 { "type": "function_call_output", "call_id": "c9", "output": "spawned" },
             ]),
         );
-        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
         let tu = &anth.messages[1].content.as_array().unwrap()[0];
         assert_eq!(tu["type"], "tool_use");
         assert_eq!(
@@ -1315,7 +1382,7 @@ mod tests {
             }]),
             simple_input(),
         );
-        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        let (anth, kinds) = responses_to_anthropic(req, None).unwrap();
         assert_eq!(
             kinds.get("apply_patch").map(|d| d.kind),
             Some(DeclaredToolKind::Custom)
@@ -1332,8 +1399,9 @@ mod tests {
         assert!(ap.description.contains("lark grammar"));
         assert!(ap.description.contains("start: PATCH"));
         // 原生 web_search 注入，noop 不再存在
-        assert!(tools.iter().any(|t| t.name == "web_search"
-            && t.tool_type.as_deref() == Some("web_search_20250305")));
+        assert!(tools.iter().any(
+            |t| t.name == "web_search" && t.tool_type.as_deref() == Some("web_search_20250305")
+        ));
         assert!(!tools.iter().any(|t| t.name == "noop"));
     }
 
@@ -1352,7 +1420,7 @@ mod tests {
             }]),
             simple_input(),
         );
-        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        let (anth, kinds) = responses_to_anthropic(req, None).unwrap();
         assert_eq!(
             kinds.get("shell").map(|d| d.kind),
             Some(DeclaredToolKind::Function)
@@ -1373,7 +1441,7 @@ mod tests {
     #[test]
     fn noop_fallback_when_no_codex_tools() {
         let req = req_with(json!([]), simple_input());
-        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        let (anth, kinds) = responses_to_anthropic(req, None).unwrap();
         assert!(kinds.is_empty());
         let tools = anth.tools.as_ref().unwrap();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
@@ -1381,8 +1449,7 @@ mod tests {
         // 严格提示保留
         let sys = system_texts(&anth);
         assert!(
-            sys.iter()
-                .any(|t| t.contains("Do not call any other tool")),
+            sys.iter().any(|t| t.contains("Do not call any other tool")),
             "strict nudge must be kept for tool-less flows"
         );
     }
@@ -1393,7 +1460,7 @@ mod tests {
             json!([{ "type": "function", "name": "shell", "parameters": {} }]),
             simple_input(),
         );
-        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
         let sys = system_texts(&anth);
         assert!(
             !sys.iter().any(|t| t.contains("Do not call any other tool")),
@@ -1412,7 +1479,7 @@ mod tests {
             json!([{ "type": "function", "name": "web_search", "parameters": {} }]),
             simple_input(),
         );
-        let (anth, kinds) = responses_to_anthropic(req).unwrap();
+        let (anth, kinds) = responses_to_anthropic(req, None).unwrap();
         assert_eq!(
             kinds.get("web_search").map(|d| d.kind),
             Some(DeclaredToolKind::Function)
@@ -1435,7 +1502,7 @@ mod tests {
             ]),
             simple_input(),
         );
-        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
         let tools = anth.tools.unwrap();
         let ws: Vec<&Tool> = tools.iter().filter(|t| t.name == "web_search").collect();
         assert_eq!(ws.len(), 1);
@@ -1455,7 +1522,7 @@ mod tests {
                 { "type": "custom_tool_call_output", "call_id": "c1", "output": "Done!" },
             ]),
         );
-        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
         assert_eq!(anth.messages.len(), 3);
 
         let assistant = &anth.messages[1];
@@ -1490,7 +1557,7 @@ mod tests {
                   ] },
             ]),
         );
-        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
         let tr = &anth.messages[2].content.as_array().unwrap()[0];
         assert_eq!(tr["content"], "line1\nline2");
     }
@@ -1505,7 +1572,7 @@ mod tests {
                 { "type": "message", "role": "user", "content": "hi" },
             ]),
         );
-        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
         let sys = system_texts(&anth);
         assert!(
             sys.iter().any(|t| t.contains("AGENTS.md rules here")),
@@ -1527,7 +1594,7 @@ mod tests {
                 { "type": "message", "role": "user", "content": "hi" },
             ]),
         );
-        let (anth, _) = responses_to_anthropic(req).unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
         assert_eq!(anth.messages.len(), 1);
         assert_eq!(anth.messages[0].role, "user");
     }
@@ -1537,7 +1604,10 @@ mod tests {
     #[test]
     fn custom_input_unwrap_fallbacks() {
         // 标准：{"input": "..."}
-        assert_eq!(custom_input_text(r#"{"input":"*** Begin Patch"}"#), "*** Begin Patch");
+        assert_eq!(
+            custom_input_text(r#"{"input":"*** Begin Patch"}"#),
+            "*** Begin Patch"
+        );
         // 单字段字符串对象
         assert_eq!(custom_input_text(r#"{"cmd":"echo hi"}"#), "echo hi");
         // 多字段对象 → 原样
@@ -1658,18 +1728,22 @@ mod tests {
         );
         let input_done_line = sse
             .lines()
-            .find(|l| {
-                l.starts_with("data: ")
-                    && l.contains("response.custom_tool_call_input.done")
-            })
+            .find(|l| l.starts_with("data: ") && l.contains("response.custom_tool_call_input.done"))
             .expect("custom input done event data line");
         assert!(input_done_line.contains("\"input\":\"PATCH BODY\""));
         // added 也必须带完整 input（codex 反序列化要求字段存在）
         let added_line = sse
             .lines()
-            .find(|l| l.starts_with("data: ") && l.contains("custom_tool_call") && l.contains("in_progress"))
+            .find(|l| {
+                l.starts_with("data: ")
+                    && l.contains("custom_tool_call")
+                    && l.contains("in_progress")
+            })
             .expect("added event data line");
-        assert!(added_line.contains("PATCH BODY"), "added item carries full input");
+        assert!(
+            added_line.contains("PATCH BODY"),
+            "added item carries full input"
+        );
     }
 
     #[test]
@@ -1697,6 +1771,38 @@ mod tests {
         assert!(sse.contains("event: response.reasoning_summary_text.delta"));
         assert!(sse.contains("deep thought"));
         assert!(sse.contains("\"reasoning\""));
+    }
+
+    #[test]
+    fn usage_maps_cached_subset_in_json_and_completed_sse() {
+        let anthropic = json!({
+            "content": [],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 3,
+                "cache_creation_input_tokens": 4,
+                "cache_read_input_tokens": 7,
+                "output_tokens": 5
+            }
+        });
+        let p = parse_anthropic_message(&anthropic, "gpt-5.6-sol");
+        let view = build_view(&p, &ToolKindMap::new());
+
+        assert_eq!(view.usage["input_tokens"], json!(14));
+        assert_eq!(
+            view.usage["input_tokens_details"]["cached_tokens"],
+            json!(7)
+        );
+        assert_eq!(view.usage["output_tokens"], json!(5));
+        assert_eq!(view.usage["total_tokens"], json!(19));
+
+        let sse = build_responses_sse(&p, &ToolKindMap::new());
+        let completed = sse
+            .lines()
+            .find(|line| line.starts_with("data: ") && line.contains("response.completed"))
+            .expect("response.completed data line");
+        let event: Value = serde_json::from_str(completed.trim_start_matches("data: ")).unwrap();
+        assert_eq!(event["response"]["usage"], view.usage);
     }
 
     // ---- credit_usage 透传 ----

--- a/src/anthropic/stream.rs
+++ b/src/anthropic/stream.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use serde_json::json;
 use uuid::Uuid;
 
-use crate::kiro::model::events::{Event, MeteringEvent};
+use crate::kiro::model::events::{Event, MeteringEvent, TokenUsage};
 
 /// thinking 块的 signature 占位字符串
 ///
@@ -1347,6 +1347,8 @@ pub struct StreamContext {
     pub input_tokens: i32,
     /// 从 contextUsageEvent 计算的实际输入 tokens
     pub context_input_tokens: Option<i32>,
+    /// 上游 metadataEvent.tokenUsage 的精确最终快照。
+    pub provider_token_usage: Option<TokenUsage>,
     /// 输出 tokens 累计
     pub output_tokens: i32,
     /// 工具块索引映射 (tool_id -> block_index)
@@ -1411,13 +1413,30 @@ pub struct StreamContext {
 }
 
 impl StreamContext {
-    /// 解析最终上报口径的 `(input_tokens, cache_creation, cache_read)`。
+    /// 解析 Anthropic 口径的 `(uncached_input, cache_write, cache_read)`。
     ///
-    /// total 真值优先取 contextUsage（上游真实百分比×窗口），否则用客户端估算的
-    /// `input_tokens`；再由 [`CacheUsage::split_against_total`] 做互斥分摊。
+    /// 精确 `metadataEvent.tokenUsage` 优先；只有上游未提供该事件时，才按
+    /// contextUsage/请求估算总量与本地 CacheMeter 比例回退。
     pub fn resolved_usage(&self) -> (i32, i32, i32) {
+        if let Some(usage) = self.provider_token_usage {
+            let usage = usage.sanitized();
+            return (
+                usage.uncached_input_tokens,
+                usage.cache_write_input_tokens,
+                usage.cache_read_input_tokens,
+            );
+        }
+
         let total_real = self.context_input_tokens.unwrap_or(self.input_tokens);
         self.cache_usage.split_against_total(total_real)
+    }
+
+    /// 精确 provider 输出 token 优先，否则返回流内容的本地估算。
+    pub fn resolved_output_tokens(&self) -> i32 {
+        self.provider_token_usage
+            .map(|usage| usage.sanitized().output_tokens)
+            .unwrap_or(self.output_tokens)
+            .max(0)
     }
 
     /// 工具调用 JSON 错误信息（非法 / 半截）。上层据此把本次请求记为 error、
@@ -1440,6 +1459,7 @@ impl StreamContext {
             message_id: format!("msg_{}", Uuid::new_v4().to_string().replace('-', "")),
             input_tokens,
             context_input_tokens: None,
+            provider_token_usage: None,
             output_tokens: 0,
             tool_block_indices: HashMap::new(),
             tool_name_map,
@@ -1534,6 +1554,22 @@ impl StreamContext {
             Event::AssistantResponse(resp) => self.process_assistant_response(&resp.content),
             Event::ToolUse(tool_use) => self.process_tool_use(tool_use),
             Event::ReasoningContent(reasoning) => self.process_reasoning_content(reasoning),
+            Event::Metadata(metadata) => {
+                if let Some(usage) = metadata.token_usage {
+                    let usage = usage.sanitized();
+                    tracing::debug!(
+                        uncached_input_tokens = usage.uncached_input_tokens,
+                        cache_write_input_tokens = usage.cache_write_input_tokens,
+                        cache_read_input_tokens = usage.cache_read_input_tokens,
+                        output_tokens = usage.output_tokens,
+                        "收到 metadataEvent.tokenUsage 精确用量"
+                    );
+                    // tokenUsage 是最终快照；同一 provider 流内重复出现时取最后一份，
+                    // 不能累加，否则会重复计费。
+                    self.provider_token_usage = Some(usage);
+                }
+                Vec::new()
+            }
             Event::ContextUsage(context_usage) => {
                 // 从上下文使用百分比计算实际的 input_tokens
                 let window_size = get_context_window_size(&self.model);
@@ -1823,18 +1859,24 @@ impl StreamContext {
                                 .as_ref()
                                 .map(|(n, _)| self.known_tool_names.contains(n))
                                 .unwrap_or(false);
-                            if invoke_looks_like_real_leak(before) && !fence_after_before && name_known {
+                            if invoke_looks_like_real_leak(before)
+                                && !fence_after_before
+                                && name_known
+                            {
                                 // 真泄漏：吐块前文本（剥掉尾部独立的 call/count 行）+ 合成 tool_use
                                 if !before.is_empty() {
                                     events.extend(self.emit_text_delta_raw(before));
                                 }
                                 // parsed 在上面已确认是 Some 且 name_known
-                                let (name, input_json) = parsed.expect("parsed is Some when name_known");
+                                let (name, input_json) =
+                                    parsed.expect("parsed is Some when name_known");
                                 // 解析完整入参 → 统一还原 → 统一发出（与结构化 toolUseEvent 同一发出口）。
                                 let input: serde_json::Value =
                                     serde_json::from_str(&input_json).unwrap_or_else(|_| json!({}));
-                                let tool_use_id =
-                                    format!("toolu_{}", Uuid::new_v4().to_string().replace('-', ""));
+                                let tool_use_id = format!(
+                                    "toolu_{}",
+                                    Uuid::new_v4().to_string().replace('-', "")
+                                );
                                 let completed = CompletedToolUse::from_kiro(
                                     tool_use_id,
                                     &name,
@@ -2344,7 +2386,10 @@ impl StreamContext {
         // 通过累积器缓冲工具参数 JSON 分片：只有收到 stop=true 且解析成功时才
         // 发出完整的工具调用；半截 / 非法 JSON 记为错误，交由收尾（generate_final_events）
         // 统一补发 error 事件，避免把无法解析的参数当成完整调用转发给客户端。
-        let completed = match self.tool_json_accumulator.push(tool_use, &self.tool_name_map) {
+        let completed = match self
+            .tool_json_accumulator
+            .push(tool_use, &self.tool_name_map)
+        {
             Ok(Some(completed)) => completed,
             Ok(None) => return events,
             Err(e) => {
@@ -2472,13 +2517,14 @@ impl StreamContext {
             self.state_manager.set_stop_reason("error");
         }
 
-        // 互斥口径：total 真值（contextUsage 优先）− 缓存覆盖 = 未缓存的 input。
+        // 精确 metadata 真值优先；缺失时才使用 contextUsage/估算回退。
         let (final_input_tokens, cache_creation, cache_read) = self.resolved_usage();
+        let final_output_tokens = self.resolved_output_tokens();
 
         // 生成最终事件（message_delta + message_stop）
         events.extend(self.state_manager.generate_final_events(
             final_input_tokens,
-            self.output_tokens,
+            final_output_tokens,
             cache_creation,
             cache_read,
             self.metering.as_ref(),
@@ -2610,7 +2656,7 @@ impl BufferedStreamContext {
         let (input, creation, read) = self.inner.resolved_usage();
         (
             input,
-            self.inner.output_tokens,
+            self.inner.resolved_output_tokens(),
             creation,
             read,
             self.inner.credits,
@@ -2705,7 +2751,10 @@ mod tests {
     fn tool_json_accumulator_invalid_json_errors() {
         let mut acc = ToolJsonAccumulator::new();
         let err = acc
-            .push(&tool_evt("t1", "read_file", "{not json", true), &HashMap::new())
+            .push(
+                &tool_evt("t1", "read_file", "{not json", true),
+                &HashMap::new(),
+            )
             .unwrap_err();
         assert_eq!(err.error_type(), "upstream_tool_json_error");
         assert!(matches!(err, ToolJsonAccumulatorError::InvalidJson { .. }));
@@ -2724,7 +2773,10 @@ mod tests {
             .is_none()
         );
         let err = acc.finish().unwrap_err();
-        assert!(matches!(err, ToolJsonAccumulatorError::IncompleteJson { .. }));
+        assert!(matches!(
+            err,
+            ToolJsonAccumulatorError::IncompleteJson { .. }
+        ));
         // 已取出残留后再 finish() 应成功。
         assert!(acc.finish().is_ok());
     }
@@ -2773,8 +2825,7 @@ mod tests {
         let start = events
             .iter()
             .find(|e| {
-                e.event == "content_block_start"
-                    && e.data["content_block"]["type"] == "tool_use"
+                e.event == "content_block_start" && e.data["content_block"]["type"] == "tool_use"
             })
             .expect("应有 tool_use content_block_start");
         assert_eq!(start.data["content_block"]["id"], block["id"]);
@@ -2785,7 +2836,10 @@ mod tests {
             .expect("应有 input_json_delta");
         let partial = delta.data["delta"]["partial_json"].as_str().unwrap();
         let parsed: serde_json::Value = serde_json::from_str(partial).unwrap();
-        assert_eq!(parsed, block["input"], "流式增量拼出的 input 应与非流式块一致");
+        assert_eq!(
+            parsed, block["input"],
+            "流式增量拼出的 input 应与非流式块一致"
+        );
         assert!(events.iter().any(|e| e.event == "content_block_stop"));
     }
 
@@ -2794,7 +2848,8 @@ mod tests {
     #[test]
     fn tool_use_xml_filter_strips_single_chunk_block() {
         let mut f = ToolUseXmlLeakFilter::default();
-        let out = f.filter("before <tool_use id=\"t\" name=\"Write\">{\"path\":\"/a\"}</tool_use> after")
+        let out = f
+            .filter("before <tool_use id=\"t\" name=\"Write\">{\"path\":\"/a\"}</tool_use> after")
             + &f.finish();
         assert!(!out.contains("<tool_use"));
         assert!(out.contains("before") && out.contains("after"));
@@ -2819,7 +2874,10 @@ mod tests {
         out.push_str(&f.filter("_use>y"));
         out.push_str(&f.finish());
         assert!(!out.contains("<tool_use"), "out={out:?}");
-        assert!(out.contains('x') && out.contains('y'), "闭合跨 chunk 时其后文本不应被吞: {out:?}");
+        assert!(
+            out.contains('x') && out.contains('y'),
+            "闭合跨 chunk 时其后文本不应被吞: {out:?}"
+        );
     }
 
     #[test]
@@ -2863,10 +2921,17 @@ mod tests {
     /// 测试用的「已知工具表」：包含 invoke 测试里会合成的工具名，
     /// 让 🅳 工具表校验放行这些名字，从而能验证捞回逻辑本身。
     fn test_known_tools() -> std::collections::HashSet<String> {
-        ["exec_command", "apply_patch", "tool_a", "tool_b", "write_file", "wait_agent"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect()
+        [
+            "exec_command",
+            "apply_patch",
+            "tool_a",
+            "tool_b",
+            "write_file",
+            "wait_agent",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
     }
 
     // ---- extract_invoke_content_blocks: one-shot (non-streaming) reclamation ----
@@ -2887,11 +2952,16 @@ mod tests {
         assert_eq!(tu["input"]["cmd"], "echo hi");
         assert!(
             !blocks.iter().any(|b| b["type"] == "text"
-                && b["text"].as_str().map(|t| t.contains("<invoke")).unwrap_or(false)),
+                && b["text"]
+                    .as_str()
+                    .map(|t| t.contains("<invoke"))
+                    .unwrap_or(false)),
             "no literal <invoke> may remain as text"
         );
         assert!(
-            !blocks.iter().any(|b| b["type"] == "text" && b["text"] == "call\n"),
+            !blocks
+                .iter()
+                .any(|b| b["type"] == "text" && b["text"] == "call\n"),
             "stray token line must be stripped"
         );
     }
@@ -2909,20 +2979,40 @@ mod tests {
         let mut map = std::collections::HashMap::new();
         map.insert(short.to_string(), original.to_string());
         let blocks = extract_invoke_content_blocks(&text, &known, &map);
-        let tu = blocks.iter().find(|b| b["type"] == "tool_use").expect("reclaimed");
-        assert_eq!(tu["name"], original, "shortened name must be restored to original");
+        let tu = blocks
+            .iter()
+            .find(|b| b["type"] == "tool_use")
+            .expect("reclaimed");
+        assert_eq!(
+            tu["name"], original,
+            "shortened name must be restored to original"
+        );
     }
 
     #[test]
     fn extract_blocks_does_not_reclaim_fenced_or_unknown() {
         // fenced -> display, not reclaimed
         let fenced = "see:\n```\n<invoke name=\"exec_command\">\n<parameter name=\"cmd\">rm -rf /</parameter>\n</invoke>\n```";
-        let b1 = extract_invoke_content_blocks(fenced, &test_known_tools(), &std::collections::HashMap::new());
-        assert!(!b1.iter().any(|b| b["type"] == "tool_use"), "fenced must not reclaim");
+        let b1 = extract_invoke_content_blocks(
+            fenced,
+            &test_known_tools(),
+            &std::collections::HashMap::new(),
+        );
+        assert!(
+            !b1.iter().any(|b| b["type"] == "tool_use"),
+            "fenced must not reclaim"
+        );
         // unknown tool name -> not reclaimed
         let unknown = "call\n<invoke name=\"not_a_real_tool\">\n<parameter name=\"x\">y</parameter>\n</invoke>";
-        let b2 = extract_invoke_content_blocks(unknown, &test_known_tools(), &std::collections::HashMap::new());
-        assert!(!b2.iter().any(|b| b["type"] == "tool_use"), "unknown name must not reclaim");
+        let b2 = extract_invoke_content_blocks(
+            unknown,
+            &test_known_tools(),
+            &std::collections::HashMap::new(),
+        );
+        assert!(
+            !b2.iter().any(|b| b["type"] == "tool_use"),
+            "unknown name must not reclaim"
+        );
     }
 
     #[test]
@@ -2991,7 +3081,8 @@ mod tests {
             "mcp__very_long_original_tool_name".to_string(),
         );
 
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, map, test_known_tools());
+        let mut ctx =
+            StreamContext::new_with_thinking("test-model", 1, false, map, test_known_tools());
         let _ = ctx.generate_initial_events();
 
         // 模拟 Kiro 返回短名称的 tool_use
@@ -3017,7 +3108,13 @@ mod tests {
 
     #[test]
     fn test_text_delta_after_tool_use_restarts_text_block() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
 
         let initial_events = ctx.generate_initial_events();
         assert!(
@@ -3078,7 +3175,13 @@ mod tests {
     fn test_tool_use_flushes_pending_thinking_buffer_text_before_tool_block() {
         // thinking 模式下，短文本可能被暂存在 thinking_buffer 以等待 `<thinking>` 的跨 chunk 匹配。
         // 当紧接着出现 tool_use 时，应先 flush 这段文本，再开始 tool_use block。
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         // 两段短文本（各 2 个中文字符），总长度仍可能不足以满足 safe_len>0 的输出条件，
@@ -3285,7 +3388,13 @@ mod tests {
 
     #[test]
     fn test_tool_use_immediately_after_thinking_filters_end_tag_and_closes_thinking_block() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all_events = Vec::new();
@@ -3340,7 +3449,13 @@ mod tests {
         // 客户端在 thinking 模式下要求 thinking 块带 signature 字段，否则下一轮回传时
         // 会抛出 "must be passed back to the API"。本测试验证 thinking 块结束前发送了
         // 一个非空的 signature_delta 事件。
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3374,7 +3489,13 @@ mod tests {
 
     #[test]
     fn test_final_flush_filters_standalone_thinking_end_tag() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all_events = Vec::new();
@@ -3394,7 +3515,13 @@ mod tests {
     #[test]
     fn test_thinking_strips_leading_newline_same_chunk() {
         // <thinking>\n 在同一个 chunk 中，\n 应被剥离
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let events = ctx.process_assistant_response("<thinking>\nHello world");
@@ -3423,7 +3550,13 @@ mod tests {
     #[test]
     fn test_thinking_strips_leading_newline_cross_chunk() {
         // <thinking> 在第一个 chunk 末尾，\n 在第二个 chunk 开头
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let events1 = ctx.process_assistant_response("<thinking>");
@@ -3455,7 +3588,13 @@ mod tests {
     #[test]
     fn test_thinking_no_strip_when_no_leading_newline() {
         // <thinking> 后直接跟内容（无 \n），内容应完整保留
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let events = ctx.process_assistant_response("<thinking>abc</thinking>\n\ntext");
@@ -3484,7 +3623,13 @@ mod tests {
     #[test]
     fn test_text_after_thinking_strips_leading_newlines() {
         // `</thinking>\n\n` 后的文本不应以 \n\n 开头
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let events = ctx.process_assistant_response("<thinking>\nabc</thinking>\n\n你好");
@@ -3561,7 +3706,13 @@ mod tests {
     #[test]
     fn test_invoke_sniff_backtick_wrapped_is_not_captured() {
         // 🔴 防误伤：被反引号包裹的 <invoke> 是引用，不应被抓
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3582,7 +3733,13 @@ mod tests {
     #[test]
     fn test_invoke_sniff_single_bare_invoke() {
         // 🟢 单个裸 invoke（无外壳）
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3602,7 +3759,13 @@ mod tests {
     #[test]
     fn test_invoke_sniff_param_value_with_lt_multiline_chinese() {
         // 🟢 参数值含 `<`、多行、中文 → 不被截断
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let value = "第一行 a < b\n第二行 路径 /tmp/中文";
@@ -3627,7 +3790,13 @@ mod tests {
     #[test]
     fn test_invoke_sniff_two_invokes_sequential() {
         // 🟢 2 个 invoke 串联 → 2 个 tool_use
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3645,7 +3814,13 @@ mod tests {
     #[test]
     fn test_invoke_sniff_split_across_chunks() {
         // 🟢 跨 chunk 分片：标签被切碎多次喂入
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3666,7 +3841,13 @@ mod tests {
     #[test]
     fn test_invoke_sniff_strips_stray_call_token() {
         // 🟢 stray token：<invoke> 前有单独一行 `call` → 剥掉，text 不含残留 call
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3708,8 +3889,13 @@ mod tests {
     fn test_invoke_sniff_reclaims_after_narrative_then_stray_token() {
         // 端到端：`正文\ncall\n<invoke...>` —— 正文 + stray token + 真泄漏 invoke。
         // 旧实现漏捞（stray 剥过头把正文和 invoke 挤一行），修后应成功捞回 tool_use。
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3719,16 +3905,31 @@ mod tests {
         all.extend(ctx.generate_final_events());
 
         let tools = collect_tool_uses(&all);
-        assert_eq!(tools.len(), 1, "narrative+stray+invoke 应捞回 1 个 tool_use: {:?}", tools);
+        assert_eq!(
+            tools.len(),
+            1,
+            "narrative+stray+invoke 应捞回 1 个 tool_use: {:?}",
+            tools
+        );
         let text = collect_text_content(&all);
         assert!(text.contains("先看看结果"), "叙述正文应保留: {:?}", text);
-        assert!(!text.contains("call\n<invoke") && !text.contains("<invoke"), "invoke 不应泄漏为文本: {:?}", text);
+        assert!(
+            !text.contains("call\n<invoke") && !text.contains("<invoke"),
+            "invoke 不应泄漏为文本: {:?}",
+            text
+        );
     }
 
     #[test]
     fn test_invoke_sniff_keeps_narrative_before_invoke() {
         // 🟢 invoke 前有叙述：text 含"先看看"，1 个 tool_use
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3751,7 +3952,13 @@ mod tests {
     #[test]
     fn test_invoke_sniff_truncated_block_not_captured() {
         // 🔴 截断半块（无 </invoke> 闭合）→ 0 tool_use
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3767,7 +3974,13 @@ mod tests {
     #[test]
     fn test_invoke_midsentence_not_captured() {
         // 🔴 P1：正文里嵌在句子中间（无反引号、非行首）的 <invoke> 是讨论文本，不应被抓
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3799,7 +4012,13 @@ mod tests {
     #[test]
     fn test_invoke_midsentence_unclosed_not_hold() {
         // 🔴 P2：流式中途遇到句中不闭合的 <invoke，不应 hold 住后续文本到流末尾
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         // 第一次 process：句中不闭合的 <invoke>，前面同一行有正文“讨论”
@@ -3834,7 +4053,13 @@ mod tests {
     fn test_invoke_multiline_patch_split_still_captured() {
         // 🟢 P3：行首合法 invoke，参数值是 20+ 行多行文本（模拟 apply_patch），
         // 逐行流式喂入。修复前换行数 ≥16 会被 too_long 误杀降级成文本；修复后应抓到。
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         // 构造一个 24 行的多行 patch 内容
@@ -3887,7 +4112,13 @@ mod tests {
     #[test]
     fn test_invoke_large_patch_split_captured() {
         // 🟢 P3：参数值 ~17KB 多行，分片喂入，断言抓到 1 个 tool_use（在 256KB 上限之下）。
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         // 每行 ~70 字节 × 250 行 ≈ 17KB
@@ -3937,7 +4168,13 @@ mod tests {
     fn test_unclosed_invoke_eventually_flushed_as_text() {
         // 🟢 锁定字节兜底仍在：行首 `<invoke>` 永不闭合、喂入超过 MAX_INVOKE_HOLD_BYTES，
         // 应被当文本吐出（不无限 hold）。
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         // 行首开标签，永不闭合；填充超过上限的纯文本（无 </invoke>）
@@ -3969,7 +4206,13 @@ mod tests {
     #[test]
     fn test_invoke_in_markdown_list_not_captured() {
         // 🔴 markdown 列表项 `- <invoke>` 当讨论文本，不抓。
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -3995,7 +4238,13 @@ mod tests {
     #[test]
     fn test_invoke_in_blockquote_not_captured() {
         // 🔴 引用 `> <invoke>` 当讨论文本，不抓。
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -4034,7 +4283,9 @@ mod tests {
     fn block_stop_position(events: &[SseEvent], index: i64) -> usize {
         events
             .iter()
-            .position(|e| e.event == "content_block_stop" && e.data["index"].as_i64() == Some(index))
+            .position(|e| {
+                e.event == "content_block_stop" && e.data["index"].as_i64() == Some(index)
+            })
             .unwrap_or_else(|| panic!("block {index} should stop"))
     }
 
@@ -4042,7 +4293,13 @@ mod tests {
     fn test_end_tag_newlines_split_across_events() {
         // `</thinking>\n` 在 chunk 1，`\n` 在 chunk 2，`text` 在 chunk 3
         // 确保 `</thinking>` 不会被部分当作 thinking 内容发出
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -4065,7 +4322,13 @@ mod tests {
     #[test]
     fn test_end_tag_alone_in_chunk_then_newlines_in_next() {
         // `</thinking>` 单独在一个 chunk，`\n\ntext` 在下一个 chunk
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -4087,7 +4350,13 @@ mod tests {
     #[test]
     fn test_start_tag_newline_split_across_events() {
         // `\n\n` 在 chunk 1，`<thinking>` 在 chunk 2，`\n` 在 chunk 3
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -4111,7 +4380,13 @@ mod tests {
     #[test]
     fn test_full_flow_maximally_split() {
         // 极端拆分：每个关键边界都在不同 chunk
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all = Vec::new();
@@ -4144,7 +4419,13 @@ mod tests {
     #[test]
     fn test_thinking_only_sets_max_tokens_stop_reason() {
         // 整个流只有 thinking 块，没有 text 也没有 tool_use，stop_reason 应为 max_tokens
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all_events = Vec::new();
@@ -4199,7 +4480,13 @@ mod tests {
     #[test]
     fn test_thinking_with_text_keeps_end_turn_stop_reason() {
         // thinking + text 的情况，stop_reason 应为 end_turn
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all_events = Vec::new();
@@ -4220,7 +4507,13 @@ mod tests {
     #[test]
     fn test_thinking_with_tool_use_keeps_tool_use_stop_reason() {
         // thinking + tool_use 的情况，stop_reason 应为 tool_use
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _initial_events = ctx.generate_initial_events();
 
         let mut all_events = Vec::new();
@@ -4251,8 +4544,13 @@ mod tests {
     /// 🅿️ P0-1：参数值里含字面 `</invoke>`，块不应被假闭合截断，input 要完整。
     #[test]
     fn test_invoke_param_value_contains_literal_invoke_close() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         // patch 正文里出现字面 </invoke>，真正的闭合在最后
         let payload = "count\n<invoke name=\"apply_patch\"><parameter name=\"input\">line1\n</invoke>\nstill in patch\nline3</parameter></invoke>";
@@ -4264,17 +4562,28 @@ mod tests {
         assert_eq!(tools[0].0, "apply_patch");
         let parsed: serde_json::Value = serde_json::from_str(&tools[0].1).expect("合法 JSON");
         let input = parsed["input"].as_str().expect("有 input");
-        assert!(input.contains("still in patch"), "input 不应被假闭合截断: {input:?}");
+        assert!(
+            input.contains("still in patch"),
+            "input 不应被假闭合截断: {input:?}"
+        );
         assert!(input.contains("line3"), "input 应含 line3: {input:?}");
         let text = collect_text_content(&all);
-        assert!(!text.contains("still in patch"), "patch 正文不应泄漏到 text: {text:?}");
+        assert!(
+            !text.contains("still in patch"),
+            "patch 正文不应泄漏到 text: {text:?}"
+        );
     }
 
     /// 🅿️ P0-1：参数值里含字面 `</parameter>`，值不应被截断丢失后半段。
     #[test]
     fn test_invoke_param_value_contains_literal_parameter_close() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let payload = "count\n<invoke name=\"apply_patch\"><parameter name=\"input\">before</parameter> after the fake close</parameter></invoke>";
         let mut all = Vec::new();
@@ -4284,14 +4593,22 @@ mod tests {
         assert_eq!(tools.len(), 1, "应合成 1 个 tool_use: {:?}", tools);
         let parsed: serde_json::Value = serde_json::from_str(&tools[0].1).expect("合法 JSON");
         let input = parsed["input"].as_str().expect("有 input");
-        assert!(input.contains("after the fake close"), "后半段不应丢: {input:?}");
+        assert!(
+            input.contains("after the fake close"),
+            "后半段不应丢: {input:?}"
+        );
     }
 
     /// 🅱：代码围栏（```）内的 <invoke> 是正文展示，不应被捞回成 tool_use。
     #[test]
     fn test_invoke_inside_code_fence_not_captured() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let payload = "示例代码：\n```\n<invoke name=\"exec_command\"><parameter name=\"cmd\">rm -rf /</parameter></invoke>\n```\n讲解完毕。";
         let mut all = Vec::new();
@@ -4300,15 +4617,23 @@ mod tests {
         let tools = collect_tool_uses(&all);
         assert!(tools.is_empty(), "围栏内展示文本不应被捞回: {:?}", tools);
         let text = collect_text_content(&all);
-        assert!(text.contains("<invoke name=\"exec_command\">"), "应原样保留: {text:?}");
+        assert!(
+            text.contains("<invoke name=\"exec_command\">"),
+            "应原样保留: {text:?}"
+        );
     }
 
     /// 🅳：合成出的工具名不在已知工具表里 → 不捞回，当文本吐出（防误执行）。
     #[test]
     fn test_invoke_unknown_tool_name_not_synthesized() {
         // 已知工具表里没有 totally_unknown_tool
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let payload = "count\n<invoke name=\"totally_unknown_tool\"><parameter name=\"x\">1</parameter></invoke>";
         let mut all = Vec::new();
@@ -4317,7 +4642,10 @@ mod tests {
         let tools = collect_tool_uses(&all);
         assert!(tools.is_empty(), "未知工具名不应被合成: {:?}", tools);
         let text = collect_text_content(&all);
-        assert!(text.contains("totally_unknown_tool"), "未知工具应原样当文本: {text:?}");
+        assert!(
+            text.contains("totally_unknown_tool"),
+            "未知工具应原样当文本: {text:?}"
+        );
     }
 
     /// 🅳：已知工具表为空（请求没带 tools）→ 一律不捞回，宁可漏捞不可误执行。
@@ -4331,7 +4659,8 @@ mod tests {
             std::collections::HashSet::new(),
         );
         let _ = ctx.generate_initial_events();
-        let payload = "count\n<invoke name=\"exec_command\"><parameter name=\"cmd\">ls</parameter></invoke>";
+        let payload =
+            "count\n<invoke name=\"exec_command\"><parameter name=\"cmd\">ls</parameter></invoke>";
         let mut all = Vec::new();
         all.extend(ctx.process_assistant_response(payload));
         all.extend(ctx.generate_final_events());
@@ -4342,8 +4671,13 @@ mod tests {
     /// 🅲：stray token `card` 也应被剥掉，块仍被捞回。
     #[test]
     fn test_invoke_strips_stray_card_token() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let payload = "我先等结果。\n\ncard\n<invoke name=\"wait_agent\"><parameter name=\"x\">1</parameter></invoke>";
         let mut all = Vec::new();
@@ -4353,20 +4687,30 @@ mod tests {
         assert_eq!(tools.len(), 1, "card 前缀的块应被捞回: {:?}", tools);
         assert_eq!(tools[0].0, "wait_agent");
         let text = collect_text_content(&all);
-        assert!(!text.contains("card"), "card stray token 不应泄漏: {text:?}");
+        assert!(
+            !text.contains("card"),
+            "card stray token 不应泄漏: {text:?}"
+        );
         assert!(text.contains("我先等结果"), "正常叙述应保留: {text:?}");
     }
 
     /// 🅱 跨 chunk：``` 围栏开标签在 chunk 边界被切碎，仍能正确识别围栏内不捞回。
     #[test]
     fn test_invoke_fence_split_across_chunks() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let mut all = Vec::new();
         // 围栏开标签分两个 chunk 到达
         all.extend(ctx.process_assistant_response("看代码：\n``"));
-        all.extend(ctx.process_assistant_response("`\n<invoke name=\"exec_command\"><parameter name=\"cmd\">x</parameter></invoke>\n```"));
+        all.extend(ctx.process_assistant_response(
+            "`\n<invoke name=\"exec_command\"><parameter name=\"cmd\">x</parameter></invoke>\n```",
+        ));
         all.extend(ctx.generate_final_events());
         let tools = collect_tool_uses(&all);
         assert!(tools.is_empty(), "跨 chunk 围栏内不应捞回: {:?}", tools);
@@ -4376,15 +4720,25 @@ mod tests {
     /// 不应把 A、B 误合并成一个块、也不应让 B 的参数串进 A。两个块都应独立捞回。
     #[test]
     fn test_invoke_burst_with_trailing_text_not_merged() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let payload = "count\n<invoke name=\"tool_a\"><parameter name=\"x\">1</parameter>trailing plain</invoke><invoke name=\"tool_b\"><parameter name=\"y\">2</parameter></invoke>";
         let mut all = Vec::new();
         all.extend(ctx.process_assistant_response(payload));
         all.extend(ctx.generate_final_events());
         let tools = collect_tool_uses(&all);
-        assert_eq!(tools.len(), 2, "应独立合成 2 个 tool_use，不能误合并: {:?}", tools);
+        assert_eq!(
+            tools.len(),
+            2,
+            "应独立合成 2 个 tool_use，不能误合并: {:?}",
+            tools
+        );
         assert_eq!(tools[0].0, "tool_a");
         assert_eq!(tools[1].0, "tool_b");
         let a: serde_json::Value = serde_json::from_str(&tools[0].1).expect("合法 JSON");
@@ -4397,8 +4751,13 @@ mod tests {
     /// 🟢 正常连发 burst（块紧贴、A 以 </parameter> 收尾）仍应正确拆成两个。
     #[test]
     fn test_invoke_burst_clean_two_blocks() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let payload = "count\n<invoke name=\"tool_a\"><parameter name=\"x\">1</parameter></invoke><invoke name=\"tool_b\"><parameter name=\"y\">2</parameter></invoke>";
         let mut all = Vec::new();
@@ -4416,7 +4775,10 @@ mod tests {
     #[test]
     fn test_invoke_real_leak_sample_from_thread_019e9e8d() {
         let known: std::collections::HashSet<String> =
-            ["exec_command", "update_plan", "update_goal"].iter().map(|s| s.to_string()).collect();
+            ["exec_command", "update_plan", "update_goal"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
         let mut ctx =
             StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), known);
         let _ = ctx.generate_initial_events();
@@ -4426,24 +4788,34 @@ mod tests {
         all.extend(ctx.process_assistant_response(real));
         all.extend(ctx.generate_final_events());
         let tools = collect_tool_uses(&all);
-        assert_eq!(tools.len(), 1, "真实泄漏样本应被捞回成 1 个 tool_use: {:?}", tools);
+        assert_eq!(
+            tools.len(),
+            1,
+            "真实泄漏样本应被捞回成 1 个 tool_use: {:?}",
+            tools
+        );
         assert_eq!(tools[0].0, "exec_command", "name 应为 exec_command");
         let parsed: serde_json::Value =
             serde_json::from_str(&tools[0].1).expect("input 应为合法 JSON");
         assert!(
             parsed["cmd"].as_str().unwrap_or("").contains("pytest"),
-            "cmd 参数应完整保留: {:?}", parsed
+            "cmd 参数应完整保留: {:?}",
+            parsed
         );
         assert_eq!(parsed["yield_time_ms"], "60000", "yield_time_ms 参数应保留");
         // 关键：字面 <invoke> 不应泄漏到 text
         let text = collect_text_content(&all);
         assert!(
             !text.contains("<invoke name=\"exec_command\">"),
-            "字面 <invoke> 不应泄漏到文本: {:?}", text
+            "字面 <invoke> 不应泄漏到文本: {:?}",
+            text
         );
         // count stray token 也不应泄漏
-        assert!(!text.contains("\ncount\n") && !text.ends_with("count"),
-            "count stray token 不应泄漏: {:?}", text);
+        assert!(
+            !text.contains("\ncount\n") && !text.ends_with("count"),
+            "count stray token 不应泄漏: {:?}",
+            text
+        );
     }
 
     // ---- 复读熔断 (repeat guard)：root cause = Opus 长上下文退化复读 ----
@@ -4452,8 +4824,13 @@ mod tests {
     /// 熔断后吐出的 count 数必须远小于喂入的数量，且不撑满输出。
     #[test]
     fn repeat_guard_trips_on_count_flood() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
 
         // 真实形态：正常话 + call + 海量 count（这里用 5000 次模拟 3.2 万次）
@@ -4483,8 +4860,13 @@ mod tests {
     /// 🟢 不误伤：正常工具调用前的 1 个引导词 `count` + 真 <invoke> 仍被正常捞回。
     #[test]
     fn repeat_guard_does_not_trip_on_single_stray_token() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let payload =
             "count\n<invoke name=\"exec_command\"><parameter name=\"cmd\">ls</parameter></invoke>";
@@ -4492,30 +4874,54 @@ mod tests {
         all.extend(ctx.process_assistant_response(payload));
         all.extend(ctx.generate_final_events());
         let tools = collect_tool_uses(&all);
-        assert_eq!(tools.len(), 1, "单个引导词不应触发熔断，invoke 应正常捞回: {:?}", tools);
+        assert_eq!(
+            tools.len(),
+            1,
+            "单个引导词不应触发熔断，invoke 应正常捞回: {:?}",
+            tools
+        );
         assert_eq!(tools[0].0, "exec_command");
     }
 
     /// 🟢 不误伤：正常多行文本里偶尔出现 count 单词（非独占行复读）不熔断。
     #[test]
     fn repeat_guard_does_not_trip_on_normal_prose() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
-        let payload = "我数了一下 count = 3，然后继续做别的事。\n这是第二行正常文字。\n第三行也正常。";
+        let payload =
+            "我数了一下 count = 3，然后继续做别的事。\n这是第二行正常文字。\n第三行也正常。";
         let mut all = Vec::new();
         all.extend(ctx.process_assistant_response(payload));
         all.extend(ctx.generate_final_events());
         let text = collect_text_content(&all);
-        assert!(text.contains("我数了一下"), "正常正文不应被熔断: {:?}", text);
-        assert!(text.contains("第三行也正常"), "正常正文应完整保留: {:?}", text);
+        assert!(
+            text.contains("我数了一下"),
+            "正常正文不应被熔断: {:?}",
+            text
+        );
+        assert!(
+            text.contains("第三行也正常"),
+            "正常正文应完整保留: {:?}",
+            text
+        );
     }
 
     /// 🟢 跨 chunk 复读也能熔断（流式分片到达，每片一个 count）。
     #[test]
     fn repeat_guard_trips_across_chunks() {
-        let mut ctx =
-            StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), test_known_tools());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
         let _ = ctx.generate_initial_events();
         let mut all = Vec::new();
         all.extend(ctx.process_assistant_response("call\n\n"));
@@ -4553,7 +4959,11 @@ mod tests {
             .collect();
         let emitted = joined.matches("count").count();
         assert!(emitted < 64, "块级路径应折叠 count 洪水：实际={}", emitted);
-        assert!(joined.contains("先看 crawlee 状态"), "正常正文应保留: {:?}", &joined[..joined.len().min(60)]);
+        assert!(
+            joined.contains("先看 crawlee 状态"),
+            "正常正文应保留: {:?}",
+            &joined[..joined.len().min(60)]
+        );
     }
 
     /// 🟢 块级不误伤：单个引导词 count + 真 invoke 仍被捞回。
@@ -4566,7 +4976,9 @@ mod tests {
             &std::collections::HashMap::new(),
         );
         assert!(
-            blocks.iter().any(|b| b["type"] == "tool_use" && b["name"] == "exec_command"),
+            blocks
+                .iter()
+                .any(|b| b["type"] == "tool_use" && b["name"] == "exec_command"),
             "单个引导词不应触发折叠，invoke 应捞回: {:?}",
             blocks
         );
@@ -4574,7 +4986,13 @@ mod tests {
 
     #[test]
     fn test_native_reasoning_event_emits_thinking_with_signature() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), std::collections::HashSet::new());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            std::collections::HashSet::new(),
+        );
         let mut all_events = ctx.generate_initial_events();
 
         all_events.extend(ctx.process_kiro_event(&Event::ReasoningContent(
@@ -4598,7 +5016,13 @@ mod tests {
 
     #[test]
     fn test_native_reasoning_signature_only_applies_to_next_thinking_text() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), std::collections::HashSet::new());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            std::collections::HashSet::new(),
+        );
         let mut all_events = ctx.generate_initial_events();
 
         all_events.extend(ctx.process_kiro_event(&Event::ReasoningContent(
@@ -4617,7 +5041,10 @@ mod tests {
         )));
         all_events.extend(ctx.generate_final_events());
 
-        assert_eq!(collect_thinking_content(&all_events), "delayed native reasoning");
+        assert_eq!(
+            collect_thinking_content(&all_events),
+            "delayed native reasoning"
+        );
         assert!(all_events.iter().any(|e| {
             e.event == "content_block_delta"
                 && e.data["delta"]["type"] == "signature_delta"
@@ -4627,7 +5054,13 @@ mod tests {
 
     #[test]
     fn test_native_reasoning_text_downgrades_to_text_when_thinking_disabled() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, false, HashMap::new(), std::collections::HashSet::new());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            std::collections::HashSet::new(),
+        );
         let mut all_events = ctx.generate_initial_events();
 
         all_events.extend(ctx.process_kiro_event(&Event::ReasoningContent(
@@ -4639,7 +5072,10 @@ mod tests {
         )));
         all_events.extend(ctx.generate_final_events());
 
-        assert_eq!(collect_text_content(&all_events), "visible reasoning fallback");
+        assert_eq!(
+            collect_text_content(&all_events),
+            "visible reasoning fallback"
+        );
         assert_eq!(collect_thinking_content(&all_events), "");
         assert!(!all_events.iter().any(|e| {
             e.event == "content_block_delta" && e.data["delta"]["type"] == "signature_delta"
@@ -4652,7 +5088,13 @@ mod tests {
 
     #[test]
     fn test_native_redacted_thinking_is_ordered_between_thinking_and_text() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), std::collections::HashSet::new());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            std::collections::HashSet::new(),
+        );
         let mut all_events = ctx.generate_initial_events();
 
         all_events.extend(ctx.process_kiro_event(&Event::ReasoningContent(
@@ -4693,7 +5135,13 @@ mod tests {
 
     #[test]
     fn test_native_reasoning_event_emits_redacted_thinking() {
-        let mut ctx = StreamContext::new_with_thinking("test-model", 1, true, HashMap::new(), std::collections::HashSet::new());
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            std::collections::HashSet::new(),
+        );
         let mut all_events = ctx.generate_initial_events();
 
         all_events.extend(ctx.process_kiro_event(&Event::ReasoningContent(
@@ -4736,9 +5184,7 @@ mod tests {
     #[test]
     fn test_generate_final_events_carries_credit_fields_when_metering_present() {
         let mut manager = SseStateManager::new();
-        let metering = parse_metering(
-            r#"{"unit":"credit","unitPlural":"credits","usage":0.75}"#,
-        );
+        let metering = parse_metering(r#"{"unit":"credit","unitPlural":"credits","usage":0.75}"#);
         let events = manager.generate_final_events(10, 5, 0, 0, Some(&metering));
         let delta = events
             .iter()
@@ -4811,5 +5257,111 @@ mod tests {
         assert!(usage.get("credit_usage").is_none());
         assert!(usage.get("credit_unit").is_none());
         assert!(usage.get("credit_unit_plural").is_none());
+    }
+
+    #[test]
+    fn provider_usage_overrides_fallback_and_keeps_the_latest_snapshot() {
+        use crate::anthropic::cache_metering::CacheUsage;
+        use crate::kiro::model::events::MetadataEvent;
+
+        let mut ctx = StreamContext::new_with_thinking(
+            "claude-opus-4-7",
+            100,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
+        ctx.context_input_tokens = Some(80);
+        ctx.output_tokens = 99;
+        ctx.cache_usage = CacheUsage {
+            cache_read: 25,
+            cache_covered_est: 50,
+            prompt_total_est: 100,
+        };
+
+        let _ = ctx.process_kiro_event(&Event::Metadata(MetadataEvent {
+            token_usage: Some(TokenUsage {
+                uncached_input_tokens: 3,
+                output_tokens: 11,
+                cache_read_input_tokens: 7,
+                cache_write_input_tokens: 4,
+            }),
+        }));
+        let _ = ctx.process_kiro_event(&Event::Metadata(MetadataEvent { token_usage: None }));
+        assert_eq!(ctx.resolved_usage(), (3, 4, 7));
+        assert_eq!(ctx.resolved_output_tokens(), 11);
+
+        let _ = ctx.process_kiro_event(&Event::Metadata(MetadataEvent {
+            token_usage: Some(TokenUsage {
+                uncached_input_tokens: -1,
+                output_tokens: 22,
+                cache_read_input_tokens: 23,
+                cache_write_input_tokens: 24,
+            }),
+        }));
+        assert_eq!(ctx.resolved_usage(), (0, 24, 23));
+        assert_eq!(ctx.resolved_output_tokens(), 22);
+    }
+
+    #[test]
+    fn stream_usage_falls_back_to_context_cache_split_and_local_output() {
+        use crate::anthropic::cache_metering::CacheUsage;
+
+        let mut ctx = StreamContext::new_with_thinking(
+            "claude-opus-4-7",
+            100,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
+        ctx.context_input_tokens = Some(80);
+        ctx.output_tokens = 9;
+        ctx.cache_usage = CacheUsage {
+            cache_read: 25,
+            cache_covered_est: 50,
+            prompt_total_est: 100,
+        };
+
+        assert_eq!(ctx.resolved_usage(), (40, 20, 20));
+        assert_eq!(ctx.resolved_output_tokens(), 9);
+    }
+
+    #[test]
+    fn buffered_stream_reports_the_same_provider_usage_in_events_and_final_usage() {
+        use crate::kiro::model::events::MetadataEvent;
+
+        let usage = TokenUsage {
+            uncached_input_tokens: 3,
+            output_tokens: 11,
+            cache_read_input_tokens: 7,
+            cache_write_input_tokens: 4,
+        };
+        let mut ctx = BufferedStreamContext::new(
+            "claude-opus-4-7",
+            100,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
+        ctx.process_and_buffer(&Event::Metadata(MetadataEvent {
+            token_usage: Some(usage),
+        }));
+        let events = ctx.finish_and_get_all_events();
+
+        assert_eq!(ctx.final_usage(), (3, 11, 4, 7, 0.0));
+        let start_usage = &events
+            .iter()
+            .find(|event| event.event == "message_start")
+            .unwrap()
+            .data["message"]["usage"];
+        assert_eq!(start_usage["input_tokens"], json!(3));
+        assert_eq!(start_usage["cache_creation_input_tokens"], json!(4));
+        assert_eq!(start_usage["cache_read_input_tokens"], json!(7));
+        let delta_usage = &events
+            .iter()
+            .find(|event| event.event == "message_delta")
+            .unwrap()
+            .data["usage"];
+        assert_eq!(delta_usage["output_tokens"], json!(11));
     }
 }

--- a/src/anthropic/websearch.rs
+++ b/src/anthropic/websearch.rs
@@ -549,7 +549,19 @@ fn render_websearch_response(
         let summary = generate_search_summary(&query, &search_results);
         let output_tokens = (summary.len() as i32 + 3) / 4;
         // 本地 WebSearch 不走上游，不会收到 meteringEvent，因此也不带 credit_* 字段。
-        super::websearch_loop::render_json(&model, content, "end_turn", input_tokens, output_tokens, "", None)
+        super::websearch_loop::render_json(
+            &model,
+            content,
+            "end_turn",
+            crate::kiro::model::events::TokenUsage {
+                uncached_input_tokens: input_tokens,
+                output_tokens,
+                cache_read_input_tokens: 0,
+                cache_write_input_tokens: 0,
+            },
+            "",
+            None,
+        )
     }
 }
 

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -20,18 +20,18 @@ use futures::{StreamExt, stream};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::kiro::model::events::{Event, MeteringEvent};
+use crate::kiro::model::events::{Event, MeteringEvent, TokenUsage};
 use crate::kiro::model::requests::kiro::KiroRequest;
 use crate::kiro::parser::decoder::EventStreamDecoder;
 use crate::kiro::provider::KiroProvider;
 use crate::token;
 
 use super::converter::{ConversionError, convert_request_with_mode, get_context_window_size};
-use crate::model::config::ToolCompatibilityMode;
 use super::handlers::{UsageRecordHook, map_provider_error};
 use super::stream::{CompletedToolUse, SseEvent};
 use super::types::{ErrorResponse, Message, MessagesRequest};
 use super::websearch::{self, WebSearchResults};
+use crate::model::config::ToolCompatibilityMode;
 
 /// Maximum number of search rounds, to prevent an infinite loop if the upstream keeps asking to search
 const MAX_WEB_SEARCH_ROUNDS: usize = 5;
@@ -61,6 +61,8 @@ struct RoundOutcome {
     tool_uses: Vec<CompletedToolUse>,
     /// Actual input tokens computed from contextUsageEvent
     context_input_tokens: Option<i32>,
+    /// metadataEvent.tokenUsage 的单轮精确最终快照。
+    provider_token_usage: Option<TokenUsage>,
     /// Cumulative credits from meteringEvent (sum of usage across rounds)
     credits: f64,
     /// 最近一次 meteringEvent 完整 payload（含 unit / unit_plural / usage）。
@@ -81,6 +83,38 @@ struct RoundOutcome {
     /// `ConversionResult::tool_name_map`. Used to restore the original tool name when a
     /// leaked `<invoke>` carries a shortened (>63 char) tool name.
     tool_name_map: std::collections::HashMap<String, String>,
+}
+
+impl RoundOutcome {
+    /// 解析本次 provider 调用的 token 用量；精确 metadata 缺失时只回退本轮。
+    fn resolved_token_usage(&self, fallback_input_tokens: i32) -> TokenUsage {
+        if let Some(usage) = self.provider_token_usage {
+            return usage.sanitized();
+        }
+
+        let mut output = Vec::new();
+        if !self.thinking.is_empty() {
+            output.push(json!({"type": "thinking", "thinking": self.thinking}));
+        }
+        if !self.text.is_empty() {
+            output.push(json!({"type": "text", "text": self.text}));
+        }
+        output.extend(
+            self.tool_uses
+                .iter()
+                .map(CompletedToolUse::to_anthropic_block),
+        );
+
+        TokenUsage {
+            uncached_input_tokens: self
+                .context_input_tokens
+                .unwrap_or(fallback_input_tokens)
+                .max(0),
+            output_tokens: token::estimate_output_tokens(&output),
+            cache_read_input_tokens: 0,
+            cache_write_input_tokens: 0,
+        }
+    }
 }
 
 /// Normalize model-produced Web Search input into one non-empty query.
@@ -150,8 +184,7 @@ fn log_normalized_web_search_query(tu: &CompletedToolUse, query: &str) {
 /// Continue condition: every tool_use this round is web_search (at least one) and the round limit has not been reached.
 /// As soon as a client tool such as exec is mixed in, there is no tool_use at all, or the limit is reached, it stops and flushes (exec is never swallowed).
 fn should_search_round(round_idx: usize, tool_uses: &[CompletedToolUse]) -> bool {
-    let only_web_search =
-        !tool_uses.is_empty() && tool_uses.iter().all(|t| t.name == "web_search");
+    let only_web_search = !tool_uses.is_empty() && tool_uses.iter().all(|t| t.name == "web_search");
     only_web_search && round_idx < MAX_WEB_SEARCH_ROUNDS
 }
 
@@ -208,6 +241,7 @@ async fn decode_round(
     let mut order: Vec<String> = Vec::new();
     let mut tool_uses: Vec<CompletedToolUse> = Vec::new();
     let mut context_input_tokens: Option<i32> = None;
+    let mut provider_token_usage: Option<TokenUsage> = None;
     let mut credits = 0.0;
     let mut last_metering: Option<MeteringEvent> = None;
     let mut stop_reason_override: Option<String> = None;
@@ -253,6 +287,12 @@ async fn decode_round(
                         entry.0 = tu.name.clone();
                     }
                     entry.1.push_str(&tu.input);
+                }
+                Event::Metadata(metadata) => {
+                    if let Some(usage) = metadata.token_usage {
+                        // 单条流内重复 metadata 是快照，取最后一份。
+                        provider_token_usage = Some(usage.sanitized());
+                    }
                 }
                 Event::ContextUsage(cu) => {
                     let window = get_context_window_size(model);
@@ -300,6 +340,7 @@ async fn decode_round(
         thinking,
         tool_uses,
         context_input_tokens,
+        provider_token_usage,
         credits,
         last_metering,
         stop_reason_override,
@@ -311,24 +352,33 @@ async fn decode_round(
     }
 }
 
-/// Run one upstream round (convert + streaming request + buffer decode)
+/// A failed round plus any usage that can still be attributed to its provider call.
+struct RoundFailure {
+    response: Response,
+    credential_id: u64,
+    token_usage: Option<TokenUsage>,
+    credits: f64,
+}
+
+/// Run one upstream round (convert + streaming request + buffer decode).
 ///
-/// On upstream/conversion failure, returns Err(an already-constructed pass-through error Response)
+/// Usage recording belongs to the outer loop so every terminal path writes exactly one
+/// aggregate. A failure after a provider call carries the usage already observed in that call.
 async fn run_round(
     provider: &Arc<KiroProvider>,
     payload: &MessagesRequest,
-    hook: &UsageRecordHook,
     fallback_input_tokens: i32,
     group: Option<&str>,
     tool_compatibility_mode: ToolCompatibilityMode,
-) -> Result<(RoundOutcome, u64), Response> {
+) -> Result<(RoundOutcome, u64), RoundFailure> {
     let conversion = match convert_request_with_mode(payload, tool_compatibility_mode) {
         Ok(c) => c,
         Err(e) => {
             let (et, msg) = match &e {
-                ConversionError::InvalidModel(reason) => {
-                    ("invalid_request_error", format!("invalid model id: {}", reason))
-                }
+                ConversionError::InvalidModel(reason) => (
+                    "invalid_request_error",
+                    format!("invalid model id: {}", reason),
+                ),
                 ConversionError::EmptyMessages => {
                     ("invalid_request_error", "message list is empty".to_string())
                 }
@@ -337,8 +387,13 @@ async fn run_round(
                     format!("unsupported tool mapping: {}", reason),
                 ),
             };
-            hook.record(0, 0, 0, 0, 0, 0.0, "error");
-            return Err((StatusCode::BAD_REQUEST, Json(ErrorResponse::new(et, msg))).into_response());
+            return Err(RoundFailure {
+                response: (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(et, msg)))
+                    .into_response(),
+                credential_id: 0,
+                token_usage: None,
+                credits: 0.0,
+            });
         }
     };
 
@@ -350,42 +405,66 @@ async fn run_round(
     let request_body = match serde_json::to_string(&kiro_request) {
         Ok(b) => b,
         Err(e) => {
-            hook.record(0, 0, 0, 0, 0, 0.0, "error");
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("internal_error", format!("failed to serialize request: {}", e))),
-            )
-                .into_response());
+            return Err(RoundFailure {
+                response: (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "internal_error",
+                        format!("failed to serialize request: {}", e),
+                    )),
+                )
+                    .into_response(),
+                credential_id: 0,
+                token_usage: None,
+                credits: 0.0,
+            });
         }
     };
 
     let call_result = match provider.call_api_stream(&request_body, None, group).await {
         Ok(r) => r,
         Err(e) => {
-            hook.record(0, fallback_input_tokens, 0, 0, 0, 0.0, "error");
-            return Err(map_provider_error(e));
+            return Err(RoundFailure {
+                response: map_provider_error(e),
+                credential_id: 0,
+                token_usage: Some(TokenUsage {
+                    uncached_input_tokens: fallback_input_tokens.max(0),
+                    ..TokenUsage::default()
+                }),
+                credits: 0.0,
+            });
         }
     };
     let credential_id = call_result.credential_id;
-    let mut outcome =
-        decode_round(call_result.response, &payload.model, &conversion.tool_name_map).await;
+    let mut outcome = decode_round(
+        call_result.response,
+        &payload.model,
+        &conversion.tool_name_map,
+    )
+    .await;
     // Carry the declared tool names (original + shortened) so the flush step can run the
     // shared `<invoke>` text-leak fault tolerance with a correct tool-table guard.
     outcome.known_tool_names = conversion.known_tool_names;
     // Carry the short->original tool name map so reclaimed <invoke> names get restored.
     outcome.tool_name_map = conversion.tool_name_map;
     if outcome.stream_error {
-        // The upstream stream was cut off mid-round; the decoded content is partial,
-        // so fail the round instead of feeding truncated text/tool_use back into the loop.
-        hook.record(0, fallback_input_tokens, 0, 0, 0, 0.0, "error");
-        return Err((
-            StatusCode::BAD_GATEWAY,
-            Json(ErrorResponse::new(
-                "upstream_error",
-                "Upstream response stream ended unexpectedly during the web_search loop.".to_string(),
-            )),
-        )
-            .into_response());
+        // The stream is partial and cannot re-enter the search loop, but any final metadata
+        // snapshot/credits observed before the cut still belong to this real provider call.
+        let token_usage = outcome.resolved_token_usage(fallback_input_tokens);
+        return Err(RoundFailure {
+            response: (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse::new(
+                    "upstream_error",
+                    "Upstream response stream ended unexpectedly during the web_search loop."
+                        .to_string(),
+                )),
+            )
+                .into_response(),
+            credential_id,
+            token_usage: Some(token_usage),
+            credits: outcome.credits,
+        });
     }
     Ok((outcome, credential_id))
 }
@@ -588,7 +667,8 @@ fn build_flush_content(
             .filter(|t| t.name != "web_search")
             .map(|t| (t.name.clone(), canonical_input_key(&t.input)))
             .collect();
-        for block in super::stream::extract_invoke_content_blocks(text, &reclaim_tools, tool_name_map)
+        for block in
+            super::stream::extract_invoke_content_blocks(text, &reclaim_tools, tool_name_map)
         {
             if block.get("type").and_then(|v| v.as_str()) == Some("tool_use") {
                 let name = block.get("name").and_then(|v| v.as_str()).unwrap_or("");
@@ -631,6 +711,25 @@ fn build_flush_content(
     content
 }
 
+fn record_aggregated_usage(
+    hook: &UsageRecordHook,
+    credential_id: u64,
+    usage: TokenUsage,
+    credits: f64,
+    status: &str,
+) {
+    let usage = usage.sanitized();
+    hook.record(
+        credential_id,
+        usage.uncached_input_tokens,
+        usage.output_tokens,
+        usage.cache_write_input_tokens,
+        usage.cache_read_input_tokens,
+        credits,
+        status,
+    );
+}
+
 /// web_search loop entry point
 ///
 /// `stream_client`: whether the client wants SSE (true) or a single JSON response (false).
@@ -642,16 +741,9 @@ pub(super) async fn run_web_search_loop(
     group: Option<String>,
     tool_compatibility_mode: ToolCompatibilityMode,
 ) -> Response {
-    let fallback_input_tokens = token::count_all_tokens(
-        payload.model.clone(),
-        payload.system.clone(),
-        payload.messages.clone(),
-        payload.tools.clone(),
-    ) as i32;
-
     let mut presentation: Vec<Value> = Vec::new();
     let mut last_credential_id: u64 = 0;
-    let mut last_context_input: Option<i32> = None;
+    let mut total_token_usage = TokenUsage::default();
     let mut total_credits = 0.0;
     let mut latest_metering: Option<MeteringEvent> = None;
     let mut all_thinking = String::new();
@@ -659,22 +751,43 @@ pub(super) async fn run_web_search_loop(
     for round_idx in 0..=MAX_WEB_SEARCH_ROUNDS {
         let mut empty_retries = 0usize;
         let round = loop {
-            let (round, credential_id) =
-                match run_round(
-                    &provider,
-                    &payload,
-                    &hook,
-                    fallback_input_tokens,
-                    group.as_deref(),
-                    tool_compatibility_mode,
-                )
-                .await
-                {
-                    Ok(v) => v,
-                    Err(resp) => return resp,
-                };
+            let round_fallback_input_tokens = token::count_all_tokens(
+                payload.model.clone(),
+                payload.system.clone(),
+                payload.messages.clone(),
+                payload.tools.clone(),
+            ) as i32;
+            let (round, credential_id) = match run_round(
+                &provider,
+                &payload,
+                round_fallback_input_tokens,
+                group.as_deref(),
+                tool_compatibility_mode,
+            )
+            .await
+            {
+                Ok(v) => v,
+                Err(failure) => {
+                    if failure.credential_id != 0 {
+                        last_credential_id = failure.credential_id;
+                    }
+                    if let Some(usage) = failure.token_usage {
+                        total_token_usage = total_token_usage.saturating_add(usage);
+                    }
+                    total_credits += failure.credits;
+                    record_aggregated_usage(
+                        &hook,
+                        last_credential_id,
+                        total_token_usage,
+                        total_credits,
+                        "error",
+                    );
+                    return failure.response;
+                }
+            };
             last_credential_id = credential_id;
-            last_context_input = round.context_input_tokens.or(last_context_input);
+            total_token_usage = total_token_usage
+                .saturating_add(round.resolved_token_usage(round_fallback_input_tokens));
             total_credits += round.credits;
             // 跨 round 保留最近一次 meteringEvent，多 round 时取最后一次
             // (clone 以避免与 empty_tool_result_disposition 后续对 round 的借用冲突)。
@@ -694,13 +807,10 @@ pub(super) async fn run_web_search_loop(
                     continue;
                 }
                 EmptyToolResultDisposition::Fail => {
-                    let final_input = last_context_input.unwrap_or(fallback_input_tokens);
-                    hook.record(
+                    record_aggregated_usage(
+                        &hook,
                         last_credential_id,
-                        final_input,
-                        0,
-                        0,
-                        0,
+                        total_token_usage,
                         total_credits,
                         "error",
                     );
@@ -735,7 +845,8 @@ pub(super) async fn run_web_search_loop(
 
         if should_search_round(round_idx, &round.tool_uses) {
             // Real search: if any one fails -> propagate the error, never silently turn it into "No results found"
-            let mut searched: Vec<Option<WebSearchResults>> = Vec::with_capacity(round.tool_uses.len());
+            let mut searched: Vec<Option<WebSearchResults>> =
+                Vec::with_capacity(round.tool_uses.len());
             for tu in &round.tool_uses {
                 let Some(query) = tool_query(tu) else {
                     log_invalid_web_search_input(tu);
@@ -747,17 +858,17 @@ pub(super) async fn run_web_search_loop(
                 match websearch::call_mcp_api(&provider, &mcp_request, group.as_deref()).await {
                     Ok(resp) => searched.push(websearch::parse_search_results(&resp)),
                     Err(e) if is_no_results_mcp_error(&e) => {
-                        tracing::warn!("web_search MCP returned no results; continuing with an empty result");
+                        tracing::warn!(
+                            "web_search MCP returned no results; continuing with an empty result"
+                        );
                         searched.push(None);
                     }
                     Err(e) => {
                         tracing::warn!("web_search MCP call failed: {}", e);
-                        hook.record(
+                        record_aggregated_usage(
+                            &hook,
                             last_credential_id,
-                            fallback_input_tokens,
-                            0,
-                            0,
-                            0,
+                            total_token_usage,
                             total_credits,
                             "error",
                         );
@@ -775,7 +886,6 @@ pub(super) async fn run_web_search_loop(
         // web_search must end as "end_turn", not "tool_use" (otherwise the host would
         // wait for a client tool call that is never emitted).
         let (_web_uses, client_uses) = partition_tool_uses(&round.tool_uses);
-        let final_input = last_context_input.unwrap_or(fallback_input_tokens);
         // INVARIANT: web_search is ALWAYS executed internally and is NEVER flushed
         // as a raw tool_use (the Codex host has no executor for it and rejects it
         // with "unsupported call: web_search"). This covers the mixed-round case
@@ -796,17 +906,17 @@ pub(super) async fn run_web_search_loop(
                 match websearch::call_mcp_api(&provider, &mcp_request, group.as_deref()).await {
                     Ok(resp) => searched.push(websearch::parse_search_results(&resp)),
                     Err(e) if is_no_results_mcp_error(&e) => {
-                        tracing::warn!("web_search MCP returned no results in final round; continuing with an empty result");
+                        tracing::warn!(
+                            "web_search MCP returned no results in final round; continuing with an empty result"
+                        );
                         searched.push(None);
                     }
                     Err(e) => {
                         tracing::warn!("web_search MCP call (final round) failed: {}", e);
-                        hook.record(
+                        record_aggregated_usage(
+                            &hook,
                             last_credential_id,
-                            fallback_input_tokens,
-                            0,
-                            0,
-                            0,
+                            total_token_usage,
                             total_credits,
                             "error",
                         );
@@ -835,13 +945,11 @@ pub(super) async fn run_web_search_loop(
             &content,
         );
 
-        let output_tokens = token::estimate_output_tokens(&content);
-        hook.record(
+        let final_usage = total_token_usage.sanitized();
+        record_aggregated_usage(
+            &hook,
             last_credential_id,
-            final_input,
-            output_tokens,
-            0,
-            0,
+            final_usage,
             total_credits,
             "success",
         );
@@ -851,8 +959,7 @@ pub(super) async fn run_web_search_loop(
                 &payload.model,
                 content,
                 &stop_reason,
-                final_input,
-                output_tokens,
+                final_usage,
                 latest_metering.as_ref(),
             )
         } else {
@@ -860,8 +967,7 @@ pub(super) async fn run_web_search_loop(
                 &payload.model,
                 content,
                 &stop_reason,
-                final_input,
-                output_tokens,
+                final_usage,
                 &all_thinking,
                 latest_metering.as_ref(),
             )
@@ -869,10 +975,19 @@ pub(super) async fn run_web_search_loop(
     }
 
     // Theoretically unreachable (the loop always returns)
-    hook.record(last_credential_id, fallback_input_tokens, 0, 0, 0, total_credits, "error");
+    record_aggregated_usage(
+        &hook,
+        last_credential_id,
+        total_token_usage,
+        total_credits,
+        "error",
+    );
     (
         StatusCode::INTERNAL_SERVER_ERROR,
-        Json(ErrorResponse::new("internal_error", "web_search loop exited unexpectedly")),
+        Json(ErrorResponse::new(
+            "internal_error",
+            "web_search loop exited unexpectedly",
+        )),
     )
         .into_response()
 }
@@ -888,16 +1003,16 @@ pub(crate) fn render_json(
     model: &str,
     content: Vec<Value>,
     stop_reason: &str,
-    input_tokens: i32,
-    output_tokens: i32,
+    token_usage: TokenUsage,
     thinking: &str,
     metering: Option<&MeteringEvent>,
 ) -> Response {
+    let token_usage = token_usage.sanitized();
     let mut usage = json!({
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens,
-        "cache_creation_input_tokens": 0,
-        "cache_read_input_tokens": 0
+        "input_tokens": token_usage.uncached_input_tokens,
+        "output_tokens": token_usage.output_tokens,
+        "cache_creation_input_tokens": token_usage.cache_write_input_tokens,
+        "cache_read_input_tokens": token_usage.cache_read_input_tokens
     });
     // 透传上游 meteringEvent 的 credit_* 字段，让客户端拿到与 Kiro 后端口径
     // 一致的计费元数据；只在收到过 meteringEvent 时才追加。
@@ -927,11 +1042,10 @@ pub(crate) fn render_sse(
     model: &str,
     content: Vec<Value>,
     stop_reason: &str,
-    input_tokens: i32,
-    output_tokens: i32,
+    token_usage: TokenUsage,
     metering: Option<&MeteringEvent>,
 ) -> Response {
-    let events = build_sse_events(model, content, stop_reason, input_tokens, output_tokens, metering);
+    let events = build_sse_events(model, content, stop_reason, token_usage, metering);
     let stream = stream::iter(
         events
             .into_iter()
@@ -951,15 +1065,12 @@ fn build_sse_events(
     model: &str,
     content: Vec<Value>,
     stop_reason: &str,
-    input_tokens: i32,
-    output_tokens: i32,
+    token_usage: TokenUsage,
     metering: Option<&MeteringEvent>,
 ) -> Vec<SseEvent> {
+    let token_usage = token_usage.sanitized();
     let mut events = Vec::new();
-    let message_id = format!(
-        "msg_{}",
-        &Uuid::new_v4().to_string().replace('-', "")[..24]
-    );
+    let message_id = format!("msg_{}", &Uuid::new_v4().to_string().replace('-', "")[..24]);
 
     events.push(SseEvent::new(
         "message_start",
@@ -974,10 +1085,10 @@ fn build_sse_events(
                 "stop_reason": null,
                 "stop_sequence": null,
                 "usage": {
-                    "input_tokens": input_tokens,
+                    "input_tokens": token_usage.uncached_input_tokens,
                     "output_tokens": 0,
-                    "cache_creation_input_tokens": 0,
-                    "cache_read_input_tokens": 0
+                    "cache_creation_input_tokens": token_usage.cache_write_input_tokens,
+                    "cache_read_input_tokens": token_usage.cache_read_input_tokens
                 }
             }
         }),
@@ -989,61 +1100,91 @@ fn build_sse_events(
         match btype {
             "text" => {
                 let text = block.get("text").and_then(|v| v.as_str()).unwrap_or("");
-                events.push(SseEvent::new("content_block_start", json!({
-                    "type": "content_block_start", "index": index,
-                    "content_block": {"type": "text", "text": ""}
-                })));
-                events.push(SseEvent::new("content_block_delta", json!({
-                    "type": "content_block_delta", "index": index,
-                    "delta": {"type": "text_delta", "text": text}
-                })));
-                events.push(SseEvent::new("content_block_stop", json!({
-                    "type": "content_block_stop", "index": index
-                })));
+                events.push(SseEvent::new(
+                    "content_block_start",
+                    json!({
+                        "type": "content_block_start", "index": index,
+                        "content_block": {"type": "text", "text": ""}
+                    }),
+                ));
+                events.push(SseEvent::new(
+                    "content_block_delta",
+                    json!({
+                        "type": "content_block_delta", "index": index,
+                        "delta": {"type": "text_delta", "text": text}
+                    }),
+                ));
+                events.push(SseEvent::new(
+                    "content_block_stop",
+                    json!({
+                        "type": "content_block_stop", "index": index
+                    }),
+                ));
             }
             "tool_use" => {
                 let id = block.get("id").and_then(|v| v.as_str()).unwrap_or("");
                 let name = block.get("name").and_then(|v| v.as_str()).unwrap_or("");
                 let input = block.get("input").cloned().unwrap_or_else(|| json!({}));
                 let partial = serde_json::to_string(&input).unwrap_or_else(|_| "{}".to_string());
-                events.push(SseEvent::new("content_block_start", json!({
-                    "type": "content_block_start", "index": index,
-                    "content_block": {"type": "tool_use", "id": id, "name": name, "input": {}}
-                })));
-                events.push(SseEvent::new("content_block_delta", json!({
-                    "type": "content_block_delta", "index": index,
-                    "delta": {"type": "input_json_delta", "partial_json": partial}
-                })));
-                events.push(SseEvent::new("content_block_stop", json!({
-                    "type": "content_block_stop", "index": index
-                })));
+                events.push(SseEvent::new(
+                    "content_block_start",
+                    json!({
+                        "type": "content_block_start", "index": index,
+                        "content_block": {"type": "tool_use", "id": id, "name": name, "input": {}}
+                    }),
+                ));
+                events.push(SseEvent::new(
+                    "content_block_delta",
+                    json!({
+                        "type": "content_block_delta", "index": index,
+                        "delta": {"type": "input_json_delta", "partial_json": partial}
+                    }),
+                ));
+                events.push(SseEvent::new(
+                    "content_block_stop",
+                    json!({
+                        "type": "content_block_stop", "index": index
+                    }),
+                ));
             }
             "server_tool_use" | "web_search_tool_result" => {
-                events.push(SseEvent::new("content_block_start", json!({
-                    "type": "content_block_start", "index": index,
-                    "content_block": block
-                })));
-                events.push(SseEvent::new("content_block_stop", json!({
-                    "type": "content_block_stop", "index": index
-                })));
+                events.push(SseEvent::new(
+                    "content_block_start",
+                    json!({
+                        "type": "content_block_start", "index": index,
+                        "content_block": block
+                    }),
+                ));
+                events.push(SseEvent::new(
+                    "content_block_stop",
+                    json!({
+                        "type": "content_block_stop", "index": index
+                    }),
+                ));
             }
             _ => {}
         }
     }
 
-    let mut message_delta_usage = json!({ "output_tokens": output_tokens });
+    let mut message_delta_usage = json!({ "output_tokens": token_usage.output_tokens });
     // 透传上游 meteringEvent 的 credit_* 字段（仅在拿到 meteringEvent 时）。
     if let Some(m) = metering {
         message_delta_usage["credit_usage"] = json!(m.usage);
         message_delta_usage["credit_unit"] = json!(m.unit);
         message_delta_usage["credit_unit_plural"] = json!(m.unit_plural);
     }
-    events.push(SseEvent::new("message_delta", json!({
-        "type": "message_delta",
-        "delta": {"stop_reason": stop_reason},
-        "usage": message_delta_usage
-    })));
-    events.push(SseEvent::new("message_stop", json!({"type": "message_stop"})));
+    events.push(SseEvent::new(
+        "message_delta",
+        json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason},
+            "usage": message_delta_usage
+        }),
+    ));
+    events.push(SseEvent::new(
+        "message_stop",
+        json!({"type": "message_stop"}),
+    ));
 
     events
 }
@@ -1071,10 +1212,22 @@ mod tests {
 
     #[test]
     fn tool_query_normalizes_supported_input_shapes() {
-        assert_eq!(tool_query(&tu_with_input(json!({"query": "  rust 2026  "}))), Some("rust 2026".to_string()));
-        assert_eq!(tool_query(&tu_with_input(json!({"search_query": "南京演唱会"}))), Some("南京演唱会".to_string()));
-        assert_eq!(tool_query(&tu_with_input(json!({"queries": ["", "上海天气"]}))), Some("上海天气".to_string()));
-        assert_eq!(tool_query(&tu_with_input(json!({"query": {"text": "Paris weather"}}))), Some("Paris weather".to_string()));
+        assert_eq!(
+            tool_query(&tu_with_input(json!({"query": "  rust 2026  "}))),
+            Some("rust 2026".to_string())
+        );
+        assert_eq!(
+            tool_query(&tu_with_input(json!({"search_query": "南京演唱会"}))),
+            Some("南京演唱会".to_string())
+        );
+        assert_eq!(
+            tool_query(&tu_with_input(json!({"queries": ["", "上海天气"]}))),
+            Some("上海天气".to_string())
+        );
+        assert_eq!(
+            tool_query(&tu_with_input(json!({"query": {"text": "Paris weather"}}))),
+            Some("Paris weather".to_string())
+        );
     }
 
     #[test]
@@ -1086,8 +1239,12 @@ mod tests {
 
     #[test]
     fn no_results_mcp_error_is_nonfatal() {
-        assert!(is_no_results_mcp_error(&anyhow::anyhow!("MCP error: -32602 - Tool returned no results")));
-        assert!(!is_no_results_mcp_error(&anyhow::anyhow!("MCP error: -32602 - Invalid tool parameters provided")));
+        assert!(is_no_results_mcp_error(&anyhow::anyhow!(
+            "MCP error: -32602 - Tool returned no results"
+        )));
+        assert!(!is_no_results_mcp_error(&anyhow::anyhow!(
+            "MCP error: -32602 - Invalid tool parameters provided"
+        )));
     }
 
     /// Build a known-tool-names set for build_flush_content tests.
@@ -1133,6 +1290,7 @@ mod tests {
             thinking: String::new(),
             tool_uses,
             context_input_tokens: None,
+            provider_token_usage: None,
             credits: 0.0,
             last_metering: None,
             stop_reason_override: None,
@@ -1322,7 +1480,13 @@ mod tests {
             json!({"type": "text", "text": "done"}),
             json!({"type": "tool_use", "id": "toolu_exec", "name": "exec", "input": {"cmd": "ls"}}),
         ];
-        let events = build_sse_events("claude-sonnet-4-8", content, "tool_use", 10, 5, None);
+        let events = build_sse_events(
+            "claude-sonnet-4-8",
+            content,
+            "tool_use",
+            token_usage(10, 5),
+            None,
+        );
 
         // Must contain message_start / message_delta(stop_reason) / message_stop
         assert_eq!(events.first().unwrap().event, "message_start");
@@ -1332,17 +1496,22 @@ mod tests {
 
         // the server_tool_use block is placed into content_block_start as-is
         let has_server_tool = events.iter().any(|e| {
-            e.event == "content_block_start"
-                && e.data["content_block"]["type"] == "server_tool_use"
+            e.event == "content_block_start" && e.data["content_block"]["type"] == "server_tool_use"
         });
-        assert!(has_server_tool, "the server_tool_use block should be presented");
+        assert!(
+            has_server_tool,
+            "the server_tool_use block should be presented"
+        );
 
         // the web_search_tool_result block is presented
         let has_result = events.iter().any(|e| {
             e.event == "content_block_start"
                 && e.data["content_block"]["type"] == "web_search_tool_result"
         });
-        assert!(has_result, "the web_search_tool_result block should be presented");
+        assert!(
+            has_result,
+            "the web_search_tool_result block should be presented"
+        );
 
         // exec tool_use is not swallowed: name=exec appears in start
         let has_exec = events.iter().any(|e| {
@@ -1350,7 +1519,10 @@ mod tests {
                 && e.data["content_block"]["type"] == "tool_use"
                 && e.data["content_block"]["name"] == "exec"
         });
-        assert!(has_exec, "the exec tool_use must be returned to the client as-is and not swallowed");
+        assert!(
+            has_exec,
+            "the exec tool_use must be returned to the client as-is and not swallowed"
+        );
     }
     // ---- INVARIANT: web_search must NEVER leave kiro-rs as a raw tool_use ----
     // Regression for the "mixed-round leak": when the final round mixes web_search
@@ -1382,8 +1554,14 @@ mod tests {
     fn flush_content_mixed_round_never_emits_raw_web_search() {
         let tool_uses = vec![tu("web_search"), tu("exec")];
         let searched = vec![fake_results("rust 2026"), None];
-        let content =
-            build_flush_content(Vec::new(), "answer", &tool_uses, &searched, &names(&["exec"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            "answer",
+            &tool_uses,
+            &searched,
+            &names(&["exec"]),
+            &nomap(),
+        );
 
         let raw_web_search = content
             .iter()
@@ -1424,7 +1602,14 @@ mod tests {
     fn flush_content_client_tools_only_passthrough() {
         let tool_uses = vec![tu("exec")];
         let searched: Vec<Option<WebSearchResults>> = vec![None];
-        let content = build_flush_content(Vec::new(), "", &tool_uses, &searched, &names(&["exec"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            "",
+            &tool_uses,
+            &searched,
+            &names(&["exec"]),
+            &nomap(),
+        );
         assert!(
             content
                 .iter()
@@ -1468,10 +1653,17 @@ mod tests {
             content
         );
         let reclaimed = content.iter().find(|c| c["type"] == "tool_use");
-        assert!(reclaimed.is_some(), "must reclaim a structured tool_use. content={:?}", content);
+        assert!(
+            reclaimed.is_some(),
+            "must reclaim a structured tool_use. content={:?}",
+            content
+        );
         let tu = reclaimed.unwrap();
         assert_eq!(tu["name"], "exec_command");
-        assert_eq!(tu["input"]["cmd"], "echo hi", "parameter must be parsed into input");
+        assert_eq!(
+            tu["input"]["cmd"], "echo hi",
+            "parameter must be parsed into input"
+        );
         // the stray `call` line in front of the invoke must be stripped, not leaked
         assert!(
             !content
@@ -1486,15 +1678,29 @@ mod tests {
         // Narrative text before the leaked invoke must be preserved as a text block,
         // and the invoke still reclaimed.
         let leaked = "Here is the result.\n<invoke name=\"exec_command\">\n<parameter name=\"cmd\">ls</parameter>\n</invoke>";
-        let content = build_flush_content(Vec::new(), leaked, &[], &[], &names(&["exec_command"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            leaked,
+            &[],
+            &[],
+            &names(&["exec_command"]),
+            &nomap(),
+        );
         assert!(!leaks_literal_invoke(&content));
         assert!(
             content.iter().any(|c| c["type"] == "text"
-                && c["text"].as_str().unwrap_or("").contains("Here is the result.")),
+                && c["text"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("Here is the result.")),
             "narrative text must be preserved. content={:?}",
             content
         );
-        assert!(content.iter().any(|c| c["type"] == "tool_use" && c["name"] == "exec_command"));
+        assert!(
+            content
+                .iter()
+                .any(|c| c["type"] == "tool_use" && c["name"] == "exec_command")
+        );
     }
 
     // ---- SAFETY GATES: must NOT reclaim (would risk executing discussed commands) ----
@@ -1504,7 +1710,14 @@ mod tests {
         // An <invoke> shown inside a ``` code fence is a DISPLAY/discussion, not a real call.
         // It must stay as text, never become a tool_use.
         let text = "Look at this example:\n```\n<invoke name=\"exec_command\">\n<parameter name=\"cmd\">rm -rf /</parameter>\n</invoke>\n```";
-        let content = build_flush_content(Vec::new(), text, &[], &[], &names(&["exec_command"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            text,
+            &[],
+            &[],
+            &names(&["exec_command"]),
+            &nomap(),
+        );
         assert!(
             !content.iter().any(|c| c["type"] == "tool_use"),
             "fenced <invoke> must NOT be reclaimed (it's a display). content={:?}",
@@ -1516,7 +1729,14 @@ mod tests {
     fn flush_content_does_not_reclaim_invoke_mid_sentence() {
         // <invoke> embedded mid-sentence (not at line start) is discussion text, not a call.
         let text = "the tag <invoke name=\"exec_command\"><parameter name=\"cmd\">x</parameter></invoke> means a call";
-        let content = build_flush_content(Vec::new(), text, &[], &[], &names(&["exec_command"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            text,
+            &[],
+            &[],
+            &names(&["exec_command"]),
+            &nomap(),
+        );
         assert!(
             !content.iter().any(|c| c["type"] == "tool_use"),
             "mid-sentence <invoke> must NOT be reclaimed. content={:?}",
@@ -1529,7 +1749,14 @@ mod tests {
         // Tool-table guard: a clean line-start <invoke> whose name is NOT a declared tool
         // must NOT be reclaimed (never synthesize a call for an unknown tool).
         let leaked = "call\n<invoke name=\"definitely_not_a_tool\">\n<parameter name=\"x\">y</parameter>\n</invoke>";
-        let content = build_flush_content(Vec::new(), leaked, &[], &[], &names(&["exec_command"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            leaked,
+            &[],
+            &[],
+            &names(&["exec_command"]),
+            &nomap(),
+        );
         assert!(
             !content.iter().any(|c| c["type"] == "tool_use"),
             "unknown tool name must NOT be reclaimed. content={:?}",
@@ -1604,7 +1831,14 @@ mod tests {
     #[test]
     fn flush_content_clean_text_is_single_text_block() {
         // No <invoke> at all -> behavior identical to before: one text block, unchanged.
-        let content = build_flush_content(Vec::new(), "just a normal answer", &[], &[], &names(&["exec_command"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            "just a normal answer",
+            &[],
+            &[],
+            &names(&["exec_command"]),
+            &nomap(),
+        );
         assert_eq!(content.len(), 1);
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[0]["text"], "just a normal answer");
@@ -1624,7 +1858,12 @@ mod tests {
         );
         assert!(!leaks_literal_invoke(&content));
         let tus: Vec<&Value> = content.iter().filter(|c| c["type"] == "tool_use").collect();
-        assert_eq!(tus.len(), 2, "both invokes reclaimed. content={:?}", content);
+        assert_eq!(
+            tus.len(),
+            2,
+            "both invokes reclaimed. content={:?}",
+            content
+        );
         assert_eq!(tus[0]["name"], "exec_command");
         assert_eq!(tus[0]["input"]["cmd"], "a");
         assert_eq!(tus[1]["name"], "get_time");
@@ -1635,7 +1874,14 @@ mod tests {
     fn flush_content_unclosed_invoke_stays_text() {
         // An <invoke> with no closing tag in the complete text is not a clean call -> keep as text.
         let text = "call\n<invoke name=\"exec_command\">\n<parameter name=\"cmd\">echo hi";
-        let content = build_flush_content(Vec::new(), text, &[], &[], &names(&["exec_command"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            text,
+            &[],
+            &[],
+            &names(&["exec_command"]),
+            &nomap(),
+        );
         assert!(
             !content.iter().any(|c| c["type"] == "tool_use"),
             "unclosed <invoke> must NOT be reclaimed. content={:?}",
@@ -1656,14 +1902,7 @@ mod tests {
         );
         let mut map = std::collections::HashMap::new();
         map.insert(short.to_string(), original.to_string());
-        let content = build_flush_content(
-            Vec::new(),
-            &leaked,
-            &[],
-            &[],
-            &names(&[short]),
-            &map,
-        );
+        let content = build_flush_content(Vec::new(), &leaked, &[], &[], &names(&[short]), &map);
         let tu = content
             .iter()
             .find(|c| c["type"] == "tool_use")
@@ -1683,7 +1922,14 @@ mod tests {
         // stop_reason="tool_use". This test pins that contract: a leaked invoke with an empty
         // tool_uses list still yields a client tool_use block in the content.
         let leaked = "call\n<invoke name=\"exec_command\">\n<parameter name=\"cmd\">echo hi</parameter>\n</invoke>";
-        let content = build_flush_content(Vec::new(), leaked, &[], &[], &names(&["exec_command"]), &nomap());
+        let content = build_flush_content(
+            Vec::new(),
+            leaked,
+            &[],
+            &[],
+            &names(&["exec_command"]),
+            &nomap(),
+        );
         let has_client_tool_use = content
             .iter()
             .any(|c| c["type"] == "tool_use" && c["name"] != "web_search");
@@ -1754,7 +2000,8 @@ mod tests {
         // the search and emit NO raw tool_use at all -> the caller derives end_turn.
         let tool_uses = vec![tu("web_search")];
         let searched = vec![fake_results("q")];
-        let content = build_flush_content(Vec::new(), "", &tool_uses, &searched, &names(&[]), &nomap());
+        let content =
+            build_flush_content(Vec::new(), "", &tool_uses, &searched, &names(&[]), &nomap());
         assert!(!content.iter().any(|c| c["type"] == "tool_use"));
         assert!(
             content
@@ -1827,6 +2074,87 @@ mod tests {
         );
     }
 
+    #[test]
+    fn round_usage_prefers_provider_and_mixed_rounds_accumulate_each_category() {
+        let mut provider_round = round_outcome("ignored fallback output", vec![]);
+        provider_round.context_input_tokens = Some(999);
+        provider_round.provider_token_usage = Some(TokenUsage {
+            uncached_input_tokens: 3,
+            output_tokens: 5,
+            cache_read_input_tokens: 7,
+            cache_write_input_tokens: 4,
+        });
+        let provider_usage = provider_round.resolved_token_usage(888);
+        assert_eq!(
+            provider_usage,
+            TokenUsage {
+                uncached_input_tokens: 3,
+                output_tokens: 5,
+                cache_read_input_tokens: 7,
+                cache_write_input_tokens: 4,
+            }
+        );
+
+        let mut fallback_round = round_outcome("fallback output", vec![]);
+        fallback_round.context_input_tokens = Some(20);
+        let fallback_usage = fallback_round.resolved_token_usage(500);
+        assert_eq!(fallback_usage.uncached_input_tokens, 20);
+        assert_eq!(fallback_usage.cache_write_input_tokens, 0);
+        assert_eq!(fallback_usage.cache_read_input_tokens, 0);
+        assert!(fallback_usage.output_tokens > 0);
+
+        let total = provider_usage.saturating_add(fallback_usage);
+        assert_eq!(total.uncached_input_tokens, 23);
+        assert_eq!(total.output_tokens, 5 + fallback_usage.output_tokens);
+        assert_eq!(total.cache_write_input_tokens, 4);
+        assert_eq!(total.cache_read_input_tokens, 7);
+    }
+
+    #[test]
+    fn json_and_sse_render_the_same_four_part_usage() {
+        let expected = TokenUsage {
+            uncached_input_tokens: 3,
+            output_tokens: 5,
+            cache_read_input_tokens: 7,
+            cache_write_input_tokens: 4,
+        };
+        let content = vec![json!({"type": "text", "text": "ok"})];
+        let response = render_json(
+            "claude-opus-4-7",
+            content.clone(),
+            "end_turn",
+            expected,
+            "",
+            None,
+        );
+        let bytes = futures::executor::block_on(async {
+            axum::body::to_bytes(response.into_body(), 64 * 1024)
+                .await
+                .unwrap()
+        });
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["usage"]["input_tokens"], json!(3));
+        assert_eq!(body["usage"]["output_tokens"], json!(5));
+        assert_eq!(body["usage"]["cache_creation_input_tokens"], json!(4));
+        assert_eq!(body["usage"]["cache_read_input_tokens"], json!(7));
+
+        let events = build_sse_events("claude-opus-4-7", content, "end_turn", expected, None);
+        let start_usage = &events
+            .iter()
+            .find(|event| event.event == "message_start")
+            .unwrap()
+            .data["message"]["usage"];
+        assert_eq!(start_usage["input_tokens"], json!(3));
+        assert_eq!(start_usage["cache_creation_input_tokens"], json!(4));
+        assert_eq!(start_usage["cache_read_input_tokens"], json!(7));
+        let delta_usage = &events
+            .iter()
+            .find(|event| event.event == "message_delta")
+            .unwrap()
+            .data["usage"];
+        assert_eq!(delta_usage["output_tokens"], json!(5));
+    }
+
     // ---- credit_usage 透传：run_web_search_loop 路径 ----
 
     fn metering_event(usage: f64) -> MeteringEvent {
@@ -1834,6 +2162,15 @@ mod tests {
             unit: "credit".to_string(),
             unit_plural: "credits".to_string(),
             usage,
+        }
+    }
+
+    fn token_usage(input_tokens: i32, output_tokens: i32) -> TokenUsage {
+        TokenUsage {
+            uncached_input_tokens: input_tokens,
+            output_tokens,
+            cache_read_input_tokens: 0,
+            cache_write_input_tokens: 0,
         }
     }
 
@@ -1845,8 +2182,7 @@ mod tests {
             "claude-opus-4-7",
             content,
             "end_turn",
-            10,
-            5,
+            token_usage(10, 5),
             "",
             Some(&metering),
         );
@@ -1872,8 +2208,7 @@ mod tests {
             "claude-opus-4-7",
             content,
             "end_turn",
-            10,
-            5,
+            token_usage(10, 5),
             "",
             None,
         );
@@ -1896,8 +2231,7 @@ mod tests {
             "claude-opus-4-7",
             content,
             "end_turn",
-            10,
-            5,
+            token_usage(10, 5),
             Some(&metering),
         );
         let delta = events
@@ -1919,8 +2253,7 @@ mod tests {
             "claude-opus-4-7",
             content,
             "end_turn",
-            10,
-            5,
+            token_usage(10, 5),
             None,
         );
         let delta = events

--- a/src/kiro/model/events/base.rs
+++ b/src/kiro/model/events/base.rs
@@ -14,6 +14,8 @@ pub enum EventType {
     ToolUse,
     /// 计费事件
     Metering,
+    /// 精确 token 用量元数据事件
+    Metadata,
     /// 上下文使用率事件
     ContextUsage,
     /// 推理内容事件
@@ -29,6 +31,7 @@ impl EventType {
             "assistantResponseEvent" => Self::AssistantResponse,
             "toolUseEvent" => Self::ToolUse,
             "meteringEvent" => Self::Metering,
+            "metadataEvent" => Self::Metadata,
             "contextUsageEvent" => Self::ContextUsage,
             "reasoningContentEvent" => Self::ReasoningContent,
             _ => Self::Unknown,
@@ -41,6 +44,7 @@ impl EventType {
             Self::AssistantResponse => "assistantResponseEvent",
             Self::ToolUse => "toolUseEvent",
             Self::Metering => "meteringEvent",
+            Self::Metadata => "metadataEvent",
             Self::ContextUsage => "contextUsageEvent",
             Self::ReasoningContent => "reasoningContentEvent",
             Self::Unknown => "unknown",
@@ -73,11 +77,13 @@ pub enum Event {
     ToolUse(super::ToolUseEvent),
     /// 计费
     Metering(super::MeteringEvent),
+    /// 精确 token 用量元数据
+    Metadata(super::MetadataEvent),
     /// 上下文使用率
     ContextUsage(super::ContextUsageEvent),
     /// 推理内容
     ReasoningContent(super::ReasoningContentEvent),
-    /// 未知事件 (保留原始帧数据)
+    /// 未知事件
     Unknown {},
     /// 服务端错误
     Error {
@@ -125,6 +131,10 @@ impl Event {
             EventType::Metering => {
                 let payload = super::MeteringEvent::from_frame(&frame)?;
                 Ok(Self::Metering(payload))
+            }
+            EventType::Metadata => {
+                let payload = super::MetadataEvent::from_frame(&frame)?;
+                Ok(Self::Metadata(payload))
             }
             EventType::ContextUsage => {
                 let payload = super::ContextUsageEvent::from_frame(&frame)?;
@@ -181,6 +191,7 @@ mod tests {
         );
         assert_eq!(EventType::from_str("toolUseEvent"), EventType::ToolUse);
         assert_eq!(EventType::from_str("meteringEvent"), EventType::Metering);
+        assert_eq!(EventType::from_str("metadataEvent"), EventType::Metadata);
         assert_eq!(
             EventType::from_str("contextUsageEvent"),
             EventType::ContextUsage
@@ -199,5 +210,6 @@ mod tests {
             "assistantResponseEvent"
         );
         assert_eq!(EventType::ToolUse.as_str(), "toolUseEvent");
+        assert_eq!(EventType::Metadata.as_str(), "metadataEvent");
     }
 }

--- a/src/kiro/model/events/metadata.rs
+++ b/src/kiro/model/events/metadata.rs
@@ -1,0 +1,173 @@
+//! 上游元数据事件
+//!
+//! Kiro 在 `metadataEvent.tokenUsage` 中返回本次模型调用的精确 token 用量。
+//! 四个字段是单次调用的最终快照，不是增量事件；调用方应在同一条流内保留最后一份快照。
+
+use serde::Deserialize;
+
+use crate::kiro::parser::error::ParseResult;
+use crate::kiro::parser::frame::Frame;
+
+use super::base::EventPayload;
+
+/// 单次 Kiro 模型调用的精确 token 用量。
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenUsage {
+    /// 未命中缓存、也未写入缓存的输入 token。
+    #[serde(default)]
+    pub uncached_input_tokens: i32,
+    /// 模型输出 token。
+    #[serde(default)]
+    pub output_tokens: i32,
+    /// 从服务端 prompt cache 读取的输入 token。
+    #[serde(default)]
+    pub cache_read_input_tokens: i32,
+    /// 本次写入服务端 prompt cache 的输入 token。
+    #[serde(default)]
+    pub cache_write_input_tokens: i32,
+}
+
+impl TokenUsage {
+    /// 清理不可信上游值，确保所有计数非负。
+    pub fn sanitized(self) -> Self {
+        Self {
+            uncached_input_tokens: self.uncached_input_tokens.max(0),
+            output_tokens: self.output_tokens.max(0),
+            cache_read_input_tokens: self.cache_read_input_tokens.max(0),
+            cache_write_input_tokens: self.cache_write_input_tokens.max(0),
+        }
+    }
+
+    #[cfg(test)]
+    /// OpenAI 口径的总输入 token（缓存读取是其中的子集）。
+    pub fn total_input_tokens(self) -> i32 {
+        let usage = self.sanitized();
+        usage
+            .uncached_input_tokens
+            .saturating_add(usage.cache_write_input_tokens)
+            .saturating_add(usage.cache_read_input_tokens)
+    }
+
+    /// 合并多次真实 provider 调用的用量。
+    pub fn saturating_add(self, other: Self) -> Self {
+        let left = self.sanitized();
+        let right = other.sanitized();
+        Self {
+            uncached_input_tokens: left
+                .uncached_input_tokens
+                .saturating_add(right.uncached_input_tokens),
+            output_tokens: left.output_tokens.saturating_add(right.output_tokens),
+            cache_read_input_tokens: left
+                .cache_read_input_tokens
+                .saturating_add(right.cache_read_input_tokens),
+            cache_write_input_tokens: left
+                .cache_write_input_tokens
+                .saturating_add(right.cache_write_input_tokens),
+        }
+    }
+}
+
+/// `metadataEvent` payload。
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataEvent {
+    /// 有些 metadataEvent 只携带 stopReason，因此 tokenUsage 必须保持可选。
+    #[serde(default)]
+    pub token_usage: Option<TokenUsage>,
+}
+
+impl EventPayload for MetadataEvent {
+    fn from_frame(frame: &Frame) -> ParseResult<Self> {
+        frame.payload_as_json()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_official_token_usage_shape() {
+        let event: MetadataEvent = serde_json::from_str(
+            r#"{
+                "tokenUsage": {
+                    "uncachedInputTokens": 101,
+                    "outputTokens": 23,
+                    "cacheReadInputTokens": 300,
+                    "cacheWriteInputTokens": 40
+                },
+                "stopReason": "end_turn"
+            }"#,
+        )
+        .unwrap();
+
+        let usage = event.token_usage.unwrap();
+        assert_eq!(usage.uncached_input_tokens, 101);
+        assert_eq!(usage.output_tokens, 23);
+        assert_eq!(usage.cache_read_input_tokens, 300);
+        assert_eq!(usage.cache_write_input_tokens, 40);
+        assert_eq!(usage.total_input_tokens(), 441);
+    }
+
+    #[test]
+    fn metadata_without_token_usage_is_not_treated_as_zero_truth() {
+        let event: MetadataEvent = serde_json::from_str(r#"{"stopReason":"end_turn"}"#).unwrap();
+        assert!(event.token_usage.is_none());
+    }
+
+    #[test]
+    fn token_usage_with_missing_fields_defaults_only_missing_fields_to_zero() {
+        let event: MetadataEvent =
+            serde_json::from_str(r#"{"tokenUsage":{"outputTokens":9}}"#).unwrap();
+
+        assert_eq!(
+            event.token_usage,
+            Some(TokenUsage {
+                uncached_input_tokens: 0,
+                output_tokens: 9,
+                cache_read_input_tokens: 0,
+                cache_write_input_tokens: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn sanitizes_negative_values() {
+        let usage = TokenUsage {
+            uncached_input_tokens: -1,
+            output_tokens: -2,
+            cache_read_input_tokens: -3,
+            cache_write_input_tokens: -4,
+        }
+        .sanitized();
+
+        assert_eq!(usage, TokenUsage::default());
+    }
+
+    #[test]
+    fn adds_multiple_provider_calls_without_overflowing() {
+        let first = TokenUsage {
+            uncached_input_tokens: i32::MAX,
+            output_tokens: 3,
+            cache_read_input_tokens: 20,
+            cache_write_input_tokens: 4,
+        };
+        let second = TokenUsage {
+            uncached_input_tokens: 7,
+            output_tokens: 5,
+            cache_read_input_tokens: 11,
+            cache_write_input_tokens: 2,
+        };
+
+        assert_eq!(
+            first.saturating_add(second),
+            TokenUsage {
+                uncached_input_tokens: i32::MAX,
+                output_tokens: 8,
+                cache_read_input_tokens: 31,
+                cache_write_input_tokens: 6,
+            }
+        );
+    }
+}

--- a/src/kiro/model/events/mod.rs
+++ b/src/kiro/model/events/mod.rs
@@ -5,6 +5,7 @@
 mod assistant;
 mod base;
 mod context_usage;
+mod metadata;
 mod metering;
 mod reasoning;
 mod tool_use;
@@ -13,6 +14,7 @@ pub use assistant::AssistantResponseEvent;
 pub(crate) use assistant::strip_tool_use_xml_leaks;
 pub use base::Event;
 pub use context_usage::ContextUsageEvent;
+pub use metadata::{MetadataEvent, TokenUsage};
 pub use metering::MeteringEvent;
 pub use reasoning::ReasoningContentEvent;
 pub use tool_use::ToolUseEvent;

--- a/src/kiro/model/requests/kiro.rs
+++ b/src/kiro/model/requests/kiro.rs
@@ -57,22 +57,23 @@ pub struct KiroRequest {
 /// so this struct **must not** inherit `rename_all = "camelCase"`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AdditionalModelRequestFields {
-    /// Output configuration (including reasoning effort)
+    /// Claude reasoning effort (`output_config.effort`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_config: Option<KiroOutputConfig>,
+    /// GPT reasoning effort (`reasoning.effort`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<KiroReasoningConfig>,
 }
 
-/// The effort control field recognized by the AWS Q backend
-///
-/// Accepted tiers are model-dependent. Older 4.5/4.6 models accept
-/// `low / medium / high / max`; newer effort-capable models may also accept
-/// `xhigh`.
-///
-/// Measured (via a ladder experiment), the same prompt between `low` and `max` differs
-/// by roughly 5x in response time and output length, so this **is a protocol field that genuinely takes effect**,
-/// completely unlike the "pseudo-protocol" of stuffing a `<thinking_effort>` XML tag into the system prompt.
+/// Claude effort control accepted by the AWS Q backend.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KiroOutputConfig {
+    pub effort: String,
+}
+
+/// GPT effort control accepted by the Mantle-backed models in Kiro.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KiroReasoningConfig {
     pub effort: String,
 }
 #[cfg(test)]
@@ -119,12 +120,27 @@ mod tests {
             output_config: Some(KiroOutputConfig {
                 effort: "max".to_string(),
             }),
+            reasoning: None,
         };
         let v = serde_json::to_value(&fields).unwrap();
         assert_eq!(v["output_config"]["effort"], "max");
+        assert!(v.get("reasoning").is_none());
         assert!(
             v.get("outputConfig").is_none(),
             "inner key must stay snake_case output_config, got {v}"
         );
+    }
+
+    #[test]
+    fn test_gpt_reasoning_effort_wire_format() {
+        let fields = AdditionalModelRequestFields {
+            output_config: None,
+            reasoning: Some(KiroReasoningConfig {
+                effort: "xhigh".to_string(),
+            }),
+        };
+        let v = serde_json::to_value(&fields).unwrap();
+        assert_eq!(v["reasoning"]["effort"], "xhigh");
+        assert!(v.get("output_config").is_none());
     }
 }


### PR DESCRIPTION
## 关联 Issue

Fixes #42
Fixes #43

## 问题背景

这个 PR 处理两个互相关联的问题。

### 1. OpenAI Compatible 的 GPT-5.6 effort 没有按正确协议下发

OpenAI Chat Completions 的 `reasoning_effort` 和 Responses 的
`reasoning.effort` 虽然能进入内部请求，但此前 converter 没有按 GPT-5.6
模型实际接受的 wire 结构生成参数。

对照官方 Kiro 1.0.288（Agent 1.0.525）的协议后确认：

- Claude 模型使用 `additionalModelRequestFields.output_config.effort`；
- GPT-5.6 sol / terra / luna 使用
  `additionalModelRequestFields.reasoning.effort`。

本 PR 按模型族分别生成对应字段。GPT-5.6 支持
`none / low / medium / high / xhigh / max`，不再把 GPT effort 当作 Claude
`output_config` 下发。

### 2. OpenAI 端点每次生成新的 conversationId，无法复用 Kiro 上游缓存

Kiro 确实存在服务端自动 Prompt Cache；它和 kiro-rs 的本地模拟缓存统计不是
同一层能力。上游缓存不要求客户端添加 Anthropic `cache_control`，但要求同一
会话稳定复用 `conversationState.conversationId`。

此前 Chat Completions 和 Responses 固定使用 `metadata: None`，converter 会为
每次请求随机生成新 `conversationId`，因此即使提示前缀完全相同，也无法稳定
命中上游缓存。这也是此前容易得出“Kiro 没有缓存”结论的原因。

## 修改内容

### GPT-5.6 reasoning effort

- 按模型族区分 Claude `output_config.effort` 与 GPT-5.6
  `reasoning.effort`；
- 支持 GPT-5.6 sol / terra / luna；
- 保留不支持模型的安全过滤，避免额外触发上游 schema 400。

### OpenAI 会话亲和与上游 Prompt Cache

Chat Completions 和 Responses 按以下优先级读取稳定会话标识：

1. 请求体 `prompt_cache_key`
2. `x-session-affinity`
3. `x-client-request-id`
4. `session_id`

支持裸 UUID 和 `session_<uuid>` 两种格式，验证后统一规范化为
`session_<lowercase-uuid>`，再通过：

```text
OpenAI 请求
→ MessagesRequest.metadata.user_id
→ conversationState.conversationId
```

传给 Kiro 上游。无合法会话标识时仍随机生成 `conversationId`，保持原有行为。

### 精确 token usage

为了正确观察真实缓存用量，本 PR 同时恢复
`metadataEvent.tokenUsage` 的解析和传递：

- `uncachedInputTokens`
- `cacheWriteInputTokens`
- `cacheReadInputTokens`
- `outputTokens`

用量优先级为：

1. `metadataEvent.tokenUsage` 精确值；
2. `contextUsageEvent` 换算；
3. 本地估算。

单次 provider 调用取最终 metadata 快照；web-search 多轮调用按真实调用逐轮
饱和累计。成功、中断和错误路径的响应、usage hook 与 trace 使用同一套结果。

OpenAI 映射规则为：

```text
input_tokens = uncached + cache_write + cache_read
Responses.cached_tokens = cache_read
```

## 真实上游缓存验证

我对 Responses 路径做了同会话/新会话配对实验，固定模型、长提示前缀、
credential 和重试次数，只改变会话 UUID：

| 条件 | credits 中位数 |
|---|---:|
| 相同 conversationId（命中缓存） | 0.00115192 |
| 新 conversationId（未复用缓存） | 0.00208465 |

结果：

- `6/6` 组配对中，新会话 credits 都高于同会话；
- 相对于新会话对照，同会话命中缓存后的 credits 中位数降低约 **44.74%**；
- 换算后，新会话成本约为同会话的 **180.97%**。

因此，本地 `cache_metering` 中的缓存字段可以是模拟统计，但不能由此推断 Kiro
上游不存在缓存。真实命中应以固定 `conversationId` 后的上游
`meteringEvent` / credits 对照为准。部分 Responses 请求即使命中上游缓存，
`cached_tokens` 仍可能为 0，因此它不能单独作为命中判据。

## 测试

- `cargo test --quiet`：**628 passed, 0 failed**
- `RUSTFLAGS='-D warnings' cargo build --quiet`：通过
- `git diff --check`：通过
- 已覆盖：
  - GPT-5.6 各 effort 档位及 wire 字段；
  - 会话 UUID 校验、规范化和来源优先级；
  - Chat Completions / Responses metadata 透传；
  - metadata token usage 解析、清洗和 fallback；
  - 流式与非流式输出；
  - web-search 多轮累计和错误出口；
  - Chat / Responses token usage 映射。

## 兼容性与范围

- 不主动添加 `cache_control`，缓存仍由 Kiro 上游自动管理；
- 未提供合法会话标识时继续使用随机 conversationId；
- 不改变 Anthropic `/v1/messages` 原有会话行为；
- 不新增依赖、数据库迁移、管理界面或配置格式变更；
- 不在日志中记录原始会话标识。
