### PR TITLE
fix(trace): record mixed web-search requests

### DIFF
--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -179,6 +179,9 @@ impl RequestTracer {
 
     /// 标记首个上游 chunk 到达（幂等，仅记录第一次）
     pub fn mark_first_token(&self) {
+        if !self.is_stream {
+            return;
+        }
         let mut slot = self.first_token_at.lock();
         if slot.is_none() {
             *slot = Some(Instant::now());
@@ -229,14 +232,19 @@ impl RequestTracer {
 }
 
 impl TraceSink for RequestTracer {
-    fn on_attempt(&self, attempt: TraceAttempt) {
-        self.attempts.lock().push(attempt);
+    fn on_attempt(&self, mut attempt: TraceAttempt) {
+        let mut attempts = self.attempts.lock();
+        // Each provider call numbers retries from zero. A web-search request can make
+        // several provider calls under one trace, so assign a request-wide sequence
+        // before persisting to the (trace_id, attempt) primary key.
+        attempt.attempt = attempts.len() as u32;
+        attempts.push(attempt);
     }
 }
 
 /// 取追踪器里最后一跳的 outcome（用于把 provider 的失败分类提升到 record.error_type）。
 /// 返回 'static str（outcome 常量），无 attempt 时返回 None。
-fn last_attempt_outcome(tracer: &RequestTracer) -> Option<&'static str> {
+pub(crate) fn last_attempt_outcome(tracer: &RequestTracer) -> Option<&'static str> {
     let last = tracer.attempts.lock().last()?.outcome.clone();
     Some(canonical_attempt_outcome(&last))
 }
@@ -681,10 +689,19 @@ pub async fn post_messages(
         tracing::info!(
             "detected mixed tools containing web_search, entering the web_search agentic loop"
         );
+        let tracer = std::sync::Arc::new(RequestTracer::new(
+            &state,
+            RequestTraceOptions {
+                key_ctx: key_ctx.clone(),
+                model: payload.model.clone(),
+                is_stream: payload_stream,
+            },
+        ));
         return super::websearch_loop::run_web_search_loop(
             provider,
             payload,
             hook,
+            tracer,
             payload_stream,
             key_ctx.group.clone(),
             state.tool_compatibility_mode,
@@ -1590,10 +1607,19 @@ pub async fn post_messages_cc(
         tracing::info!(
             "detected mixed tools containing web_search, entering the web_search agentic loop"
         );
+        let tracer = std::sync::Arc::new(RequestTracer::new(
+            &state,
+            RequestTraceOptions {
+                key_ctx: key_ctx.clone(),
+                model: payload.model.clone(),
+                is_stream: payload_stream,
+            },
+        ));
         return super::websearch_loop::run_web_search_loop(
             provider,
             payload,
             hook,
+            tracer,
             payload_stream,
             key_ctx.group.clone(),
             state.tool_compatibility_mode,
@@ -1934,6 +1960,154 @@ fn create_buffered_sse_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tracer_renumbers_attempts_across_provider_rounds_before_persisting() {
+        use crate::admin::trace_db::{TraceQuery, TraceStore};
+
+        let store = std::sync::Arc::new(TraceStore::open_in_memory().unwrap());
+        let tracer = RequestTracer {
+            store: Some(store.clone()),
+            trace_id: "gpt-websearch-trace".to_string(),
+            ts: Utc::now().to_rfc3339(),
+            key_id: 7,
+            key_source: TraceKeySource::ClientKey,
+            model: "gpt-5.6-luna".to_string(),
+            is_stream: false,
+            started_at: Instant::now(),
+            first_token_at: parking_lot::Mutex::new(None),
+            attempts: parking_lot::Mutex::new(Vec::new()),
+        };
+
+        let attempt = |attempt, credential_id, outcome: &str| TraceAttempt {
+            attempt,
+            credential_id,
+            endpoint: "ide".to_string(),
+            http_status: Some(200),
+            outcome: outcome.to_string(),
+            error_snippet: None,
+            duration_ms: 10,
+        };
+
+        // First provider round reports local attempts 0,1; the next round starts at 0 again.
+        tracer.on_attempt(attempt(0, 11, outcome::TRANSIENT));
+        tracer.on_attempt(attempt(1, 12, outcome::SUCCESS));
+        tracer.on_attempt(attempt(0, 13, outcome::SUCCESS));
+        tracer.finalize(
+            "success",
+            None,
+            None,
+            None,
+            TraceUsage {
+                input_tokens: 101,
+                output_tokens: 23,
+                cache_creation_tokens: 7,
+                cache_read_tokens: 89,
+                credits: 0.25,
+            },
+        );
+
+        let (records, total) = store.query_paged(&TraceQuery {
+            model: Some("gpt-5.6-luna".to_string()),
+            limit: 10,
+            ..Default::default()
+        });
+        assert_eq!(total, 1);
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record.final_credential_id, 13);
+        assert_eq!(record.total_attempts, 3);
+        assert_eq!(
+            record
+                .attempts
+                .iter()
+                .map(|a| a.attempt)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert_eq!(record.input_tokens, 101);
+        assert_eq!(record.output_tokens, 23);
+        assert_eq!(record.cache_creation_tokens, 7);
+        assert_eq!(record.cache_read_tokens, 89);
+        assert_eq!(record.credits, 0.25);
+    }
+
+    #[test]
+    fn tracer_only_marks_first_token_for_streaming_requests() {
+        let mut tracer = RequestTracer {
+            store: None,
+            trace_id: "first-token-trace".to_string(),
+            ts: Utc::now().to_rfc3339(),
+            key_id: 0,
+            key_source: TraceKeySource::MasterApiKey,
+            model: "claude-sonnet-4".to_string(),
+            is_stream: false,
+            started_at: Instant::now(),
+            first_token_at: parking_lot::Mutex::new(None),
+            attempts: parking_lot::Mutex::new(Vec::new()),
+        };
+
+        tracer.mark_first_token();
+        assert!(tracer.first_token_at.lock().is_none());
+
+        tracer.is_stream = true;
+        tracer.mark_first_token();
+        let first = *tracer.first_token_at.lock();
+        assert!(first.is_some());
+
+        tracer.mark_first_token();
+        assert_eq!(*tracer.first_token_at.lock(), first);
+    }
+
+    #[test]
+    fn tracer_uses_terminal_mcp_attempt_for_failure_fields() {
+        use crate::admin::trace_db::{TraceQuery, TraceStore};
+
+        let store = std::sync::Arc::new(TraceStore::open_in_memory().unwrap());
+        let tracer = RequestTracer {
+            store: Some(store.clone()),
+            trace_id: "mcp-failure-trace".to_string(),
+            ts: Utc::now().to_rfc3339(),
+            key_id: 0,
+            key_source: TraceKeySource::MasterApiKey,
+            model: "claude-sonnet-4".to_string(),
+            is_stream: true,
+            started_at: Instant::now(),
+            first_token_at: parking_lot::Mutex::new(None),
+            attempts: parking_lot::Mutex::new(Vec::new()),
+        };
+        let attempt = |credential_id, endpoint: &str, status, attempt_outcome: &str| TraceAttempt {
+            attempt: 0,
+            credential_id,
+            endpoint: endpoint.to_string(),
+            http_status: Some(status),
+            outcome: attempt_outcome.to_string(),
+            error_snippet: None,
+            duration_ms: 10,
+        };
+
+        tracer.on_attempt(attempt(11, "ide", 200, outcome::SUCCESS));
+        tracer.on_attempt(attempt(29, "cli", 503, outcome::TRANSIENT));
+        tracer.finalize(
+            "error",
+            last_attempt_outcome(&tracer),
+            Some("MCP request failed"),
+            None,
+            TraceUsage::zero(),
+        );
+
+        let (records, total) = store.query_paged(&TraceQuery {
+            limit: 10,
+            ..Default::default()
+        });
+        assert_eq!(total, 1);
+        let record = &records[0];
+        assert_eq!(record.final_credential_id, 29);
+        assert_eq!(record.error_type.as_deref(), Some(outcome::TRANSIENT));
+        assert_eq!(record.total_attempts, 2);
+        assert_eq!(record.attempts[0].endpoint, "ide");
+        assert_eq!(record.attempts[1].endpoint, "cli");
+    }
 
     #[test]
     fn account_suspended_attempt_is_preserved_as_request_error_type() {

--- a/src/anthropic/websearch.rs
+++ b/src/anthropic/websearch.rs
@@ -15,6 +15,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
+use crate::admin::trace_db::TraceSink;
+
 use super::stream::SseEvent;
 use super::types::{ErrorResponse, MessagesRequest};
 
@@ -593,10 +595,11 @@ pub async fn handle_websearch_request(
     let (tool_use_id, mcp_request) = create_mcp_request(&query);
 
     // 3. 调用 Kiro MCP API
-    let search_results = match finish_mcp_call(call_mcp_api(&provider, &mcp_request, group).await) {
-        Ok(results) => results,
-        Err(response) => return response,
-    };
+    let search_results =
+        match finish_mcp_call(call_mcp_api(&provider, &mcp_request, None, group).await) {
+            Ok(results) => results,
+            Err(response) => return response,
+        };
 
     // 4. 按请求模式生成响应
     render_websearch_response(
@@ -613,18 +616,34 @@ pub async fn handle_websearch_request(
 pub(crate) async fn call_mcp_api(
     provider: &crate::kiro::provider::KiroProvider,
     request: &McpRequest,
+    sink: Option<&dyn TraceSink>,
     group: Option<&str>,
 ) -> anyhow::Result<McpResponse> {
     let request_body = serde_json::to_string(request)?;
 
     tracing::debug!("MCP request: {}", request_body);
 
-    let response = provider.call_mcp(&request_body, group).await?;
+    if let Some(sink) = sink {
+        return provider
+            .call_mcp_with_trace(
+                &request_body,
+                sink,
+                group,
+                parse_mcp_response,
+                is_no_results_mcp_error,
+            )
+            .await;
+    }
 
+    let response = provider.call_mcp(&request_body, group).await?;
     let body = response.text().await?;
+    parse_mcp_response(&body)
+}
+
+fn parse_mcp_response(body: &str) -> anyhow::Result<McpResponse> {
     tracing::debug!("MCP response: {}", body);
 
-    let mcp_response: McpResponse = serde_json::from_str(&body)?;
+    let mcp_response: McpResponse = serde_json::from_str(body)?;
 
     if let Some(ref error) = mcp_response.error {
         anyhow::bail!(
@@ -635,6 +654,12 @@ pub(crate) async fn call_mcp_api(
     }
 
     Ok(mcp_response)
+}
+
+pub(crate) fn is_no_results_mcp_error(error: &anyhow::Error) -> bool {
+    error
+        .to_string()
+        .contains("MCP error: -32602 - Tool returned no results")
 }
 
 #[cfg(test)]
@@ -648,6 +673,32 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(response.headers().get(header::RETRY_AFTER).unwrap(), "60");
+    }
+
+    #[test]
+    fn parse_mcp_response_rejects_json_rpc_errors() {
+        let error = parse_mcp_response(
+            r#"{"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"search failed"}}"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "MCP error: -32603 - search failed");
+    }
+
+    #[test]
+    fn parse_mcp_response_rejects_malformed_bodies() {
+        assert!(parse_mcp_response("not-json").is_err());
+    }
+
+    #[test]
+    fn parse_mcp_response_accepts_successful_results() {
+        let response = parse_mcp_response(
+            r#"{"jsonrpc":"2.0","id":"1","error":null,"result":{"content":[],"isError":false}}"#,
+        )
+        .unwrap();
+
+        assert!(response.error.is_none());
+        assert!(response.result.is_some());
     }
 
     #[tokio::test]

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -20,6 +20,7 @@ use futures::{StreamExt, stream};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
+use crate::admin::trace_db::outcome;
 use crate::kiro::model::events::{Event, MeteringEvent, TokenUsage};
 use crate::kiro::model::requests::kiro::KiroRequest;
 use crate::kiro::parser::decoder::EventStreamDecoder;
@@ -27,7 +28,9 @@ use crate::kiro::provider::KiroProvider;
 use crate::token;
 
 use super::converter::{ConversionError, convert_request_with_mode, get_context_window_size};
-use super::handlers::{UsageRecordHook, map_provider_error};
+use super::handlers::{
+    RequestTracer, TraceUsage, UsageRecordHook, last_attempt_outcome, map_provider_error,
+};
 use super::stream::{CompletedToolUse, SseEvent};
 use super::types::{ErrorResponse, Message, MessagesRequest};
 use super::websearch::{self, WebSearchResults};
@@ -71,9 +74,9 @@ struct RoundOutcome {
     last_metering: Option<MeteringEvent>,
     /// stop_reason override (max_tokens / model_context_window_exceeded)
     stop_reason_override: Option<String>,
-    /// True if the upstream stream ended due to a read error, so the decoded
-    /// content for this round is partial and must not be treated as a success.
-    stream_error: bool,
+    /// Upstream body-read error, if any. Content decoded before this error is
+    /// partial and must not be treated as a successful round.
+    stream_error: Option<String>,
     /// Tool names declared to the upstream this round (original + shortened),
     /// taken from `ConversionResult::known_tool_names`. Used by the shared
     /// `<invoke>` text-leak fault tolerance so a leaked `<invoke name=...>` is only
@@ -165,12 +168,6 @@ fn log_invalid_web_search_input(tu: &CompletedToolUse) {
     );
 }
 
-fn is_no_results_mcp_error(error: &anyhow::Error) -> bool {
-    error
-        .to_string()
-        .contains("MCP error: -32602 - Tool returned no results")
-}
-
 fn log_normalized_web_search_query(tu: &CompletedToolUse, query: &str) {
     tracing::info!(
         tool_use_id = %tu.id,
@@ -229,6 +226,7 @@ async fn decode_round(
     response: reqwest::Response,
     model: &str,
     tool_name_map: &std::collections::HashMap<String, String>,
+    tracer: &RequestTracer,
 ) -> RoundOutcome {
     let mut body_stream = response.bytes_stream();
     let mut decoder = EventStreamDecoder::new();
@@ -245,14 +243,17 @@ async fn decode_round(
     let mut credits = 0.0;
     let mut last_metering: Option<MeteringEvent> = None;
     let mut stop_reason_override: Option<String> = None;
-    let mut stream_error = false;
+    let mut stream_error = None;
 
     while let Some(chunk) = body_stream.next().await {
         let chunk = match chunk {
-            Ok(c) => c,
+            Ok(c) => {
+                tracer.mark_first_token();
+                c
+            }
             Err(e) => {
                 tracing::error!("web_search loop failed to read the response stream: {}", e);
-                stream_error = true;
+                stream_error = Some(e.to_string());
                 break;
             }
         };
@@ -355,6 +356,8 @@ async fn decode_round(
 /// A failed round plus any usage that can still be attributed to its provider call.
 struct RoundFailure {
     response: Response,
+    error_type: &'static str,
+    error_message: String,
     credential_id: u64,
     token_usage: Option<TokenUsage>,
     credits: f64,
@@ -368,6 +371,7 @@ async fn run_round(
     provider: &Arc<KiroProvider>,
     payload: &MessagesRequest,
     fallback_input_tokens: i32,
+    tracer: &RequestTracer,
     group: Option<&str>,
     tool_compatibility_mode: ToolCompatibilityMode,
 ) -> Result<(RoundOutcome, u64), RoundFailure> {
@@ -387,9 +391,12 @@ async fn run_round(
                     format!("unsupported tool mapping: {}", reason),
                 ),
             };
+            let error_message = msg.clone();
             return Err(RoundFailure {
                 response: (StatusCode::BAD_REQUEST, Json(ErrorResponse::new(et, msg)))
                     .into_response(),
+                error_type: outcome::BAD_REQUEST,
+                error_message,
                 credential_id: 0,
                 token_usage: None,
                 credits: 0.0,
@@ -405,15 +412,15 @@ async fn run_round(
     let request_body = match serde_json::to_string(&kiro_request) {
         Ok(b) => b,
         Err(e) => {
+            let error_message = format!("failed to serialize request: {}", e);
             return Err(RoundFailure {
                 response: (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new(
-                        "internal_error",
-                        format!("failed to serialize request: {}", e),
-                    )),
+                    Json(ErrorResponse::new("internal_error", error_message.clone())),
                 )
                     .into_response(),
+                error_type: outcome::UNKNOWN,
+                error_message,
                 credential_id: 0,
                 token_usage: None,
                 credits: 0.0,
@@ -421,11 +428,18 @@ async fn run_round(
         }
     };
 
-    let call_result = match provider.call_api_stream(&request_body, None, group).await {
+    let call_result = match provider
+        .call_api_stream(&request_body, Some(tracer), group)
+        .await
+    {
         Ok(r) => r,
         Err(e) => {
+            let error_type = last_attempt_outcome(tracer).unwrap_or(outcome::UNKNOWN);
+            let error_message = e.to_string();
             return Err(RoundFailure {
                 response: map_provider_error(e),
+                error_type,
+                error_message,
                 credential_id: 0,
                 token_usage: Some(TokenUsage {
                     uncached_input_tokens: fallback_input_tokens.max(0),
@@ -440,6 +454,7 @@ async fn run_round(
         call_result.response,
         &payload.model,
         &conversion.tool_name_map,
+        tracer,
     )
     .await;
     // Carry the declared tool names (original + shortened) so the flush step can run the
@@ -447,7 +462,7 @@ async fn run_round(
     outcome.known_tool_names = conversion.known_tool_names;
     // Carry the short->original tool name map so reclaimed <invoke> names get restored.
     outcome.tool_name_map = conversion.tool_name_map;
-    if outcome.stream_error {
+    if let Some(error_message) = outcome.stream_error.take() {
         // The stream is partial and cannot re-enter the search loop, but any final metadata
         // snapshot/credits observed before the cut still belong to this real provider call.
         let token_usage = outcome.resolved_token_usage(fallback_input_tokens);
@@ -461,6 +476,8 @@ async fn run_round(
                 )),
             )
                 .into_response(),
+            error_type: outcome::STREAM_INTERRUPTED,
+            error_message,
             credential_id,
             token_usage: Some(token_usage),
             credits: outcome.credits,
@@ -730,6 +747,38 @@ fn record_aggregated_usage(
     );
 }
 
+fn aggregated_trace_usage(usage: TokenUsage, credits: f64) -> TraceUsage {
+    let usage = usage.sanitized();
+    TraceUsage {
+        input_tokens: usage.uncached_input_tokens as u64,
+        output_tokens: usage.output_tokens as u64,
+        cache_creation_tokens: usage.cache_write_input_tokens as u64,
+        cache_read_tokens: usage.cache_read_input_tokens as u64,
+        credits: if credits.is_finite() && credits > 0.0 {
+            credits
+        } else {
+            0.0
+        },
+    }
+}
+
+fn finalize_aggregated_trace(
+    tracer: &RequestTracer,
+    status: &str,
+    error_type: Option<&str>,
+    error_message: Option<&str>,
+    usage: TokenUsage,
+    credits: f64,
+) {
+    tracer.finalize(
+        status,
+        error_type,
+        error_message,
+        None,
+        aggregated_trace_usage(usage, credits),
+    );
+}
+
 /// web_search loop entry point
 ///
 /// `stream_client`: whether the client wants SSE (true) or a single JSON response (false).
@@ -737,6 +786,7 @@ pub(super) async fn run_web_search_loop(
     provider: Arc<KiroProvider>,
     mut payload: MessagesRequest,
     hook: UsageRecordHook,
+    tracer: Arc<RequestTracer>,
     stream_client: bool,
     group: Option<String>,
     tool_compatibility_mode: ToolCompatibilityMode,
@@ -761,6 +811,7 @@ pub(super) async fn run_web_search_loop(
                 &provider,
                 &payload,
                 round_fallback_input_tokens,
+                tracer.as_ref(),
                 group.as_deref(),
                 tool_compatibility_mode,
             )
@@ -781,6 +832,14 @@ pub(super) async fn run_web_search_loop(
                         total_token_usage,
                         total_credits,
                         "error",
+                    );
+                    finalize_aggregated_trace(
+                        tracer.as_ref(),
+                        "error",
+                        Some(failure.error_type),
+                        Some(&failure.error_message),
+                        total_token_usage,
+                        total_credits,
                     );
                     return failure.response;
                 }
@@ -813,6 +872,16 @@ pub(super) async fn run_web_search_loop(
                         total_token_usage,
                         total_credits,
                         "error",
+                    );
+                    finalize_aggregated_trace(
+                        tracer.as_ref(),
+                        "error",
+                        Some(outcome::UNKNOWN),
+                        Some(
+                            "Upstream returned no assistant text or tool call after a tool result.",
+                        ),
+                        total_token_usage,
+                        total_credits,
                     );
                     tracing::error!(
                         round = round_idx,
@@ -855,9 +924,16 @@ pub(super) async fn run_web_search_loop(
                 };
                 log_normalized_web_search_query(tu, &query);
                 let (_id, mcp_request) = websearch::create_mcp_request(&query);
-                match websearch::call_mcp_api(&provider, &mcp_request, group.as_deref()).await {
+                match websearch::call_mcp_api(
+                    &provider,
+                    &mcp_request,
+                    Some(tracer.as_ref()),
+                    group.as_deref(),
+                )
+                .await
+                {
                     Ok(resp) => searched.push(websearch::parse_search_results(&resp)),
-                    Err(e) if is_no_results_mcp_error(&e) => {
+                    Err(e) if websearch::is_no_results_mcp_error(&e) => {
                         tracing::warn!(
                             "web_search MCP returned no results; continuing with an empty result"
                         );
@@ -865,12 +941,21 @@ pub(super) async fn run_web_search_loop(
                     }
                     Err(e) => {
                         tracing::warn!("web_search MCP call failed: {}", e);
+                        let error_message = e.to_string();
                         record_aggregated_usage(
                             &hook,
                             last_credential_id,
                             total_token_usage,
                             total_credits,
                             "error",
+                        );
+                        finalize_aggregated_trace(
+                            tracer.as_ref(),
+                            "error",
+                            last_attempt_outcome(tracer.as_ref()),
+                            Some(&error_message),
+                            total_token_usage,
+                            total_credits,
                         );
                         return map_provider_error(e);
                     }
@@ -903,9 +988,16 @@ pub(super) async fn run_web_search_loop(
                 };
                 log_normalized_web_search_query(tu, &query);
                 let (_id, mcp_request) = websearch::create_mcp_request(&query);
-                match websearch::call_mcp_api(&provider, &mcp_request, group.as_deref()).await {
+                match websearch::call_mcp_api(
+                    &provider,
+                    &mcp_request,
+                    Some(tracer.as_ref()),
+                    group.as_deref(),
+                )
+                .await
+                {
                     Ok(resp) => searched.push(websearch::parse_search_results(&resp)),
-                    Err(e) if is_no_results_mcp_error(&e) => {
+                    Err(e) if websearch::is_no_results_mcp_error(&e) => {
                         tracing::warn!(
                             "web_search MCP returned no results in final round; continuing with an empty result"
                         );
@@ -913,12 +1005,21 @@ pub(super) async fn run_web_search_loop(
                     }
                     Err(e) => {
                         tracing::warn!("web_search MCP call (final round) failed: {}", e);
+                        let error_message = e.to_string();
                         record_aggregated_usage(
                             &hook,
                             last_credential_id,
                             total_token_usage,
                             total_credits,
                             "error",
+                        );
+                        finalize_aggregated_trace(
+                            tracer.as_ref(),
+                            "error",
+                            last_attempt_outcome(tracer.as_ref()),
+                            Some(&error_message),
+                            total_token_usage,
+                            total_credits,
                         );
                         return map_provider_error(e);
                     }
@@ -953,6 +1054,14 @@ pub(super) async fn run_web_search_loop(
             total_credits,
             "success",
         );
+        finalize_aggregated_trace(
+            tracer.as_ref(),
+            "success",
+            None,
+            None,
+            final_usage,
+            total_credits,
+        );
 
         return if stream_client {
             render_sse(
@@ -981,6 +1090,14 @@ pub(super) async fn run_web_search_loop(
         total_token_usage,
         total_credits,
         "error",
+    );
+    finalize_aggregated_trace(
+        tracer.as_ref(),
+        "error",
+        Some(outcome::UNKNOWN),
+        Some("web_search loop exited unexpectedly"),
+        total_token_usage,
+        total_credits,
     );
     (
         StatusCode::INTERNAL_SERVER_ERROR,
@@ -1239,10 +1356,10 @@ mod tests {
 
     #[test]
     fn no_results_mcp_error_is_nonfatal() {
-        assert!(is_no_results_mcp_error(&anyhow::anyhow!(
+        assert!(websearch::is_no_results_mcp_error(&anyhow::anyhow!(
             "MCP error: -32602 - Tool returned no results"
         )));
-        assert!(!is_no_results_mcp_error(&anyhow::anyhow!(
+        assert!(!websearch::is_no_results_mcp_error(&anyhow::anyhow!(
             "MCP error: -32602 - Invalid tool parameters provided"
         )));
     }
@@ -1294,7 +1411,7 @@ mod tests {
             credits: 0.0,
             last_metering: None,
             stop_reason_override: None,
-            stream_error: false,
+            stream_error: None,
             known_tool_names: std::collections::HashSet::new(),
             tool_name_map: std::collections::HashMap::new(),
         }
@@ -2108,6 +2225,39 @@ mod tests {
         assert_eq!(total.output_tokens, 5 + fallback_usage.output_tokens);
         assert_eq!(total.cache_write_input_tokens, 4);
         assert_eq!(total.cache_read_input_tokens, 7);
+    }
+
+    #[test]
+    fn aggregated_trace_usage_matches_websearch_usage_and_sanitizes_values() {
+        let trace = aggregated_trace_usage(
+            TokenUsage {
+                uncached_input_tokens: 3,
+                output_tokens: 5,
+                cache_read_input_tokens: 7,
+                cache_write_input_tokens: 4,
+            },
+            0.125,
+        );
+        assert_eq!(trace.input_tokens, 3);
+        assert_eq!(trace.output_tokens, 5);
+        assert_eq!(trace.cache_creation_tokens, 4);
+        assert_eq!(trace.cache_read_tokens, 7);
+        assert_eq!(trace.credits, 0.125);
+
+        let sanitized = aggregated_trace_usage(
+            TokenUsage {
+                uncached_input_tokens: -1,
+                output_tokens: -2,
+                cache_read_input_tokens: -3,
+                cache_write_input_tokens: -4,
+            },
+            f64::NAN,
+        );
+        assert_eq!(sanitized.input_tokens, 0);
+        assert_eq!(sanitized.output_tokens, 0);
+        assert_eq!(sanitized.cache_creation_tokens, 0);
+        assert_eq!(sanitized.cache_read_tokens, 0);
+        assert_eq!(sanitized.credits, 0.0);
     }
 
     #[test]

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -89,6 +89,15 @@ pub struct KiroCallResult {
     pub credential_id: u64,
 }
 
+/// A successful MCP HTTP response whose trace attempt is finalized after body validation.
+struct McpCallResult {
+    response: reqwest::Response,
+    credential_id: u64,
+    endpoint: &'static str,
+    attempt: usize,
+    started_at: Instant,
+}
+
 /// Kiro API Provider
 ///
 /// 核心组件，负责与 Kiro API 通信
@@ -269,31 +278,123 @@ impl KiroProvider {
         request_body: &str,
         group: Option<&str>,
     ) -> anyhow::Result<reqwest::Response> {
-        self.call_mcp_with_retry(request_body, group).await
+        let result = self.call_mcp_with_retry(request_body, None, group).await?;
+        self.token_manager
+            .report_success_for_request(result.credential_id, None);
+        Ok(result.response)
+    }
+
+    /// 发送 MCP API 请求，并在响应正文通过调用方校验后提交最终 trace attempt。
+    pub(crate) async fn call_mcp_with_trace<T>(
+        &self,
+        request_body: &str,
+        sink: &dyn TraceSink,
+        group: Option<&str>,
+        validate: fn(&str) -> anyhow::Result<T>,
+        is_benign_error: fn(&anyhow::Error) -> bool,
+    ) -> anyhow::Result<T> {
+        let result = self
+            .call_mcp_with_retry(request_body, Some(sink), group)
+            .await?;
+        let status = result.response.status().as_u16();
+        let body = match result.response.text().await {
+            Ok(body) => body,
+            Err(e) => {
+                Self::emit_attempt(
+                    Some(sink),
+                    result.attempt,
+                    result.credential_id,
+                    result.endpoint,
+                    Some(status),
+                    outcome::NETWORK_ERROR,
+                    Some(&e.to_string()),
+                    result.started_at,
+                );
+                return Err(e.into());
+            }
+        };
+
+        let validation = validate(&body);
+        let validation_outcome = Self::mcp_validation_outcome(&validation, is_benign_error);
+        let error = validation
+            .as_ref()
+            .err()
+            .filter(|_| validation_outcome != outcome::SUCCESS)
+            .map(|e| format!("{}: {}", e, body));
+        Self::emit_attempt(
+            Some(sink),
+            result.attempt,
+            result.credential_id,
+            result.endpoint,
+            Some(status),
+            validation_outcome,
+            error.as_deref(),
+            result.started_at,
+        );
+        if validation_outcome == outcome::SUCCESS {
+            self.token_manager
+                .report_success_for_request(result.credential_id, None);
+        }
+        validation
+    }
+
+    fn mcp_validation_outcome<T>(
+        validation: &anyhow::Result<T>,
+        is_benign_error: fn(&anyhow::Error) -> bool,
+    ) -> &'static str {
+        match validation {
+            Ok(_) => outcome::SUCCESS,
+            Err(error) if is_benign_error(error) => outcome::SUCCESS,
+            Err(_) => outcome::UNKNOWN,
+        }
     }
 
     /// 内部方法：带重试逻辑的 MCP API 调用
     async fn call_mcp_with_retry(
         &self,
         request_body: &str,
+        sink: Option<&dyn TraceSink>,
         group: Option<&str>,
-    ) -> anyhow::Result<reqwest::Response> {
+    ) -> anyhow::Result<McpCallResult> {
         let total_credentials = self.token_manager.total_count_in_group(group).max(1);
         let max_retries = (total_credentials * MAX_RETRIES_PER_CREDENTIAL).min(MAX_TOTAL_RETRIES);
         let mut last_error: Option<anyhow::Error> = None;
         let mut force_refreshed: HashSet<u64> = HashSet::new();
 
         for attempt in 0..max_retries {
+            let attempt_start = Instant::now();
             // MCP 调用不涉及模型选择，但必须遵守客户端 Key 的凭据分组隔离。
             let mut ctx = match self.token_manager.acquire_context(None, group).await {
                 Ok(c) => c,
                 Err(e) => {
                     if is_rate_limit_error(&e) {
+                        Self::emit_attempt(
+                            sink,
+                            attempt,
+                            0,
+                            "",
+                            None,
+                            outcome::TRANSIENT,
+                            Some(&e.to_string()),
+                            attempt_start,
+                        );
                         return Err(e);
                     }
+                    // Preserve the prior upstream 429 as the terminal trace attempt. A
+                    // concurrent selection failure has no credential to attribute.
                     if let Some(rate_limit) = take_rate_limit_error(&mut last_error) {
                         return Err(rate_limit);
                     }
+                    Self::emit_attempt(
+                        sink,
+                        attempt,
+                        0,
+                        "",
+                        None,
+                        outcome::UNKNOWN,
+                        Some(&e.to_string()),
+                        attempt_start,
+                    );
                     last_error = Some(e);
                     continue;
                 }
@@ -301,7 +402,19 @@ impl KiroProvider {
 
             // Pure MCP routes (including Web Search) require the same Enterprise / IdC
             // profileArn resolution as regular model calls.
-            self.ensure_profile_arn(&mut ctx).await?;
+            if let Err(e) = self.ensure_profile_arn(&mut ctx).await {
+                Self::emit_attempt(
+                    sink,
+                    attempt,
+                    ctx.id,
+                    "",
+                    None,
+                    outcome::TRANSIENT,
+                    Some(&e.to_string()),
+                    attempt_start,
+                );
+                return Err(e);
+            }
 
             let config = self.token_manager.config();
             let machine_id = machine_id::generate_from_credentials(&ctx.credentials, config);
@@ -309,6 +422,16 @@ impl KiroProvider {
             let endpoint = match self.endpoint_for(&ctx.credentials) {
                 Ok(e) => e,
                 Err(e) => {
+                    Self::emit_attempt(
+                        sink,
+                        attempt,
+                        ctx.id,
+                        "",
+                        None,
+                        outcome::UNKNOWN,
+                        Some(&e.to_string()),
+                        attempt_start,
+                    );
                     last_error = Some(e);
                     // endpoint 解析失败：记为失败，换下一张凭据
                     self.token_manager
@@ -316,6 +439,7 @@ impl KiroProvider {
                     continue;
                 }
             };
+            let endpoint_name = endpoint.name();
 
             let rctx = RequestContext {
                 credentials: &ctx.credentials,
@@ -327,8 +451,23 @@ impl KiroProvider {
             let url = endpoint.mcp_url(&rctx);
             let body = endpoint.transform_mcp_body(request_body, &rctx);
 
-            let base = self
-                .client_for(&ctx.credentials)?
+            let client = match self.client_for(&ctx.credentials) {
+                Ok(client) => client,
+                Err(e) => {
+                    Self::emit_attempt(
+                        sink,
+                        attempt,
+                        ctx.id,
+                        endpoint_name,
+                        None,
+                        outcome::NETWORK_ERROR,
+                        Some(&e.to_string()),
+                        attempt_start,
+                    );
+                    return Err(e);
+                }
+            };
+            let base = client
                 .post(&url)
                 .body(body)
                 .header("content-type", endpoint.content_type())
@@ -344,6 +483,16 @@ impl KiroProvider {
                         max_retries,
                         e
                     );
+                    Self::emit_attempt(
+                        sink,
+                        attempt,
+                        ctx.id,
+                        endpoint_name,
+                        None,
+                        outcome::NETWORK_ERROR,
+                        Some(&e.to_string()),
+                        attempt_start,
+                    );
                     last_error = Some(e.into());
                     if attempt + 1 < max_retries {
                         sleep(Self::retry_delay(attempt)).await;
@@ -358,8 +507,13 @@ impl KiroProvider {
 
             // 成功响应
             if status.is_success() {
-                self.token_manager.report_success_for_request(ctx.id, None);
-                return Ok(response);
+                return Ok(McpCallResult {
+                    response,
+                    credential_id: ctx.id,
+                    endpoint: endpoint_name,
+                    attempt,
+                    started_at: attempt_start,
+                });
             }
 
             // 失败响应
@@ -367,6 +521,16 @@ impl KiroProvider {
 
             // 402 额度用尽
             if status.as_u16() == 402 && endpoint.is_monthly_request_limit(&body) {
+                Self::emit_attempt(
+                    sink,
+                    attempt,
+                    ctx.id,
+                    endpoint_name,
+                    Some(status.as_u16()),
+                    outcome::QUOTA_EXHAUSTED,
+                    Some(&body),
+                    attempt_start,
+                );
                 let has_available = self
                     .token_manager
                     .report_quota_exhausted_for_request(ctx.id, None, group);
@@ -379,6 +543,16 @@ impl KiroProvider {
 
             // 400 Bad Request
             if status.as_u16() == 400 {
+                Self::emit_attempt(
+                    sink,
+                    attempt,
+                    ctx.id,
+                    endpoint_name,
+                    Some(status.as_u16()),
+                    outcome::BAD_REQUEST,
+                    Some(&body),
+                    attempt_start,
+                );
                 anyhow::bail!("MCP 请求失败: {} {}", status, body);
             }
 
@@ -389,6 +563,16 @@ impl KiroProvider {
                     && self.token_manager.get_suspended_detection_enabled()
                     && endpoint.is_account_suspended(&body)
                 {
+                    Self::emit_attempt(
+                        sink,
+                        attempt,
+                        ctx.id,
+                        endpoint_name,
+                        Some(status.as_u16()),
+                        outcome::ACCOUNT_SUSPENDED,
+                        Some(&body),
+                        attempt_start,
+                    );
                     let has_available = self
                         .token_manager
                         .report_suspended_for_request(ctx.id, None, group);
@@ -398,6 +582,17 @@ impl KiroProvider {
                     last_error = Some(anyhow::anyhow!("MCP 请求失败（账号封禁）: {} {}", status, body));
                     continue;
                 }
+
+                Self::emit_attempt(
+                    sink,
+                    attempt,
+                    ctx.id,
+                    endpoint_name,
+                    Some(status.as_u16()),
+                    outcome::AUTH_FAILED,
+                    Some(&body),
+                    attempt_start,
+                );
 
                 // token 被上游失效：先尝试 force-refresh，每凭据仅一次机会
                 if endpoint.is_bearer_token_invalid(&body) && !force_refreshed.contains(&ctx.id) {
@@ -431,6 +626,16 @@ impl KiroProvider {
                     status,
                     body
                 );
+                Self::emit_attempt(
+                    sink,
+                    attempt,
+                    ctx.id,
+                    endpoint_name,
+                    Some(status.as_u16()),
+                    outcome::TRANSIENT,
+                    Some(&body),
+                    attempt_start,
+                );
                 last_error = if let Some(rate_limit) = rate_limit_error {
                     if !rate_limit.should_retry_locally() {
                         return Err(rate_limit.into());
@@ -453,10 +658,30 @@ impl KiroProvider {
 
             // 其他 4xx
             if status.is_client_error() {
+                Self::emit_attempt(
+                    sink,
+                    attempt,
+                    ctx.id,
+                    endpoint_name,
+                    Some(status.as_u16()),
+                    outcome::BAD_REQUEST,
+                    Some(&body),
+                    attempt_start,
+                );
                 anyhow::bail!("MCP 请求失败: {} {}", status, body);
             }
 
             // 兜底
+            Self::emit_attempt(
+                sink,
+                attempt,
+                ctx.id,
+                endpoint_name,
+                Some(status.as_u16()),
+                outcome::UNKNOWN,
+                Some(&body),
+                attempt_start,
+            );
             last_error = Some(anyhow::anyhow!("MCP 请求失败: {} {}", status, body));
             if attempt + 1 < max_retries {
                 sleep(Self::retry_delay(attempt)).await;
@@ -497,23 +722,39 @@ impl KiroProvider {
             let mut ctx = match self.token_manager.acquire_context(model.as_deref(), group).await {
                 Ok(c) => c,
                 Err(e) => {
-                    Self::emit_attempt(
-                        sink, attempt, 0, "", None, outcome::UNKNOWN,
-                        Some(&e.to_string()), attempt_start,
-                    );
                     if is_rate_limit_error(&e) {
+                        Self::emit_attempt(
+                            sink, attempt, 0, "", None, outcome::TRANSIENT,
+                            Some(&e.to_string()), attempt_start,
+                        );
                         return Err(e);
                     }
                     if let Some(rate_limit) = take_rate_limit_error(&mut last_error) {
                         return Err(rate_limit);
                     }
+                    Self::emit_attempt(
+                        sink, attempt, 0, "", None, outcome::UNKNOWN,
+                        Some(&e.to_string()), attempt_start,
+                    );
                     last_error = Some(e);
                     continue;
                 }
             };
 
             // 确保 Enterprise / IdC 账号的真实 profileArn 已解析（流式端点强制要求）
-            self.ensure_profile_arn(&mut ctx).await?;
+            if let Err(e) = self.ensure_profile_arn(&mut ctx).await {
+                Self::emit_attempt(
+                    sink,
+                    attempt,
+                    ctx.id,
+                    "",
+                    None,
+                    outcome::TRANSIENT,
+                    Some(&e.to_string()),
+                    attempt_start,
+                );
+                return Err(e);
+            }
 
             let config = self.token_manager.config();
             let machine_id = machine_id::generate_from_credentials(&ctx.credentials, config);
@@ -1018,6 +1259,30 @@ fn account_rate_limit_with_fallback(
 #[cfg(test)]
 mod rate_limit_tests {
     use super::*;
+
+    #[test]
+    fn mcp_validation_treats_caller_accepted_errors_as_success() {
+        fn is_no_results(error: &anyhow::Error) -> bool {
+            error.to_string().contains("Tool returned no results")
+        }
+
+        let valid: anyhow::Result<()> = Ok(());
+        let no_results: anyhow::Result<()> = Err(anyhow::anyhow!("Tool returned no results"));
+        let malformed: anyhow::Result<()> = Err(anyhow::anyhow!("invalid JSON"));
+
+        assert_eq!(
+            KiroProvider::mcp_validation_outcome(&valid, is_no_results),
+            outcome::SUCCESS
+        );
+        assert_eq!(
+            KiroProvider::mcp_validation_outcome(&no_results, is_no_results),
+            outcome::SUCCESS
+        );
+        assert_eq!(
+            KiroProvider::mcp_validation_outcome(&malformed, is_no_results),
+            outcome::UNKNOWN
+        );
+    }
 
     #[test]
     fn preserves_typed_rate_limit_when_later_credential_selection_fails() {


### PR DESCRIPTION
## Summary

- persist mixed model and MCP web-search rounds as one request trace
- keep attempt numbering, usage, first-token timing, credential attribution, and terminal errors accurate across retries
- preserve the supported no-results behavior while classifying failed model and MCP attempts consistently

## Testing

- `cargo test --locked` (639 passed)
- `cargo clippy --tests --locked` (passes with the repository's existing warnings)

Closes #65
