### PR TITLE
fix(responses): 稳定流式传输与 Codex 长连接

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ export KIRO_RS_API_KEY='sk-kiro-rs-...'
 codex
 ```
 
-两个 OpenAI 端点都会复用现有的模型映射、凭据故障转移和用量计量链路。当前实现会先取得完整的内部非流式响应，再为 `stream: true` 合成 SSE，因此不是逐 token 的上游实时流。Responses 端点不会把 Codex 的 `exec`、`shell`、`apply_patch` 等本地执行工具声明转发给 Kiro；时效性查询由服务端的 Kiro MCP WebSearch 处理。
+两个 OpenAI 端点都会复用现有的模型映射、凭据故障转移和用量计量链路。`/v1/responses` 在 `stream: true` 时会复用 Anthropic 流式链路，将上游 SSE 事件增量转换为 Responses SSE，而不是等待完整响应后再合成；WebSearch 多轮调用期间也会持续发送搜索进度和保活事件。Responses 端点会将 Codex 声明的 function、custom 和 namespace 工具（包括 `additional_tools`）转换后转发给 Kiro，并将工具调用还原为对应的 Responses 事件；hosted `web_search` 则由服务端的 Kiro MCP WebSearch 处理。
 
 <a id="api-routes"></a>
 ## API 路由

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -796,8 +796,11 @@ pub async fn post_messages(
         )
         .await
     } else {
-        // 非流式响应：仅在配置开启时提取 thinking 块
-        let extract_thinking = state.extract_thinking && thinking_enabled;
+        // Responses reasoning requests must expose native reasoning even when the
+        // global Anthropic compatibility flag is disabled; the Responses adapter
+        // explicitly opted into it via `thinking`/`output_config`.
+        let extract_thinking =
+            (state.extract_thinking || payload.output_config.is_some()) && thinking_enabled;
         let tracer = std::sync::Arc::new(RequestTracer::new(
             &state,
             RequestTraceOptions {
@@ -911,10 +914,11 @@ fn create_sse_stream(
 
     // 然后处理 Kiro 响应流，同时每25秒发送 ping 保活
     let body_stream = response.bytes_stream();
+    let settlement = StreamSettlement::new(hook, credential_id, tracer, &ctx);
 
     let processing_stream = stream::unfold(
-        (body_stream, ctx, EventStreamDecoder::new(), false, interval(Duration::from_secs(PING_INTERVAL_SECS)), hook, credential_id, tracer, 0u64),
-        |(mut body_stream, mut ctx, mut decoder, finished, mut ping_interval, hook, credential_id, tracer, mut sent_bytes)| async move {
+        (body_stream, ctx, EventStreamDecoder::new(), false, interval(Duration::from_secs(PING_INTERVAL_SECS)), settlement, 0u64),
+        |(mut body_stream, mut ctx, mut decoder, finished, mut ping_interval, mut settlement, mut sent_bytes)| async move {
             if finished {
                 return None;
             }
@@ -925,7 +929,7 @@ fn create_sse_stream(
                 chunk_result = body_stream.next() => {
                     match chunk_result {
                         Some(Ok(chunk)) => {
-                            tracer.mark_first_token();
+                            settlement.tracer.mark_first_token();
                             sent_bytes += chunk.len() as u64;
                             // 解码事件
                             if let Err(e) = decoder.feed(&chunk) {
@@ -952,58 +956,56 @@ fn create_sse_stream(
                                 .into_iter()
                                 .map(|e| Ok(Bytes::from(e.to_sse_string())))
                                 .collect();
+                            settlement.update(&ctx, sent_bytes);
 
-                            Some((stream::iter(bytes), (body_stream, ctx, decoder, false, ping_interval, hook, credential_id, tracer, sent_bytes)))
+                            Some((stream::iter(bytes), (body_stream, ctx, decoder, false, ping_interval, settlement, sent_bytes)))
                         }
                         Some(Err(e)) => {
                             tracing::error!("读取响应流失败: {}", e);
-                            // 发送最终事件并结束（记为 error）
-                            let final_events = ctx.generate_final_events();
-                            record_stream_usage(&hook, &ctx, credential_id, "error");
+                            // 流已开始后无法修改 HTTP 状态码。关闭已打开的内容块并发送
+                            // Anthropic error 终态，不能用正常 message_stop 掩盖上游断流。
+                            let final_events = ctx.generate_error_events(
+                                "upstream_error",
+                                "Upstream response stream was interrupted",
+                            );
+                            settlement.update(&ctx, sent_bytes);
                             // 已开始返回内容后上游断流：标记为 interrupted，带已发送字节数
-                            tracer.finalize(
+                            settlement.finish(
+                                "error",
                                 "interrupted",
                                 Some(outcome::STREAM_INTERRUPTED),
                                 Some(&e.to_string()),
                                 Some(sent_bytes),
-                                stream_trace_usage(&ctx),
                             );
                             let bytes: Vec<Result<Bytes, Infallible>> = final_events
                                 .into_iter()
                                 .map(|e| Ok(Bytes::from(e.to_sse_string())))
                                 .collect();
-                            Some((stream::iter(bytes), (body_stream, ctx, decoder, true, ping_interval, hook, credential_id, tracer, sent_bytes)))
+                            Some((stream::iter(bytes), (body_stream, ctx, decoder, true, ping_interval, settlement, sent_bytes)))
                         }
                         None => {
                             // 流结束，发送最终事件（generate_final_events 内部会 finish()
                             // 累积器，据此判定是否有半截 / 非法工具调用 JSON）。
                             let final_events = ctx.generate_final_events();
+                            settlement.update(&ctx, sent_bytes);
                             if let Some(message) = ctx.tool_json_error_message() {
                                 // 工具调用 JSON 半截 / 非法：实时流已回 200，无法改状态码，
                                 // 只能记 error 并让 generate_final_events 补发的 `error` 事件透传给客户端。
-                                record_stream_usage(&hook, &ctx, credential_id, "error");
-                                tracer.finalize(
+                                settlement.finish(
+                                    "error",
                                     "error",
                                     Some(outcome::BAD_REQUEST),
                                     Some(&message),
                                     None,
-                                    stream_trace_usage(&ctx),
                                 );
                             } else {
-                                record_stream_usage(&hook, &ctx, credential_id, "success");
-                                tracer.finalize(
-                                    "success",
-                                    None,
-                                    None,
-                                    None,
-                                    stream_trace_usage(&ctx),
-                                );
+                                settlement.finish("success", "success", None, None, None);
                             }
                             let bytes: Vec<Result<Bytes, Infallible>> = final_events
                                 .into_iter()
                                 .map(|e| Ok(Bytes::from(e.to_sse_string())))
                                 .collect();
-                            Some((stream::iter(bytes), (body_stream, ctx, decoder, true, ping_interval, hook, credential_id, tracer, sent_bytes)))
+                            Some((stream::iter(bytes), (body_stream, ctx, decoder, true, ping_interval, settlement, sent_bytes)))
                         }
                     }
                 }
@@ -1011,7 +1013,7 @@ fn create_sse_stream(
                 _ = ping_interval.tick() => {
                     tracing::trace!("发送 ping 保活事件");
                     let bytes: Vec<Result<Bytes, Infallible>> = vec![Ok(create_ping_sse())];
-                    Some((stream::iter(bytes), (body_stream, ctx, decoder, false, ping_interval, hook, credential_id, tracer, sent_bytes)))
+                    Some((stream::iter(bytes), (body_stream, ctx, decoder, false, ping_interval, settlement, sent_bytes)))
                 }
             }
         },
@@ -1021,24 +1023,93 @@ fn create_sse_stream(
     initial_stream.chain(processing_stream)
 }
 
-/// 从 StreamContext 提取最终用量并写入 hook
-fn record_stream_usage(
-    hook: &UsageRecordHook,
-    ctx: &StreamContext,
+/// Exactly-once settlement for a live Messages stream.
+///
+/// Responses consumes this stream as an inner body. If the outer client goes
+/// away, dropping that body also drops the in-flight unfold future; `Drop`
+/// records the latest usage snapshot and closes the trace instead of losing
+/// already incurred provider usage.
+struct StreamSettlement {
+    hook: UsageRecordHook,
     credential_id: u64,
-    status: &str,
-) {
-    // 互斥分摊后的 (input, cache_creation, cache_read)，与 trace 上报口径一致。
-    let (input, cache_creation, cache_read) = ctx.resolved_usage();
-    hook.record(
-        credential_id,
-        input,
-        ctx.resolved_output_tokens(),
-        cache_creation,
-        cache_read,
-        ctx.credits,
-        status,
-    );
+    tracer: std::sync::Arc<RequestTracer>,
+    usage: TraceUsage,
+    sent_bytes: u64,
+    settled: bool,
+}
+
+impl StreamSettlement {
+    fn new(
+        hook: UsageRecordHook,
+        credential_id: u64,
+        tracer: std::sync::Arc<RequestTracer>,
+        ctx: &StreamContext,
+    ) -> Self {
+        Self {
+            hook,
+            credential_id,
+            tracer,
+            usage: stream_trace_usage(ctx),
+            sent_bytes: 0,
+            settled: false,
+        }
+    }
+
+    fn update(&mut self, ctx: &StreamContext, sent_bytes: u64) {
+        self.usage = stream_trace_usage(ctx);
+        self.sent_bytes = sent_bytes;
+    }
+
+    fn finish(
+        &mut self,
+        usage_status: &str,
+        trace_status: &str,
+        error_type: Option<&str>,
+        error_message: Option<&str>,
+        interrupted_after_bytes: Option<u64>,
+    ) {
+        if self.settled {
+            return;
+        }
+        self.record_usage(usage_status);
+        self.tracer.finalize(
+            trace_status,
+            error_type,
+            error_message,
+            interrupted_after_bytes,
+            self.usage,
+        );
+        self.settled = true;
+    }
+
+    fn record_usage(&self, status: &str) {
+        self.hook.record(
+            self.credential_id,
+            self.usage.input_tokens.min(i32::MAX as u64) as i32,
+            self.usage.output_tokens.min(i32::MAX as u64) as i32,
+            self.usage.cache_creation_tokens.min(i32::MAX as u64) as i32,
+            self.usage.cache_read_tokens.min(i32::MAX as u64) as i32,
+            self.usage.credits,
+            status,
+        );
+    }
+}
+
+impl Drop for StreamSettlement {
+    fn drop(&mut self) {
+        if self.settled {
+            return;
+        }
+        self.record_usage("error");
+        self.tracer.finalize(
+            "interrupted",
+            Some(outcome::STREAM_INTERRUPTED),
+            Some("response stream was cancelled before completion"),
+            Some(self.sent_bytes),
+            self.usage,
+        );
+        self.settled = true;
+    }
 }
 
 /// 从 StreamContext 提取用量，转成 trace 行用量（与 record_stream_usage 同源）
@@ -1934,6 +2005,50 @@ fn create_buffered_sse_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::config::ToolCompatibilityMode;
+
+    #[test]
+    fn dropped_stream_settles_latest_usage_exactly_once() {
+        let aggregator = std::sync::Arc::new(crate::admin::usage_stats::UsageAggregator::new());
+        let state = AppState::new(false, ToolCompatibilityMode::Raw).with_usage(
+            None,
+            None,
+            Some(aggregator.clone()),
+        );
+        let hook = UsageRecordHook::from_state(&state, 0, "test-model".to_string());
+        let tracer = std::sync::Arc::new(RequestTracer::new(
+            &state,
+            RequestTraceOptions {
+                key_ctx: KeyContext {
+                    key_id: 0,
+                    group: None,
+                    key_source: TraceKeySource::MasterApiKey,
+                },
+                model: "test-model".to_string(),
+                is_stream: true,
+            },
+        ));
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            11,
+            false,
+            std::collections::HashMap::new(),
+            std::collections::HashSet::new(),
+        );
+        ctx.output_tokens = 7;
+        ctx.credits = 0.5;
+
+        let mut settlement = StreamSettlement::new(hook, 42, tracer, &ctx);
+        settlement.update(&ctx, 123);
+        drop(settlement);
+
+        let overview = aggregator.overview();
+        assert_eq!(overview.today_calls, 1);
+        assert_eq!(overview.today_errors, 1);
+        assert_eq!(overview.today_input_tokens, 11);
+        assert_eq!(overview.today_output_tokens, 7);
+        assert_eq!(overview.today_credits, 0.5);
+    }
 
     #[test]
     fn account_suspended_attempt_is_preserved_as_request_error_type() {

--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -18,20 +18,21 @@
 //!   → 应答 `custom_tool_call`（原始字符串 `input`）。
 //!   Anthropic 侧没有自由文本工具，进方向包一层
 //!   `{"input": <string>}` 单字段 schema，出方向再解包。
+//!
 //! 每个请求维护一张 name → 声明类型 的 [`ToolKindMap`]，请求翻译时生成、
 //! 响应构造时消费，保证出方向 item 类型永远与声明一致。
 //!
-//! web_search 始终由 kiro-rs 内部代答（codex 自带的搜索插件在自定义
-//! provider 下 401）：注入原生 `web_search_20250305`，请求因此必然进入
-//! handlers 的 web_search agentic loop——该 loop 会内部消化 web_search、
-//! 把其它 client 工具的 tool_use 原样透传（见 websearch_loop.rs）。
+//! 客户端显式声明 `type:"web_search"` 时由 kiro-rs 内部代答：注入原生
+//! `web_search_20250305` 并进入 handlers 的 web_search agentic loop。普通
+//! 文本和本地工具请求不注入搜索工具，以便沿用 Anthropic 的实时流。
 //!
-//! 说明：内部调用始终以非流式方式执行，`stream: true` 的请求在拿到完整结果后
-//! 合成为 Responses 的 SSE 事件序列（response.created / output_item /
-//! output_text.delta / function_call_arguments / response.completed）。
-//! codex 只从 `response.output_item.done` 构建回合内容，缓冲式合成足够。
+//! `stream:true` 时内部同样使用流式 Messages 请求，并逐事件把 Anthropic SSE
+//! 翻译成 Responses SSE；显式 WebSearch 仍由现有 agentic loop 整轮缓冲。
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    convert::Infallible,
+};
 
 use axum::{
     Json,
@@ -40,6 +41,8 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
+use futures::{StreamExt, stream};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -50,7 +53,9 @@ use super::openai::{
     ParsedResponse, collect_text_strings, now_ts, parse_anthropic_message, push_merged,
     resolve_session_metadata,
 };
-use super::types::{Message, MessagesRequest, Metadata, OutputConfig, SystemMessage, Tool};
+use super::types::{
+    Message, MessagesRequest, Metadata, OutputConfig, SystemMessage, Thinking, Tool,
+};
 
 /// 读取内部响应体时的上限（64MB，与请求体上限对齐）
 const MAX_INNER_BODY: usize = 64 * 1024 * 1024;
@@ -125,16 +130,59 @@ pub struct ResponsesRequest {
     pub tools: Option<Vec<Value>>,
     #[serde(default)]
     pub tool_choice: Option<Value>,
+    #[serde(default = "default_parallel_tool_calls")]
+    pub parallel_tool_calls: bool,
     #[serde(default)]
     pub reasoning: Option<ReasoningConfig>,
     #[serde(default)]
     pub prompt_cache_key: Option<String>,
 }
 
+fn default_parallel_tool_calls() -> bool {
+    true
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ReasoningConfig {
     #[serde(default)]
     pub effort: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ResponsesResponseConfig {
+    parallel_tool_calls: bool,
+    tool_choice: Value,
+    tools: Vec<Value>,
+}
+
+impl Default for ResponsesResponseConfig {
+    fn default() -> Self {
+        Self {
+            parallel_tool_calls: true,
+            tool_choice: json!("auto"),
+            tools: Vec::new(),
+        }
+    }
+}
+
+impl ResponsesResponseConfig {
+    fn from_request(req: &ResponsesRequest) -> Self {
+        let mut tools = req.tools.clone().unwrap_or_default();
+        if let Value::Array(items) = &req.input {
+            for item in items {
+                if item.get("type").and_then(Value::as_str) == Some("additional_tools")
+                    && let Some(extra) = item.get("tools").and_then(Value::as_array)
+                {
+                    tools.extend(extra.iter().cloned());
+                }
+            }
+        }
+        Self {
+            parallel_tool_calls: req.parallel_tool_calls,
+            tool_choice: req.tool_choice.clone().unwrap_or_else(|| json!("auto")),
+            tools,
+        }
+    }
 }
 
 // ============================ Handler ============================
@@ -148,6 +196,7 @@ pub async fn post_responses(
 ) -> Response {
     let want_stream = req.stream;
     let model = req.model.clone();
+    let response_config = ResponsesResponseConfig::from_request(&req);
     let metadata = resolve_session_metadata(req.prompt_cache_key.as_deref(), &headers);
 
     tracing::info!(
@@ -164,10 +213,32 @@ pub async fn post_responses(
         }
     };
 
-    // 2. 复用 Anthropic 全链路（内部强制非流式）
+    // 2. 复用 Anthropic 全链路。流式请求会得到标准 Anthropic SSE。
     let inner = post_messages(State(state), Extension(key_ctx), Json(anthropic_req)).await;
 
     let status = inner.status();
+    if !status.is_success() {
+        let body_bytes = match to_bytes(inner.into_body(), MAX_INNER_BODY).await {
+            Ok(b) => b,
+            Err(e) => {
+                return responses_error(
+                    StatusCode::BAD_GATEWAY,
+                    "api_error",
+                    &format!("failed to read upstream response: {e}"),
+                );
+            }
+        };
+        return Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body_bytes))
+            .unwrap();
+    }
+
+    if want_stream {
+        return responses_streaming_response(inner.into_body(), model, tool_kinds, response_config);
+    }
+
     let body_bytes = match to_bytes(inner.into_body(), MAX_INNER_BODY).await {
         Ok(b) => b,
         Err(e) => {
@@ -178,15 +249,6 @@ pub async fn post_responses(
             );
         }
     };
-
-    // 上游非 2xx：原样透传
-    if !status.is_success() {
-        return Response::builder()
-            .status(status)
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body_bytes))
-            .unwrap();
-    }
 
     let anthropic: Value = match serde_json::from_slice(&body_bytes) {
         Ok(v) => v,
@@ -202,18 +264,8 @@ pub async fn post_responses(
     // 3. Anthropic -> Responses 响应翻译
     let parsed = parse_anthropic_message(&anthropic, &model);
 
-    if want_stream {
-        let sse = build_responses_sse(&parsed, &tool_kinds);
-        Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, "text/event-stream")
-            .header(header::CACHE_CONTROL, "no-cache")
-            .body(Body::from(sse))
-            .unwrap()
-    } else {
-        let body = build_responses_object(&parsed, &tool_kinds);
-        (StatusCode::OK, Json(body)).into_response()
-    }
+    let body = build_responses_object_with_config(&parsed, &tool_kinds, &response_config);
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 // ============================ 请求翻译 ============================
@@ -228,13 +280,13 @@ fn responses_to_anthropic(
         .unwrap_or(DEFAULT_MAX_TOKENS);
 
     let mut system: Vec<SystemMessage> = Vec::new();
-    if let Some(instr) = req.instructions.as_ref() {
-        if !instr.trim().is_empty() {
-            system.push(SystemMessage {
-                text: instr.clone(),
-                cache_control: None,
-            });
-        }
+    if let Some(instr) = req.instructions.as_ref()
+        && !instr.trim().is_empty()
+    {
+        system.push(SystemMessage {
+            text: instr.clone(),
+            cache_control: None,
+        });
     }
 
     let mut merged: Vec<(String, Vec<Value>)> = Vec::new();
@@ -244,10 +296,8 @@ fn responses_to_anthropic(
 
     match &req.input {
         // input 直接是字符串 → 单条 user 文本
-        Value::String(s) => {
-            if !s.is_empty() {
-                push_merged(&mut merged, "user", vec![json!({"type":"text","text":s})]);
-            }
+        Value::String(s) if !s.is_empty() => {
+            push_merged(&mut merged, "user", vec![json!({"type":"text","text":s})]);
         }
         Value::Array(items) => {
             for item in items {
@@ -263,7 +313,7 @@ fn responses_to_anthropic(
                     continue;
                 }
 
-                translate_input_item(item, &mut system, &mut merged);
+                translate_input_item(item, &mut system, &mut merged)?;
             }
         }
         _ => {}
@@ -282,41 +332,53 @@ fn responses_to_anthropic(
         return Err("input must contain at least one user/assistant message".to_string());
     }
 
-    // 翻译 codex 声明的工具，并记录每个工具的声明类型（出方向要用）。
+    let hosted_web_search_declared = declared_entries
+        .iter()
+        .any(|entry| entry.get("type").and_then(Value::as_str) == Some("web_search"));
+
+    let tool_choice = req
+        .tool_choice
+        .as_ref()
+        .map(convert_tool_choice)
+        .transpose()?;
+    let tool_choice_none = tool_choice
+        .as_ref()
+        .is_some_and(|choice| choice.get("type").and_then(Value::as_str) == Some("none"));
+
+    // 翻译 codex 声明的本地工具，并记录每个工具的声明类型（出方向要用）。
     let mut tool_kinds: ToolKindMap = HashMap::new();
     let mut tool_list = convert_responses_tools(&declared_entries, &mut tool_kinds, None);
 
-    if tool_list.is_empty() {
-        // 无 codex 工具（纯聊天流）：保持既有已验证行为——noop 占位 +
-        // 原生 web_search（占位保证 tool_count > 1，走 agentic loop 而非
-        // 单工具 fast-path）+ 严格提示。
-        tool_list = vec![
-            Tool {
+    // `tool_choice: none` 是显式禁止工具调用，不能让 hosted web_search
+    // 注入工具，也不能把声明的工具继续转发给上游。
+    if !tool_choice_none
+        // 只有 hosted web_search 声明才进入内部搜索循环。若客户端声明了同名
+        // function，则客户端工具优先，避免破坏工具类型及名称还原。
+        && hosted_web_search_declared
+        && !tool_list.iter().any(|t| t.name == "web_search")
+    {
+        if tool_list.is_empty() {
+            // noop 保证不触发单 WebSearch fast-path，继续使用已验证的 agentic loop。
+            tool_list.push(Tool {
                 tool_type: None,
                 name: "noop".to_string(),
                 description: "Placeholder tool; never call this.".to_string(),
                 input_schema: Default::default(),
                 max_uses: None,
                 cache_control: None,
-            },
-            native_web_search_tool(),
-        ];
-        system.push(SystemMessage {
-            text: NUDGE_STRICT.to_string(),
-            cache_control: None,
-        });
-    } else {
-        // 有 codex 工具：追加原生 web_search（除非客户端已声明同名工具，
-        // 避免名字冲突破坏 tool_name 还原逻辑），并使用软化提示。
-        // 注入后 has_web_search_among_tools 命中 → 走 agentic loop，
-        // loop 会把非 web_search 的 client 工具 tool_use 原样透传。
-        if !tool_list.iter().any(|t| t.name == "web_search") {
+            });
             tool_list.push(native_web_search_tool());
+            system.push(SystemMessage {
+                text: NUDGE_STRICT.to_string(),
+                cache_control: None,
+            });
+        } else {
+            tool_list.push(native_web_search_tool());
+            system.push(SystemMessage {
+                text: NUDGE_SOFT.to_string(),
+                cache_control: None,
+            });
         }
-        system.push(SystemMessage {
-            text: NUDGE_SOFT.to_string(),
-            cache_control: None,
-        });
     }
 
     let custom_count = tool_kinds
@@ -329,20 +391,33 @@ fn responses_to_anthropic(
         "responses: forwarding tools to upstream"
     );
 
-    let tools = Some(tool_list);
-    let tool_choice = req.tool_choice.as_ref().and_then(convert_tool_choice);
+    let tools = if tool_choice_none || tool_list.is_empty() {
+        None
+    } else {
+        Some(tool_list)
+    };
     let output_config = req
         .reasoning
-        .and_then(|r| r.effort)
+        .as_ref()
+        .and_then(|r| r.effort.clone())
         .filter(|e| !e.trim().is_empty())
         .map(|effort| OutputConfig { effort });
+    let thinking = req.reasoning.and_then(|reasoning| {
+        reasoning
+            .effort
+            .filter(|effort| !effort.trim().is_empty())
+            .map(|_| Thinking {
+                thinking_type: "enabled".to_string(),
+                budget_tokens: 20_000,
+            })
+    });
 
     Ok((
         MessagesRequest {
             model: req.model,
             max_tokens,
             messages,
-            stream: false,
+            stream: req.stream,
             system: if system.is_empty() {
                 None
             } else {
@@ -350,7 +425,7 @@ fn responses_to_anthropic(
             },
             tools,
             tool_choice,
-            thinking: None,
+            thinking,
             output_config,
             metadata,
         },
@@ -529,7 +604,7 @@ fn translate_input_item(
     item: &Value,
     system: &mut Vec<SystemMessage>,
     merged: &mut Vec<(String, Vec<Value>)>,
-) {
+) -> Result<(), String> {
     let ty = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
     match ty {
@@ -552,7 +627,9 @@ fn translate_input_item(
                 .get("arguments")
                 .and_then(|v| v.as_str())
                 .unwrap_or("{}");
-            let input: Value = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+            let input: Value = serde_json::from_str(args_str).map_err(|error| {
+                format!("input function_call {call_id} has invalid JSON arguments: {error}")
+            })?;
             let block = json!({
                 "type": "tool_use",
                 "id": call_id,
@@ -607,7 +684,7 @@ fn translate_input_item(
         _ => {
             let role = item.get("role").and_then(|v| v.as_str());
             let Some(role) = role else {
-                return;
+                return Ok(());
             };
             match role {
                 "system" | "developer" => {
@@ -626,26 +703,25 @@ fn translate_input_item(
             }
         }
     }
+    Ok(())
 }
 
 /// 把 Responses message.content（字符串或数组）转成 Anthropic content blocks
 fn content_blocks(content: Option<&Value>) -> Vec<Value> {
     let mut out = Vec::new();
     match content {
-        Some(Value::String(s)) => {
-            if !s.is_empty() {
-                out.push(json!({"type":"text","text":s}));
-            }
+        Some(Value::String(s)) if !s.is_empty() => {
+            out.push(json!({"type":"text","text":s}));
         }
         Some(Value::Array(parts)) => {
             for part in parts {
                 let ty = part.get("type").and_then(|v| v.as_str()).unwrap_or("");
                 match ty {
                     "input_text" | "output_text" | "text" => {
-                        if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
-                            if !t.is_empty() {
-                                out.push(json!({"type":"text","text":t}));
-                            }
+                        if let Some(t) = part.get("text").and_then(|v| v.as_str())
+                            && !t.is_empty()
+                        {
+                            out.push(json!({"type":"text","text":t}));
                         }
                     }
                     "input_image" => {
@@ -697,23 +773,36 @@ fn stringify_output(output: Option<&Value>) -> String {
     }
 }
 
-fn convert_tool_choice(tc: &Value) -> Option<Value> {
+fn convert_tool_choice(tc: &Value) -> Result<Value, String> {
     match tc {
         Value::String(s) => match s.as_str() {
-            "auto" => Some(json!({"type":"auto"})),
-            "required" => Some(json!({"type":"any"})),
-            "none" => None,
-            _ => Some(json!({"type":"auto"})),
+            "auto" => Ok(json!({"type":"auto"})),
+            "required" => Ok(json!({"type":"any"})),
+            "none" => Ok(json!({"type":"none"})),
+            other => Err(format!("unsupported tool_choice value: {other}")),
         },
-        Value::Object(_) => {
-            // Responses: {"type":"function","name":"..."}
-            let name = tc
-                .get("name")
-                .or_else(|| tc.get("function").and_then(|f| f.get("name")))
-                .and_then(|v| v.as_str());
-            name.map(|n| json!({"type":"tool","name":n}))
+        Value::Object(object) => {
+            let choice_type = object
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("function");
+            match choice_type {
+                "function" => {
+                    let name = object
+                        .get("name")
+                        .or_else(|| object.get("function").and_then(|f| f.get("name")))
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "tool_choice function is missing name".to_string())?;
+                    let namespace = object.get("namespace").and_then(Value::as_str);
+                    Ok(json!({"type":"tool","name":flat_tool_name(namespace, name)}))
+                }
+                "auto" => Ok(json!({"type":"auto"})),
+                "required" => Ok(json!({"type":"any"})),
+                "none" => Ok(json!({"type":"none"})),
+                other => Err(format!("unsupported tool_choice type: {other}")),
+            }
         }
-        _ => None,
+        _ => Err("tool_choice must be a string or object".to_string()),
     }
 }
 
@@ -749,10 +838,10 @@ fn custom_input_text(arguments_json: &str) -> String {
             if let Some(Value::String(s)) = map.get("input") {
                 return s.clone();
             }
-            if map.len() == 1 {
-                if let Some(Value::String(s)) = map.values().next() {
-                    return s.clone();
-                }
+            if map.len() == 1
+                && let Some(Value::String(s)) = map.values().next()
+            {
+                return s.clone();
             }
             arguments_json.to_string()
         }
@@ -893,7 +982,12 @@ fn build_view(p: &ParsedResponse, kinds: &ToolKindMap) -> ResponsesView {
     }
 }
 
-fn build_response_object_from(p: &ParsedResponse, view: &ResponsesView, id: &str) -> Value {
+fn build_response_object_from(
+    p: &ParsedResponse,
+    view: &ResponsesView,
+    id: &str,
+    config: &ResponsesResponseConfig,
+) -> Value {
     let mut obj = json!({
         "id": id,
         "object": "response",
@@ -902,9 +996,9 @@ fn build_response_object_from(p: &ParsedResponse, view: &ResponsesView, id: &str
         "model": p.model,
         "output": view.output,
         "usage": view.usage,
-        "parallel_tool_calls": true,
-        "tool_choice": "auto",
-        "tools": [],
+        "parallel_tool_calls": config.parallel_tool_calls,
+        "tool_choice": config.tool_choice,
+        "tools": config.tools,
     });
     if view.status == "incomplete" {
         obj["incomplete_details"] = json!({ "reason": "max_output_tokens" });
@@ -912,10 +1006,850 @@ fn build_response_object_from(p: &ParsedResponse, view: &ResponsesView, id: &str
     obj
 }
 
-fn build_responses_object(p: &ParsedResponse, kinds: &ToolKindMap) -> Value {
+fn build_responses_object_with_config(
+    p: &ParsedResponse,
+    kinds: &ToolKindMap,
+    config: &ResponsesResponseConfig,
+) -> Value {
     let view = build_view(p, kinds);
     let id = new_resp_id();
-    build_response_object_from(p, &view, &id)
+    build_response_object_from(p, &view, &id, config)
+}
+
+#[cfg(test)]
+fn build_responses_object(p: &ParsedResponse, kinds: &ToolKindMap) -> Value {
+    build_responses_object_with_config(p, kinds, &ResponsesResponseConfig::default())
+}
+
+// ============================ 流式响应翻译 ============================
+
+#[derive(Debug)]
+enum StreamingBlock {
+    Text {
+        item_id: String,
+        output_index: Option<i64>,
+        text: String,
+    },
+    Reasoning {
+        item_id: String,
+        output_index: Option<i64>,
+        text: String,
+    },
+    Tool {
+        call_id: String,
+        flat_name: String,
+        arguments: String,
+    },
+    WebSearch {
+        item_id: String,
+        query: String,
+        output_index: i64,
+    },
+    Ignored,
+}
+
+struct ResponsesStreamContext {
+    response_id: String,
+    created_at: i64,
+    model: String,
+    tool_kinds: ToolKindMap,
+    response_config: ResponsesResponseConfig,
+    sequence_number: i64,
+    next_output_index: i64,
+    blocks: HashMap<i64, StreamingBlock>,
+    output: Vec<Value>,
+    input_tokens: i64,
+    cache_creation_tokens: i64,
+    cached_tokens: i64,
+    output_tokens: i64,
+    reasoning_tokens: i64,
+    credit_usage: Option<f64>,
+    credit_unit: Option<String>,
+    credit_unit_plural: Option<String>,
+    stop_reason: Option<String>,
+    saw_message_stop: bool,
+    terminal: bool,
+}
+
+impl ResponsesStreamContext {
+    fn new(
+        model: String,
+        tool_kinds: ToolKindMap,
+        response_config: ResponsesResponseConfig,
+    ) -> Self {
+        Self {
+            response_id: new_resp_id(),
+            created_at: now_ts(),
+            model,
+            tool_kinds,
+            response_config,
+            sequence_number: 0,
+            next_output_index: 0,
+            blocks: HashMap::new(),
+            output: Vec::new(),
+            input_tokens: 0,
+            cache_creation_tokens: 0,
+            cached_tokens: 0,
+            output_tokens: 0,
+            reasoning_tokens: 0,
+            credit_usage: None,
+            credit_unit: None,
+            credit_unit_plural: None,
+            stop_reason: None,
+            saw_message_stop: false,
+            terminal: false,
+        }
+    }
+
+    fn initial_events(&mut self) -> Vec<Bytes> {
+        let response = json!({
+            "id": self.response_id,
+            "object": "response",
+            "created_at": self.created_at,
+            "status": "in_progress",
+            "model": self.model,
+            "output": [],
+        });
+        vec![
+            self.emit("response.created", json!({ "response": response.clone() })),
+            self.emit("response.in_progress", json!({ "response": response })),
+        ]
+    }
+
+    fn emit(&mut self, event_type: &str, mut payload: Value) -> Bytes {
+        payload["type"] = json!(event_type);
+        payload["sequence_number"] = json!(self.sequence_number);
+        self.sequence_number += 1;
+        Bytes::from(format!("event: {event_type}\ndata: {}\n\n", payload))
+    }
+
+    fn allocate_output_index(&mut self) -> i64 {
+        let index = self.next_output_index;
+        self.next_output_index += 1;
+        index
+    }
+
+    fn handle_anthropic_event(&mut self, event: &str, data: Value) -> Vec<Bytes> {
+        if self.terminal {
+            return Vec::new();
+        }
+        // The hosted web-search loop carries unsigned provider reasoning as an
+        // out-of-band field on the next standard event. Consume it first so the
+        // Responses reasoning item precedes the visible answer/tool item.
+        let mut events = data
+            .get("kiro_thinking")
+            .and_then(Value::as_str)
+            .filter(|thinking| !thinking.is_empty())
+            .map(|thinking| self.emit_reasoning_summary(thinking))
+            .unwrap_or_default();
+        let translated = match event {
+            "message_start" => {
+                if let Some(usage) = data.pointer("/message/usage") {
+                    self.update_usage(usage);
+                }
+                Vec::new()
+            }
+            "content_block_start" => self.handle_block_start(&data),
+            "content_block_delta" => self.handle_block_delta(&data),
+            "content_block_stop" => self.handle_block_stop(&data),
+            "message_delta" => {
+                if let Some(usage) = data.get("usage") {
+                    self.update_usage(usage);
+                }
+                self.stop_reason = data
+                    .pointer("/delta/stop_reason")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                Vec::new()
+            }
+            "message_stop" => {
+                self.saw_message_stop = true;
+                self.finish()
+            }
+            "error" => {
+                let error_type = data
+                    .pointer("/error/type")
+                    .and_then(Value::as_str)
+                    .unwrap_or("server_error");
+                let message = data
+                    .pointer("/error/message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("upstream stream failed");
+                vec![self.fail(error_type, message)]
+            }
+            "ping" => vec![Bytes::from(": ping\n\n")],
+            _ => Vec::new(),
+        };
+        events.extend(translated);
+        events
+    }
+
+    fn handle_block_start(&mut self, data: &Value) -> Vec<Bytes> {
+        let Some(index) = data.get("index").and_then(Value::as_i64) else {
+            return Vec::new();
+        };
+        let block = data.get("content_block").unwrap_or(&Value::Null);
+        let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
+        let state = match block_type {
+            "text" => StreamingBlock::Text {
+                item_id: new_msg_id(),
+                output_index: None,
+                text: String::new(),
+            },
+            "thinking" => StreamingBlock::Reasoning {
+                item_id: new_rs_id(),
+                output_index: None,
+                text: String::new(),
+            },
+            "tool_use" => StreamingBlock::Tool {
+                call_id: block
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+                flat_name: block
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+                arguments: String::new(),
+            },
+            "server_tool_use"
+                if block.get("name").and_then(Value::as_str) == Some("web_search") =>
+            {
+                let item_id = block
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or_else(new_fc_id);
+                let query = block
+                    .pointer("/input/query")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let output_index = self.allocate_output_index();
+                let added = json!({
+                    "type": "web_search_call",
+                    "id": item_id,
+                    "status": "in_progress",
+                    "action": { "type": "search", "query": query },
+                });
+                self.blocks.insert(
+                    index,
+                    StreamingBlock::WebSearch {
+                        item_id,
+                        query,
+                        output_index,
+                    },
+                );
+                return vec![self.emit(
+                    "response.output_item.added",
+                    json!({ "output_index": output_index, "item": added }),
+                )];
+            }
+            _ => StreamingBlock::Ignored,
+        };
+        self.blocks.insert(index, state);
+        Vec::new()
+    }
+
+    fn handle_block_delta(&mut self, data: &Value) -> Vec<Bytes> {
+        let Some(index) = data.get("index").and_then(Value::as_i64) else {
+            return Vec::new();
+        };
+        let delta = data.get("delta").unwrap_or(&Value::Null);
+        match delta.get("type").and_then(Value::as_str).unwrap_or("") {
+            "text_delta" => {
+                let text = delta.get("text").and_then(Value::as_str).unwrap_or("");
+                self.handle_text_delta(index, text)
+            }
+            "thinking_delta" => {
+                let text = delta.get("thinking").and_then(Value::as_str).unwrap_or("");
+                self.handle_reasoning_delta(index, text)
+            }
+            "input_json_delta" => {
+                if let Some(StreamingBlock::Tool { arguments, .. }) = self.blocks.get_mut(&index) {
+                    arguments.push_str(
+                        delta
+                            .get("partial_json")
+                            .and_then(Value::as_str)
+                            .unwrap_or(""),
+                    );
+                }
+                Vec::new()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn handle_text_delta(&mut self, index: i64, delta: &str) -> Vec<Bytes> {
+        if delta.is_empty() {
+            return Vec::new();
+        }
+        let needs_start = matches!(
+            self.blocks.get(&index),
+            Some(StreamingBlock::Text {
+                output_index: None,
+                ..
+            })
+        );
+        if needs_start {
+            let output_index = self.allocate_output_index();
+            if let Some(StreamingBlock::Text {
+                output_index: block_index,
+                ..
+            }) = self.blocks.get_mut(&index)
+            {
+                *block_index = Some(output_index);
+            }
+        }
+        let Some(StreamingBlock::Text {
+            item_id,
+            output_index: Some(output_index),
+            text,
+        }) = self.blocks.get_mut(&index)
+        else {
+            return Vec::new();
+        };
+        let first = text.is_empty();
+        text.push_str(delta);
+        let item_id = item_id.clone();
+        let output_index = *output_index;
+        let mut events = Vec::new();
+        if first {
+            events.push(self.emit(
+                "response.output_item.added",
+                json!({ "output_index": output_index, "item": {
+                    "type": "message", "id": item_id, "status": "in_progress",
+                    "role": "assistant", "content": [],
+                }}),
+            ));
+            events.push(self.emit(
+                "response.content_part.added",
+                json!({
+                    "item_id": item_id, "output_index": output_index, "content_index": 0,
+                    "part": { "type": "output_text", "text": "", "annotations": [] },
+                }),
+            ));
+        }
+        events.push(self.emit(
+            "response.output_text.delta",
+            json!({
+                "item_id": item_id, "output_index": output_index,
+                "content_index": 0, "delta": delta,
+            }),
+        ));
+        events
+    }
+
+    fn handle_reasoning_delta(&mut self, index: i64, delta: &str) -> Vec<Bytes> {
+        if delta.is_empty() {
+            return Vec::new();
+        }
+        let needs_start = matches!(
+            self.blocks.get(&index),
+            Some(StreamingBlock::Reasoning {
+                output_index: None,
+                ..
+            })
+        );
+        if needs_start {
+            let output_index = self.allocate_output_index();
+            if let Some(StreamingBlock::Reasoning {
+                output_index: block_index,
+                ..
+            }) = self.blocks.get_mut(&index)
+            {
+                *block_index = Some(output_index);
+            }
+        }
+        let Some(StreamingBlock::Reasoning {
+            item_id,
+            output_index: Some(output_index),
+            text,
+        }) = self.blocks.get_mut(&index)
+        else {
+            return Vec::new();
+        };
+        let first = text.is_empty();
+        text.push_str(delta);
+        let item_id = item_id.clone();
+        let output_index = *output_index;
+        let mut events = Vec::new();
+        if first {
+            events.push(self.emit(
+                "response.output_item.added",
+                json!({ "output_index": output_index, "item": {
+                    "type": "reasoning", "id": item_id, "summary": [],
+                }}),
+            ));
+        }
+        events.push(self.emit(
+            "response.reasoning_summary_text.delta",
+            json!({
+                "item_id": item_id, "output_index": output_index,
+                "summary_index": 0, "delta": delta,
+            }),
+        ));
+        events
+    }
+
+    fn handle_block_stop(&mut self, data: &Value) -> Vec<Bytes> {
+        let Some(index) = data.get("index").and_then(Value::as_i64) else {
+            return Vec::new();
+        };
+        match self.blocks.remove(&index) {
+            Some(StreamingBlock::Text {
+                item_id,
+                output_index: Some(output_index),
+                text,
+            }) => self.finish_text(item_id, output_index, text),
+            Some(StreamingBlock::Reasoning {
+                item_id,
+                output_index: Some(output_index),
+                text,
+            }) => self.finish_reasoning(item_id, output_index, text),
+            Some(StreamingBlock::Tool {
+                call_id,
+                flat_name,
+                arguments,
+            }) => self.finish_tool(call_id, flat_name, arguments),
+            Some(StreamingBlock::WebSearch {
+                item_id,
+                query,
+                output_index,
+            }) => self.finish_web_search(item_id, query, output_index),
+            _ => Vec::new(),
+        }
+    }
+
+    fn finish_text(&mut self, item_id: String, output_index: i64, text: String) -> Vec<Bytes> {
+        let item = json!({
+            "type": "message", "id": item_id, "status": "completed",
+            "role": "assistant", "content": [{
+                "type": "output_text", "text": text, "annotations": [],
+            }],
+        });
+        self.output.push(item.clone());
+        vec![
+            self.emit(
+                "response.output_text.done",
+                json!({
+                    "item_id": item_id, "output_index": output_index,
+                    "content_index": 0, "text": text,
+                }),
+            ),
+            self.emit(
+                "response.content_part.done",
+                json!({
+                    "item_id": item_id, "output_index": output_index, "content_index": 0,
+                    "part": { "type": "output_text", "text": text, "annotations": [] },
+                }),
+            ),
+            self.emit(
+                "response.output_item.done",
+                json!({ "output_index": output_index, "item": item }),
+            ),
+        ]
+    }
+
+    fn finish_reasoning(&mut self, item_id: String, output_index: i64, text: String) -> Vec<Bytes> {
+        let item = json!({
+            "type": "reasoning", "id": item_id,
+            "summary": [{ "type": "summary_text", "text": text }],
+        });
+        self.output.push(item.clone());
+        vec![
+            self.emit(
+                "response.reasoning_summary_text.done",
+                json!({
+                    "item_id": item_id, "output_index": output_index,
+                    "summary_index": 0, "text": text,
+                }),
+            ),
+            self.emit(
+                "response.output_item.done",
+                json!({ "output_index": output_index, "item": item }),
+            ),
+        ]
+    }
+
+    /// Translate the hosted web-search loop's out-of-band reasoning extension.
+    /// It deliberately does not use an Anthropic `thinking` block because those
+    /// require a provider signature when replayed by Anthropic clients.
+    fn emit_reasoning_summary(&mut self, text: &str) -> Vec<Bytes> {
+        let item_id = new_rs_id();
+        let output_index = self.allocate_output_index();
+        let item = json!({
+            "type": "reasoning", "id": item_id,
+            "summary": [{ "type": "summary_text", "text": text }],
+        });
+        self.output.push(item.clone());
+        vec![
+            self.emit(
+                "response.output_item.added",
+                json!({ "output_index": output_index, "item": {
+                    "type": "reasoning", "id": item_id, "summary": [],
+                }}),
+            ),
+            self.emit(
+                "response.reasoning_summary_text.delta",
+                json!({
+                    "item_id": item_id, "output_index": output_index,
+                    "summary_index": 0, "delta": text,
+                }),
+            ),
+            self.emit(
+                "response.reasoning_summary_text.done",
+                json!({
+                    "item_id": item_id, "output_index": output_index,
+                    "summary_index": 0, "text": text,
+                }),
+            ),
+            self.emit(
+                "response.output_item.done",
+                json!({ "output_index": output_index, "item": item }),
+            ),
+        ]
+    }
+
+    fn finish_tool(
+        &mut self,
+        call_id: String,
+        flat_name: String,
+        mut arguments: String,
+    ) -> Vec<Bytes> {
+        if arguments.trim().is_empty() {
+            arguments = "{}".to_string();
+        }
+        let output_index = self.allocate_output_index();
+        let decl = self.tool_kinds.get(&flat_name);
+        let (name, namespace, kind) = match decl {
+            Some(d) => (d.name.clone(), d.namespace.clone(), d.kind),
+            None => (flat_name, None, DeclaredToolKind::Function),
+        };
+        let (item, added, delta_event, done_event, done_key, value) = match kind {
+            DeclaredToolKind::Custom => {
+                let input = custom_input_text(&arguments);
+                let mut item = json!({
+                    "type": "custom_tool_call", "id": new_ctc_id(),
+                    "call_id": call_id, "name": name, "input": input,
+                    "status": "completed",
+                });
+                if let Some(ns) = namespace {
+                    item["namespace"] = json!(ns);
+                }
+                let mut added = item.clone();
+                added["status"] = json!("in_progress");
+                (
+                    item,
+                    added,
+                    "response.custom_tool_call_input.delta",
+                    "response.custom_tool_call_input.done",
+                    "input",
+                    input,
+                )
+            }
+            DeclaredToolKind::Function => {
+                let mut item = json!({
+                    "type": "function_call", "id": new_fc_id(),
+                    "call_id": call_id, "name": name, "arguments": arguments,
+                    "status": "completed",
+                });
+                if let Some(ns) = namespace {
+                    item["namespace"] = json!(ns);
+                }
+                let mut added = item.clone();
+                added["status"] = json!("in_progress");
+                added["arguments"] = json!("");
+                (
+                    item,
+                    added,
+                    "response.function_call_arguments.delta",
+                    "response.function_call_arguments.done",
+                    "arguments",
+                    arguments,
+                )
+            }
+        };
+        let item_id = item["id"].as_str().unwrap_or("").to_string();
+        self.output.push(item.clone());
+        let mut delta_payload = json!({
+            "item_id": item_id,
+            "output_index": output_index,
+        });
+        delta_payload["delta"] = json!(value);
+        let mut done_payload = json!({
+            "item_id": item_id,
+            "output_index": output_index,
+        });
+        done_payload[done_key] = json!(value);
+        vec![
+            self.emit(
+                "response.output_item.added",
+                json!({ "output_index": output_index, "item": added }),
+            ),
+            self.emit(delta_event, delta_payload),
+            self.emit(done_event, done_payload),
+            self.emit(
+                "response.output_item.done",
+                json!({ "output_index": output_index, "item": item }),
+            ),
+        ]
+    }
+
+    fn finish_web_search(
+        &mut self,
+        item_id: String,
+        query: String,
+        output_index: i64,
+    ) -> Vec<Bytes> {
+        let item = json!({
+            "type": "web_search_call", "id": item_id, "status": "completed",
+            "action": { "type": "search", "query": query },
+        });
+        self.output.push(item.clone());
+        vec![self.emit(
+            "response.output_item.done",
+            json!({ "output_index": output_index, "item": item }),
+        )]
+    }
+
+    fn update_usage(&mut self, usage: &Value) {
+        if let Some(value) = usage.get("input_tokens").and_then(Value::as_i64) {
+            self.input_tokens = value.max(0);
+        }
+        if let Some(value) = usage
+            .get("cache_creation_input_tokens")
+            .and_then(Value::as_i64)
+        {
+            self.cache_creation_tokens = value.max(0);
+        }
+        if let Some(value) = usage.get("output_tokens").and_then(Value::as_i64) {
+            self.output_tokens = value.max(0);
+        }
+        if let Some(value) = usage.get("cache_read_input_tokens").and_then(Value::as_i64) {
+            self.cached_tokens = value.max(0);
+        }
+        if let Some(value) = usage.get("reasoning_tokens").and_then(Value::as_i64) {
+            self.reasoning_tokens = value.max(0);
+        }
+        if let Some(value) = usage.get("credit_usage").and_then(Value::as_f64) {
+            self.credit_usage = Some(value);
+        }
+        if let Some(value) = usage.get("credit_unit").and_then(Value::as_str) {
+            self.credit_unit = Some(value.to_string());
+        }
+        if let Some(value) = usage.get("credit_unit_plural").and_then(Value::as_str) {
+            self.credit_unit_plural = Some(value.to_string());
+        }
+    }
+
+    fn usage(&self) -> Value {
+        let total_input_tokens = self
+            .input_tokens
+            .saturating_add(self.cache_creation_tokens)
+            .saturating_add(self.cached_tokens);
+        let mut usage = json!({
+            "input_tokens": total_input_tokens,
+            "input_tokens_details": { "cached_tokens": self.cached_tokens },
+            "output_tokens": self.output_tokens,
+            "output_tokens_details": { "reasoning_tokens": self.reasoning_tokens },
+            "total_tokens": total_input_tokens.saturating_add(self.output_tokens),
+        });
+        if let Some(value) = self.credit_usage {
+            usage["credit_usage"] = json!(value);
+        }
+        if let Some(value) = &self.credit_unit {
+            usage["credit_unit"] = json!(value);
+        }
+        if let Some(value) = &self.credit_unit_plural {
+            usage["credit_unit_plural"] = json!(value);
+        }
+        usage
+    }
+
+    fn response_object(&self, status: &str) -> Value {
+        let mut response = json!({
+            "id": self.response_id,
+            "object": "response",
+            "created_at": self.created_at,
+            "status": status,
+            "model": self.model,
+            "output": self.output,
+            "usage": self.usage(),
+            "parallel_tool_calls": self.response_config.parallel_tool_calls,
+            "tool_choice": self.response_config.tool_choice,
+            "tools": self.response_config.tools,
+        });
+        if status == "incomplete" {
+            response["incomplete_details"] = json!({ "reason": "max_output_tokens" });
+        }
+        response
+    }
+
+    fn finish(&mut self) -> Vec<Bytes> {
+        if self.terminal {
+            return Vec::new();
+        }
+        if !self.saw_message_stop {
+            return vec![self.fail("server_error", "upstream stream ended before message_stop")];
+        }
+        let incomplete = matches!(
+            self.stop_reason.as_deref(),
+            Some("max_tokens" | "model_context_window_exceeded")
+        );
+        let status = if incomplete {
+            "incomplete"
+        } else {
+            "completed"
+        };
+        let event = if incomplete {
+            "response.incomplete"
+        } else {
+            "response.completed"
+        };
+        self.terminal = true;
+        vec![self.emit(event, json!({ "response": self.response_object(status) }))]
+    }
+
+    fn fail(&mut self, error_type: &str, message: &str) -> Bytes {
+        self.terminal = true;
+        let mut response = self.response_object("failed");
+        response["error"] = json!({
+            "code": error_type,
+            "message": message,
+        });
+        self.emit("response.failed", json!({ "response": response }))
+    }
+}
+
+fn responses_streaming_response(
+    body: Body,
+    model: String,
+    tool_kinds: ToolKindMap,
+    response_config: ResponsesResponseConfig,
+) -> Response {
+    let mut context = ResponsesStreamContext::new(model, tool_kinds, response_config);
+    let pending = VecDeque::from(context.initial_events());
+    let stream = stream::unfold(
+        (
+            body.into_data_stream(),
+            Vec::<u8>::new(),
+            context,
+            pending,
+            false,
+        ),
+        |(mut body, mut buffer, mut context, mut pending, mut finished)| async move {
+            loop {
+                if let Some(bytes) = pending.pop_front() {
+                    return Some((
+                        Ok::<Bytes, Infallible>(bytes),
+                        (body, buffer, context, pending, finished),
+                    ));
+                }
+                if finished || context.terminal {
+                    return None;
+                }
+                match body.next().await {
+                    Some(Ok(chunk)) => {
+                        buffer.extend_from_slice(&chunk);
+                        for frame in take_sse_frames(&mut buffer) {
+                            if context.terminal {
+                                break;
+                            }
+                            match parse_sse_frame(&frame) {
+                                Ok(Some((event, data))) => {
+                                    pending.extend(context.handle_anthropic_event(&event, data))
+                                }
+                                Ok(None) => {}
+                                Err(message) => {
+                                    pending.push_back(context.fail("server_error", &message))
+                                }
+                            }
+                        }
+                    }
+                    Some(Err(error)) => {
+                        pending.push_back(context.fail(
+                            "upstream_error",
+                            &format!("failed to read upstream stream: {error}"),
+                        ));
+                        finished = true;
+                    }
+                    None => {
+                        if buffer.iter().any(|byte| !byte.is_ascii_whitespace()) {
+                            pending.push_back(
+                                context
+                                    .fail("server_error", "upstream sent an incomplete SSE frame"),
+                            );
+                        } else {
+                            pending.extend(context.finish());
+                        }
+                        finished = true;
+                    }
+                }
+            }
+        },
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .header(header::CONNECTION, "keep-alive")
+        .body(Body::from_stream(stream))
+        .unwrap()
+}
+
+fn take_sse_frames(buffer: &mut Vec<u8>) -> Vec<Vec<u8>> {
+    let mut frames = Vec::new();
+    loop {
+        let lf = buffer.windows(2).position(|window| window == b"\n\n");
+        let crlf = buffer.windows(4).position(|window| window == b"\r\n\r\n");
+        let delimiter = match (lf, crlf) {
+            (Some(a), Some(b)) if a <= b => Some((a, 2)),
+            (Some(_), Some(b)) => Some((b, 4)),
+            (Some(a), None) => Some((a, 2)),
+            (None, Some(b)) => Some((b, 4)),
+            (None, None) => None,
+        };
+        let Some((position, length)) = delimiter else {
+            break;
+        };
+        let frame = buffer.drain(..position).collect::<Vec<_>>();
+        buffer.drain(..length);
+        if frame.iter().any(|byte| !byte.is_ascii_whitespace()) {
+            frames.push(frame);
+        }
+    }
+    frames
+}
+
+fn parse_sse_frame(frame: &[u8]) -> Result<Option<(String, Value)>, String> {
+    let text = std::str::from_utf8(frame)
+        .map_err(|error| format!("upstream sent invalid UTF-8 SSE: {error}"))?;
+    let mut event = None;
+    let mut data_lines = Vec::new();
+    for line in text.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.starts_with(':') {
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("event:") {
+            event = Some(value.trim().to_string());
+        } else if let Some(value) = line.strip_prefix("data:") {
+            data_lines.push(value.trim_start());
+        }
+    }
+    let Some(event) = event else {
+        return Ok(None);
+    };
+    if event == "ping" {
+        return Ok(Some((event, json!({ "type": "ping" }))));
+    }
+    let data = serde_json::from_str::<Value>(&data_lines.join("\n"))
+        .map_err(|error| format!("failed to parse upstream SSE event {event}: {error}"))?;
+    Ok(Some((event, data)))
 }
 
 /// 把完整结果合成为 Responses SSE 事件序列
@@ -923,6 +1857,7 @@ fn build_responses_object(p: &ParsedResponse, kinds: &ToolKindMap) -> Value {
 /// codex 只从 `response.output_item.done` 构建回合内容（`.added` 用于进度
 /// 展示，`response.completed` 只取 id/usage），所以每个 item 只要保证
 /// added/done 成对且 done 携带完整内容即可。delta 事件是锦上添花。
+#[cfg(test)]
 fn build_responses_sse(p: &ParsedResponse, kinds: &ToolKindMap) -> String {
     let view = build_view(p, kinds);
     let resp_id = new_resp_id();
@@ -1146,7 +2081,8 @@ fn build_responses_sse(p: &ParsedResponse, kinds: &ToolKindMap) -> String {
     }
 
     // response.completed（完整对象含 usage）
-    let final_obj = build_response_object_from(p, &view, &resp_id);
+    let final_obj =
+        build_response_object_from(p, &view, &resp_id, &ResponsesResponseConfig::default());
     let completed_event = if view.status == "incomplete" {
         "response.incomplete"
     } else {
@@ -1274,6 +2210,28 @@ mod tests {
             .unwrap_or_default()
     }
 
+    fn event_text(events: Vec<Bytes>) -> String {
+        events
+            .into_iter()
+            .map(|bytes| String::from_utf8(bytes.to_vec()).unwrap())
+            .collect()
+    }
+
+    fn feed_event(context: &mut ResponsesStreamContext, event: &str, data: Value) -> String {
+        event_text(context.handle_anthropic_event(event, data))
+    }
+
+    fn sequence_numbers(sse: &str) -> Vec<i64> {
+        sse.lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .map(|data| {
+                serde_json::from_str::<Value>(data).unwrap()["sequence_number"]
+                    .as_i64()
+                    .unwrap()
+            })
+            .collect()
+    }
+
     // ---- 请求方向：工具声明转换 ----
 
     #[test]
@@ -1301,7 +2259,7 @@ mod tests {
         let tools = anth.tools.as_ref().unwrap();
         assert!(tools.iter().any(|t| t.name == "exec"));
         assert!(tools.iter().any(|t| t.name == "wait"));
-        assert!(tools.iter().any(|t| t.name == "web_search"));
+        assert!(!tools.iter().any(|t| t.name == "web_search"));
         assert!(!tools.iter().any(|t| t.name == "noop"));
         // additional_tools item 本身不进消息
         assert_eq!(anth.messages.len(), 1);
@@ -1372,6 +2330,85 @@ mod tests {
     }
 
     #[test]
+    fn tool_choice_none_disables_forwarded_tools() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "input": simple_input(),
+            "tools": [{ "type": "function", "name": "shell", "parameters": {} }],
+            "tool_choice": "none",
+        }))
+        .unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
+        assert!(anth.tools.is_none());
+        assert_eq!(anth.tool_choice, Some(json!({"type": "none"})));
+    }
+
+    #[test]
+    fn namespaced_tool_choice_is_flattened() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "input": simple_input(),
+            "tools": [{
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{ "type": "function", "name": "spawn_agent", "parameters": {} }]
+            }],
+            "tool_choice": {
+                "type": "function",
+                "name": "spawn_agent",
+                "namespace": "collaboration"
+            },
+        }))
+        .unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
+        assert_eq!(
+            anth.tool_choice,
+            Some(json!({"type": "tool", "name": "collaboration__spawn_agent"}))
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_enables_non_stream_reasoning_extraction() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "input": simple_input(),
+            "reasoning": { "effort": "medium" },
+        }))
+        .unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
+        assert!(anth.thinking.as_ref().is_some_and(Thinking::is_enabled));
+        assert_eq!(anth.output_config.as_ref().unwrap().effort, "medium");
+    }
+
+    #[test]
+    fn malformed_historical_function_arguments_are_rejected() {
+        let req = req_with(
+            json!([]),
+            json!([
+                { "type": "message", "role": "user", "content": "go" },
+                { "type": "function_call", "call_id": "c1", "name": "shell", "arguments": "{" },
+            ]),
+        );
+        let error = responses_to_anthropic(req, None).unwrap_err();
+        assert!(error.contains("invalid JSON arguments"));
+    }
+
+    #[test]
+    fn response_metadata_preserves_request_controls() {
+        let config = ResponsesResponseConfig {
+            parallel_tool_calls: false,
+            tool_choice: json!("required"),
+            tools: vec![json!({ "type": "function", "name": "shell" })],
+        };
+        let mut p = parsed_with_tool_calls(vec![]);
+        p.text = "done".to_string();
+        let response = build_responses_object_with_config(&p, &ToolKindMap::new(), &config);
+        assert_eq!(response["parallel_tool_calls"], json!(false));
+        assert_eq!(response["tool_choice"], json!("required"));
+        assert_eq!(response["tools"][0]["name"], json!("shell"));
+    }
+
+    #[test]
     fn custom_tool_declared_maps_to_wrapper_and_kind() {
         let req = req_with(
             json!([{
@@ -1388,7 +2425,7 @@ mod tests {
             Some(DeclaredToolKind::Custom)
         );
 
-        let tools = anth.tools.unwrap();
+        let tools = anth.tools.as_ref().unwrap();
         let ap = tools.iter().find(|t| t.name == "apply_patch").unwrap();
         // 包装 schema：单个 input 字符串字段
         let props = ap.input_schema.get("properties").unwrap();
@@ -1398,10 +2435,8 @@ mod tests {
         assert!(ap.description.contains("Apply a patch."));
         assert!(ap.description.contains("lark grammar"));
         assert!(ap.description.contains("start: PATCH"));
-        // 原生 web_search 注入，noop 不再存在
-        assert!(tools.iter().any(
-            |t| t.name == "web_search" && t.tool_type.as_deref() == Some("web_search_20250305")
-        ));
+        // 普通本地工具不应触发缓冲式 WebSearch loop。
+        assert!(!tools.iter().any(|t| t.name == "web_search"));
         assert!(!tools.iter().any(|t| t.name == "noop"));
     }
 
@@ -1425,7 +2460,7 @@ mod tests {
             kinds.get("shell").map(|d| d.kind),
             Some(DeclaredToolKind::Function)
         );
-        let tools = anth.tools.unwrap();
+        let tools = anth.tools.as_ref().unwrap();
         let shell = tools.iter().find(|t| t.name == "shell").unwrap();
         assert_eq!(shell.input_schema.get("type").unwrap(), &json!("object"));
         assert!(
@@ -1439,38 +2474,25 @@ mod tests {
     }
 
     #[test]
-    fn noop_fallback_when_no_codex_tools() {
+    fn no_tools_remains_toolless() {
         let req = req_with(json!([]), simple_input());
         let (anth, kinds) = responses_to_anthropic(req, None).unwrap();
         assert!(kinds.is_empty());
-        let tools = anth.tools.as_ref().unwrap();
-        let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
-        assert_eq!(names, vec!["noop", "web_search"]);
-        // 严格提示保留
-        let sys = system_texts(&anth);
-        assert!(
-            sys.iter().any(|t| t.contains("Do not call any other tool")),
-            "strict nudge must be kept for tool-less flows"
-        );
+        assert!(anth.tools.is_none());
+        assert!(system_texts(&anth).is_empty());
     }
 
     #[test]
-    fn nudge_softened_when_codex_tools_present() {
+    fn local_tools_do_not_add_web_search_nudge() {
         let req = req_with(
             json!([{ "type": "function", "name": "shell", "parameters": {} }]),
             simple_input(),
         );
         let (anth, _) = responses_to_anthropic(req, None).unwrap();
-        let sys = system_texts(&anth);
-        assert!(
-            !sys.iter().any(|t| t.contains("Do not call any other tool")),
-            "strict nudge must be removed when codex tools are forwarded"
-        );
-        assert!(
-            sys.iter()
-                .any(|t| t.contains("Use your other tools normally")),
-            "soft nudge must be present"
-        );
+        let tools = anth.tools.as_ref().unwrap();
+        assert!(tools.iter().any(|tool| tool.name == "shell"));
+        assert!(!tools.iter().any(|tool| tool.name == "web_search"));
+        assert!(system_texts(&anth).is_empty());
     }
 
     #[test]
@@ -1503,10 +2525,41 @@ mod tests {
             simple_input(),
         );
         let (anth, _) = responses_to_anthropic(req, None).unwrap();
-        let tools = anth.tools.unwrap();
+        let tools = anth.tools.as_ref().unwrap();
         let ws: Vec<&Tool> = tools.iter().filter(|t| t.name == "web_search").collect();
         assert_eq!(ws.len(), 1);
         assert_eq!(ws[0].tool_type.as_deref(), Some("web_search_20250305"));
+        assert!(
+            system_texts(&anth)
+                .iter()
+                .any(|text| text.contains("Use your other tools normally"))
+        );
+    }
+
+    #[test]
+    fn hosted_web_search_without_local_tools_uses_agentic_loop_pair() {
+        let req = req_with(json!([{ "type": "web_search" }]), simple_input());
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
+        let tools = anth.tools.as_ref().unwrap();
+        let names: Vec<_> = tools.iter().map(|tool| tool.name.as_str()).collect();
+        assert_eq!(names, vec!["noop", "web_search"]);
+        assert!(
+            system_texts(&anth)
+                .iter()
+                .any(|text| text.contains("Do not call any other tool"))
+        );
+    }
+
+    #[test]
+    fn stream_flag_is_forwarded_to_messages_request() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "input": simple_input(),
+            "stream": true,
+        }))
+        .unwrap();
+        let (anth, _) = responses_to_anthropic(req, None).unwrap();
+        assert!(anth.stream);
     }
 
     // ---- 请求方向：input item 回放 ----
@@ -1699,6 +2752,337 @@ mod tests {
     }
 
     // ---- 响应方向：SSE ----
+
+    #[test]
+    fn streaming_text_preserves_each_delta_and_completes_with_usage() {
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            ToolKindMap::new(),
+            ResponsesResponseConfig::default(),
+        );
+        let mut sse = event_text(context.initial_events());
+        sse.push_str(&feed_event(
+            &mut context,
+            "message_start",
+            json!({
+                "type": "message_start",
+                "message": { "usage": { "input_tokens": 7 } },
+            }),
+        ));
+        sse.push_str(&feed_event(
+            &mut context,
+            "content_block_start",
+            json!({
+                "type": "content_block_start", "index": 0,
+                "content_block": { "type": "text", "text": "" },
+            }),
+        ));
+        let first = feed_event(
+            &mut context,
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta", "index": 0,
+                "delta": { "type": "text_delta", "text": "hel" },
+            }),
+        );
+        assert!(first.contains("response.output_text.delta"));
+        assert!(first.contains("\"delta\":\"hel\""));
+        assert!(!first.contains("response.output_text.done"));
+        sse.push_str(&first);
+
+        let second = feed_event(
+            &mut context,
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta", "index": 0,
+                "delta": { "type": "text_delta", "text": "lo" },
+            }),
+        );
+        assert_eq!(
+            second.matches("event: response.output_text.delta").count(),
+            1
+        );
+        assert!(second.contains("\"delta\":\"lo\""));
+        sse.push_str(&second);
+        sse.push_str(&feed_event(
+            &mut context,
+            "content_block_stop",
+            json!({ "type": "content_block_stop", "index": 0 }),
+        ));
+        sse.push_str(&feed_event(
+            &mut context,
+            "message_delta",
+            json!({
+                "type": "message_delta",
+                "delta": { "stop_reason": "end_turn" },
+                "usage": {
+                    "output_tokens": 3,
+                    "cache_read_input_tokens": 2,
+                    "credit_usage": 0.25,
+                    "credit_unit": "credit",
+                    "credit_unit_plural": "credits"
+                },
+            }),
+        ));
+        sse.push_str(&feed_event(
+            &mut context,
+            "message_stop",
+            json!({ "type": "message_stop" }),
+        ));
+
+        assert_eq!(sse.matches("event: response.output_text.delta").count(), 2);
+        assert!(sse.contains("\"text\":\"hello\""));
+        assert!(sse.contains("event: response.completed"));
+        assert!(sse.contains("\"input_tokens\":9"));
+        assert!(sse.contains("\"output_tokens\":3"));
+        assert!(sse.contains("\"cached_tokens\":2"));
+        assert!(sse.contains("\"credit_usage\":0.25"));
+        let sequences = sequence_numbers(&sse);
+        assert_eq!(sequences, (0..sequences.len() as i64).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn streaming_tool_waits_for_complete_json_and_restores_custom_namespace() {
+        let mut kinds = ToolKindMap::new();
+        kinds.insert(
+            "collaboration__apply_patch".into(),
+            DeclaredTool {
+                kind: DeclaredToolKind::Custom,
+                name: "apply_patch".into(),
+                namespace: Some("collaboration".into()),
+            },
+        );
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            kinds,
+            ResponsesResponseConfig::default(),
+        );
+        context.initial_events();
+        assert!(
+            feed_event(
+                &mut context,
+                "content_block_start",
+                json!({
+                    "type": "content_block_start", "index": 1,
+                    "content_block": {
+                        "type": "tool_use", "id": "toolu_1",
+                        "name": "collaboration__apply_patch", "input": {}
+                    },
+                }),
+            )
+            .is_empty()
+        );
+        assert!(
+            feed_event(
+                &mut context,
+                "content_block_delta",
+                json!({
+                    "type": "content_block_delta", "index": 1,
+                    "delta": { "type": "input_json_delta", "partial_json": "{\"input\":\"PATCH" },
+                }),
+            )
+            .is_empty()
+        );
+        assert!(
+            feed_event(
+                &mut context,
+                "content_block_delta",
+                json!({
+                    "type": "content_block_delta", "index": 1,
+                    "delta": { "type": "input_json_delta", "partial_json": " BODY\"}" },
+                }),
+            )
+            .is_empty()
+        );
+        let completed = feed_event(
+            &mut context,
+            "content_block_stop",
+            json!({ "type": "content_block_stop", "index": 1 }),
+        );
+        assert!(completed.contains("response.custom_tool_call_input.delta"));
+        assert!(completed.contains("response.custom_tool_call_input.done"));
+        assert!(completed.contains("\"input\":\"PATCH BODY\""));
+        assert!(completed.contains("\"name\":\"apply_patch\""));
+        assert!(completed.contains("\"namespace\":\"collaboration\""));
+        assert!(completed.contains("\"call_id\":\"toolu_1\""));
+        assert!(!completed.contains("\"done_key\""));
+    }
+
+    #[test]
+    fn streaming_error_maps_to_failed_without_completed() {
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            ToolKindMap::new(),
+            ResponsesResponseConfig::default(),
+        );
+        let mut sse = event_text(context.initial_events());
+        sse.push_str(&feed_event(
+            &mut context,
+            "error",
+            json!({
+                "type": "error",
+                "error": { "type": "api_error", "message": "broken upstream" },
+            }),
+        ));
+        sse.push_str(&event_text(context.finish()));
+        assert!(sse.contains("event: response.failed"));
+        assert!(sse.contains("broken upstream"));
+        assert!(sse.contains("\"code\":\"api_error\""));
+        assert!(!sse.contains("event: response.completed"));
+    }
+
+    #[test]
+    fn streaming_usage_includes_uncached_created_and_read_cache_tokens() {
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            ToolKindMap::new(),
+            ResponsesResponseConfig::default(),
+        );
+        context.update_usage(&json!({
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 4,
+            "cache_read_input_tokens": 7,
+            "output_tokens": 5
+        }));
+
+        let usage = context.usage();
+        assert_eq!(usage["input_tokens"], json!(14));
+        assert_eq!(usage["input_tokens_details"]["cached_tokens"], json!(7));
+        assert_eq!(usage["output_tokens"], json!(5));
+        assert_eq!(usage["total_tokens"], json!(19));
+    }
+
+    #[test]
+    fn hosted_web_search_thinking_becomes_a_responses_reasoning_item() {
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            ToolKindMap::new(),
+            ResponsesResponseConfig::default(),
+        );
+        let sse = feed_event(
+            &mut context,
+            "message_delta",
+            json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 2},
+                "kiro_thinking": "search reasoning"
+            }),
+        );
+
+        assert!(sse.contains("event: response.reasoning_summary_text.delta"));
+        assert!(sse.contains("event: response.reasoning_summary_text.done"));
+        assert!(sse.contains("search reasoning"));
+        assert_eq!(context.output.len(), 1);
+        assert_eq!(context.output[0]["type"], json!("reasoning"));
+    }
+
+    #[test]
+    fn hosted_web_search_reasoning_precedes_final_answer_item() {
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            ToolKindMap::new(),
+            ResponsesResponseConfig::default(),
+        );
+        context.initial_events();
+        let started = feed_event(
+            &mut context,
+            "content_block_start",
+            json!({
+                "type": "content_block_start",
+                "index": 2,
+                "content_block": {"type": "text", "text": ""},
+                "kiro_thinking": "search reasoning"
+            }),
+        );
+        let answer = feed_event(
+            &mut context,
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta",
+                "index": 2,
+                "delta": {"type": "text_delta", "text": "final answer"}
+            }),
+        );
+
+        assert!(started.contains("response.reasoning_summary_text.done"));
+        assert!(answer.contains("response.output_text.delta"));
+        assert_eq!(context.next_output_index, 2);
+        assert!(started.contains("\"output_index\":0"));
+        assert!(answer.contains("\"output_index\":1"));
+    }
+
+    #[tokio::test]
+    async fn message_stop_completes_without_waiting_for_upstream_eof() {
+        let upstream = stream::iter([Ok::<Bytes, Infallible>(Bytes::from_static(
+            b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+        ))])
+        .chain(stream::pending());
+        let response = responses_streaming_response(
+            Body::from_stream(upstream),
+            "gpt-5.6-sol".into(),
+            ToolKindMap::new(),
+            ResponsesResponseConfig::default(),
+        );
+        let mut body = response.into_body().into_data_stream();
+
+        let mut output = String::new();
+        while !output.contains("event: response.completed") {
+            let chunk = tokio::time::timeout(std::time::Duration::from_millis(100), body.next())
+                .await
+                .expect("response.completed must not wait for upstream EOF")
+                .expect("stream must emit response.completed")
+                .unwrap();
+            output.push_str(std::str::from_utf8(&chunk).unwrap());
+        }
+        let end = tokio::time::timeout(std::time::Duration::from_millis(100), body.next())
+            .await
+            .expect("translated stream must terminate after message_stop");
+        assert!(end.is_none());
+    }
+
+    #[test]
+    fn streaming_max_tokens_maps_to_incomplete() {
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            ToolKindMap::new(),
+            ResponsesResponseConfig::default(),
+        );
+        context.initial_events();
+        feed_event(
+            &mut context,
+            "message_delta",
+            json!({
+                "type": "message_delta",
+                "delta": { "stop_reason": "max_tokens" },
+                "usage": { "output_tokens": 12 },
+            }),
+        );
+        let sse = feed_event(
+            &mut context,
+            "message_stop",
+            json!({ "type": "message_stop" }),
+        );
+        assert!(sse.contains("event: response.incomplete"));
+        assert!(sse.contains("\"reason\":\"max_output_tokens\""));
+    }
+
+    #[test]
+    fn sse_parser_handles_chunk_boundaries_and_crlf() {
+        let mut buffer = b"event: ping\r\ndata: {}\r\n\r".to_vec();
+        assert!(take_sse_frames(&mut buffer).is_empty());
+        buffer.extend_from_slice(b"\nevent: message_stop\n");
+        let first = take_sse_frames(&mut buffer);
+        assert_eq!(first.len(), 1);
+        assert_eq!(parse_sse_frame(&first[0]).unwrap().unwrap().0, "ping");
+        buffer.extend_from_slice(b"data: {\"type\":\"message_stop\"}\n\n");
+        let second = take_sse_frames(&mut buffer);
+        assert_eq!(second.len(), 1);
+        assert_eq!(
+            parse_sse_frame(&second[0]).unwrap().unwrap().0,
+            "message_stop"
+        );
+    }
 
     #[test]
     fn sse_contains_custom_item_events_with_full_input() {

--- a/src/anthropic/stream.rs
+++ b/src/anthropic/stream.rs
@@ -1331,6 +1331,41 @@ impl SseStateManager {
 
         events
     }
+
+    /// 生成异常终止事件序列。
+    ///
+    /// 流已经开始后无法再修改 HTTP 状态码，因此先关闭仍处于打开状态的内容块，
+    /// 再发送 Anthropic `error` 事件。异常路径不能发送 `message_delta` 或
+    /// `message_stop`，否则下游会把中断的响应误判为正常完成。
+    pub fn generate_error_events(&mut self, error_type: &str, message: &str) -> Vec<SseEvent> {
+        let mut events = Vec::new();
+
+        for (index, block) in self.active_blocks.iter_mut() {
+            if block.started && !block.stopped {
+                events.push(SseEvent::new(
+                    "content_block_stop",
+                    json!({
+                        "type": "content_block_stop",
+                        "index": index
+                    }),
+                ));
+                block.stopped = true;
+            }
+        }
+
+        self.message_ended = true;
+        events.push(SseEvent::new(
+            "error",
+            json!({
+                "type": "error",
+                "error": {
+                    "type": error_type,
+                    "message": message
+                }
+            }),
+        ));
+        events
+    }
 }
 
 use super::converter::get_context_window_size;
@@ -2517,6 +2552,15 @@ impl StreamContext {
             self.state_manager.set_stop_reason("error");
         }
 
+        // 工具调用 JSON 错误必须直接以异常终态结束，不能先发送正常的
+        // message_delta/message_stop，否则 Responses 等下游会把请求标记为 completed。
+        if let Some(err) = &self.tool_json_error {
+            let error_type = err.error_type();
+            let message = err.message();
+            events.extend(self.generate_error_events(error_type, &message));
+            return events;
+        }
+
         // 精确 metadata 真值优先；缺失时才使用 contextUsage/估算回退。
         let (final_input_tokens, cache_creation, cache_read) = self.resolved_usage();
         let final_output_tokens = self.resolved_output_tokens();
@@ -2530,21 +2574,19 @@ impl StreamContext {
             self.metering.as_ref(),
         ));
 
-        // 工具调用 JSON 错误：在最终事件之后补一个 Anthropic `error` 事件，明确告知
-        // 客户端本次工具调用因上游半截 / 非法 JSON 未被转发（实时流已返回 200，无法再改状态码）。
-        if let Some(err) = &self.tool_json_error {
-            events.push(SseEvent::new(
-                "error",
-                json!({
-                    "type": "error",
-                    "error": {
-                        "type": err.error_type(),
-                        "message": err.message()
-                    }
-                }),
-            ));
-        }
+        events
+    }
 
+    /// 上游响应体读取失败时生成异常终态，不 flush 可能已被截断的缓冲内容。
+    pub fn generate_error_events(&mut self, error_type: &str, message: &str) -> Vec<SseEvent> {
+        // Anthropic requires a signature_delta before a thinking block closes,
+        // including abnormal termination. Close it through the thinking-aware
+        // path first; the generic state manager then closes any other blocks.
+        let mut events = self.close_open_thinking_block();
+        events.extend(
+            self.state_manager
+                .generate_error_events(error_type, message),
+        );
         events
     }
 }
@@ -2779,6 +2821,37 @@ mod tests {
         ));
         // 已取出残留后再 finish() 应成功。
         assert!(acc.finish().is_ok());
+    }
+
+    #[test]
+    fn incomplete_tool_json_ends_stream_with_error_only() {
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            false,
+            HashMap::new(),
+            test_known_tools(),
+        );
+        let _ = ctx.generate_initial_events();
+        let emitted = ctx.process_kiro_event(&Event::ToolUse(tool_evt(
+            "t1",
+            "read_file",
+            "{\"path\":\"/a",
+            false,
+        )));
+        assert!(emitted.is_empty(), "partial tool JSON must remain buffered");
+
+        let final_events = ctx.generate_final_events();
+        assert_eq!(final_events.last().unwrap().event, "error");
+        assert_eq!(
+            final_events.last().unwrap().data["error"]["type"],
+            json!("upstream_tool_json_error")
+        );
+        assert!(
+            final_events
+                .iter()
+                .all(|event| event.event != "message_delta" && event.event != "message_stop")
+        );
     }
 
     #[test]
@@ -3485,6 +3558,47 @@ mod tests {
             pos_sig.unwrap() < pos_stop.unwrap(),
             "signature_delta must precede content_block_stop"
         );
+    }
+
+    #[test]
+    fn error_termination_signs_thinking_before_stop() {
+        let mut ctx = StreamContext::new_with_thinking(
+            "test-model",
+            1,
+            true,
+            HashMap::new(),
+            test_known_tools(),
+        );
+        let _ = ctx.generate_initial_events();
+        let mut events =
+            ctx.process_reasoning_content(&crate::kiro::model::events::ReasoningContentEvent {
+                text: Some("unfinished reasoning".to_string()),
+                signature: None,
+                redacted_content: None,
+            });
+        events.extend(ctx.generate_error_events("upstream_error", "stream interrupted"));
+
+        let thinking_index = ctx.thinking_block_index.unwrap();
+        let signature = events
+            .iter()
+            .position(|event| {
+                event.event == "content_block_delta"
+                    && event.data["index"] == thinking_index
+                    && event.data["delta"]["type"] == "signature_delta"
+            })
+            .expect("thinking error close must include a signature");
+        let stop = events
+            .iter()
+            .position(|event| {
+                event.event == "content_block_stop" && event.data["index"] == thinking_index
+            })
+            .expect("thinking block must close");
+        let error = events
+            .iter()
+            .position(|event| event.event == "error")
+            .expect("stream must end with error");
+        assert!(signature < stop && stop < error);
+        assert!(events.iter().all(|event| event.event != "message_stop"));
     }
 
     #[test]
@@ -5197,6 +5311,35 @@ mod tests {
         // 既有字段保持原样
         assert_eq!(usage["input_tokens"], json!(10));
         assert_eq!(usage["output_tokens"], json!(5));
+    }
+
+    #[test]
+    fn error_events_close_open_blocks_without_normal_message_terminal() {
+        let mut manager = SseStateManager::new();
+        let _ = manager.handle_content_block_start(
+            0,
+            "text",
+            json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""}
+            }),
+        );
+
+        let events = manager.generate_error_events("upstream_error", "stream interrupted");
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.event.as_str())
+                .collect::<Vec<_>>(),
+            vec!["content_block_stop", "error"]
+        );
+        assert_eq!(events[1].data["error"]["type"], json!("upstream_error"));
+        assert!(
+            events
+                .iter()
+                .all(|event| { event.event != "message_delta" && event.event != "message_stop" })
+        );
     }
 
     #[test]

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -7,17 +7,24 @@
 //! Reuses: converter::convert_request (feedback), provider.call_api_stream, EventStreamDecoder,
 //! websearch::{create_mcp_request, call_mcp_api, parse_search_results, generate_search_summary}。
 
+use std::collections::BTreeSet;
 use std::convert::Infallible;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
 use axum::{
-    body::Body,
+    body::{Body, to_bytes},
     http::{StatusCode, header},
     response::{IntoResponse, Json, Response},
 };
 use bytes::Bytes;
-use futures::{StreamExt, stream};
+use futures::{FutureExt, StreamExt, stream};
 use serde_json::{Value, json};
+use tokio::{
+    sync::mpsc,
+    time::{Duration, Instant, interval_at},
+};
 use uuid::Uuid;
 
 use crate::kiro::model::events::{Event, MeteringEvent, TokenUsage};
@@ -41,6 +48,16 @@ const MAX_WEB_SEARCH_ROUNDS: usize = 5;
 /// without either, which used to be serialized as `end_turn` and made Codex mark an
 /// unfinished task complete. Retry once before surfacing an upstream error.
 const MAX_EMPTY_TOOL_RESULT_RETRIES: usize = 1;
+
+/// Bounded progress queue for the streamed agentic loop. Search result blocks
+/// are small, so this is enough to provide backpressure without buffering an
+/// unbounded response when the client is slow.
+const WEB_SEARCH_PROGRESS_CAPACITY: usize = 32;
+
+/// Keep a streamed response alive while an upstream model round or MCP call is
+/// still running. The first `message_start` is emitted immediately; pings cover
+/// any subsequent long-running operation.
+const WEB_SEARCH_PING_INTERVAL_SECS: u64 = 25;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EmptyToolResultDisposition {
@@ -730,21 +747,524 @@ fn record_aggregated_usage(
     );
 }
 
+/// Cancellation-safe, exactly-once accounting for the multi-round search loop.
+/// The snapshot is updated after every completed provider round, so cancelling
+/// a later MCP/provider await still records all usage already observed.
+struct WebSearchUsageSettlement {
+    hook: UsageRecordHook,
+    credential_id: u64,
+    usage: TokenUsage,
+    credits: f64,
+    settled: bool,
+}
+
+impl WebSearchUsageSettlement {
+    fn new(hook: UsageRecordHook) -> Self {
+        Self {
+            hook,
+            credential_id: 0,
+            usage: TokenUsage::default(),
+            credits: 0.0,
+            settled: false,
+        }
+    }
+
+    fn add(&mut self, credential_id: u64, usage: TokenUsage, credits: f64) {
+        if credential_id != 0 {
+            self.credential_id = credential_id;
+        }
+        self.usage = self.usage.saturating_add(usage);
+        if credits.is_finite() && credits > 0.0 {
+            self.credits += credits;
+        }
+    }
+
+    fn usage(&self) -> TokenUsage {
+        self.usage.sanitized()
+    }
+
+    fn finish(&mut self, status: &str) {
+        if self.settled {
+            return;
+        }
+        record_aggregated_usage(
+            &self.hook,
+            self.credential_id,
+            self.usage,
+            self.credits,
+            status,
+        );
+        self.settled = true;
+    }
+}
+
+impl Drop for WebSearchUsageSettlement {
+    fn drop(&mut self) {
+        if !self.settled {
+            self.finish("error");
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PendingWebSearch {
+    block_index: i32,
+}
+
+/// Emits one coherent Anthropic SSE message while the agentic loop runs in a
+/// background task. Content block indexes are allocated once across all search
+/// rounds and the final assistant content, so downstream Responses translation
+/// sees a single ordered stream instead of several synthetic messages.
+struct WebSearchSseEmitter {
+    sender: mpsc::Sender<Bytes>,
+    next_block_index: i32,
+    active_blocks: BTreeSet<i32>,
+    terminal: bool,
+}
+
+impl WebSearchSseEmitter {
+    fn new(sender: mpsc::Sender<Bytes>) -> Self {
+        Self {
+            sender,
+            next_block_index: 0,
+            active_blocks: BTreeSet::new(),
+            terminal: false,
+        }
+    }
+
+    async fn send(&self, event: SseEvent) {
+        if self
+            .sender
+            .send(Bytes::from(event.to_sse_string()))
+            .await
+            .is_err()
+        {
+            tracing::debug!("web_search SSE receiver disconnected");
+        }
+    }
+
+    async fn begin_search(&mut self, query: &str) -> PendingWebSearch {
+        let block_index = self.next_block_index;
+        self.next_block_index += 1;
+        self.active_blocks.insert(block_index);
+        let (tool_use_id, _) = websearch::create_mcp_request(query);
+        self.send(SseEvent::new(
+            "content_block_start",
+            json!({
+                "type": "content_block_start",
+                "index": block_index,
+                "content_block": {
+                    "id": tool_use_id,
+                    "type": "server_tool_use",
+                    "name": "web_search",
+                    "input": {"query": query}
+                }
+            }),
+        ))
+        .await;
+        PendingWebSearch { block_index }
+    }
+
+    /// Closes a search block that was opened via `begin_search` but must not be
+    /// presented as a successful result — the MCP call itself failed. Sends only
+    /// the matching `content_block_stop` (no `web_search_tool_result`), keeping
+    /// every `content_block_start` paired before the caller's terminal `error`
+    /// event, exactly like `stream.rs::generate_final_events` closes open blocks
+    /// before a mid-stream tool error.
+    async fn abort_search(&mut self, pending: PendingWebSearch) {
+        self.active_blocks.remove(&pending.block_index);
+        self.send(SseEvent::new(
+            "content_block_stop",
+            json!({
+                "type": "content_block_stop",
+                "index": pending.block_index
+            }),
+        ))
+        .await;
+    }
+
+    async fn complete_search(
+        &mut self,
+        pending: PendingWebSearch,
+        results: &Option<WebSearchResults>,
+    ) {
+        self.active_blocks.remove(&pending.block_index);
+        self.send(SseEvent::new(
+            "content_block_stop",
+            json!({
+                "type": "content_block_stop",
+                "index": pending.block_index
+            }),
+        ))
+        .await;
+
+        let result_index = self.next_block_index;
+        self.next_block_index += 1;
+        self.active_blocks.insert(result_index);
+        self.send(SseEvent::new(
+            "content_block_start",
+            json!({
+                "type": "content_block_start",
+                "index": result_index,
+                "content_block": {
+                    "type": "web_search_tool_result",
+                    "content": build_result_block(results)
+                }
+            }),
+        ))
+        .await;
+        self.active_blocks.remove(&result_index);
+        self.send(SseEvent::new(
+            "content_block_stop",
+            json!({
+                "type": "content_block_stop",
+                "index": result_index
+            }),
+        ))
+        .await;
+    }
+
+    async fn finish(
+        &mut self,
+        content: Vec<Value>,
+        stop_reason: &str,
+        token_usage: TokenUsage,
+        thinking: &str,
+        metering: Option<&MeteringEvent>,
+    ) {
+        let content = without_web_search_presentation(content);
+        let (mut events, next_index) = build_sse_content_events(&content, self.next_block_index);
+        self.next_block_index = next_index;
+        // Keep the extension on a standard Anthropic event so ordinary Messages
+        // clients can ignore the unknown field. Responses consumes it before
+        // translating that event, which puts reasoning ahead of final answer/tools.
+        let reasoning_attached_to_content = if thinking.is_empty() {
+            false
+        } else if let Some(first) = events.first_mut() {
+            first.data["kiro_thinking"] = json!(thinking);
+            true
+        } else {
+            false
+        };
+        for event in events {
+            self.send(event).await;
+        }
+
+        let token_usage = token_usage.sanitized();
+        let mut usage = json!({
+            "input_tokens": token_usage.uncached_input_tokens,
+            "output_tokens": token_usage.output_tokens,
+            "cache_creation_input_tokens": token_usage.cache_write_input_tokens,
+            "cache_read_input_tokens": token_usage.cache_read_input_tokens
+        });
+        if let Some(metering) = metering {
+            usage["credit_usage"] = json!(metering.usage);
+            usage["credit_unit"] = json!(metering.unit);
+            usage["credit_unit_plural"] = json!(metering.unit_plural);
+        }
+        let mut message_delta = json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason},
+            "usage": usage
+        });
+        if !reasoning_attached_to_content && !thinking.is_empty() {
+            message_delta["kiro_thinking"] = json!(thinking);
+        }
+        self.send(SseEvent::new("message_delta", message_delta))
+            .await;
+        self.send(SseEvent::new(
+            "message_stop",
+            json!({"type": "message_stop"}),
+        ))
+        .await;
+        self.terminal = true;
+    }
+
+    async fn fail(&mut self, error_type: &str, message: &str) {
+        if self.terminal {
+            return;
+        }
+        let active_blocks = std::mem::take(&mut self.active_blocks);
+        for index in active_blocks {
+            self.send(SseEvent::new(
+                "content_block_stop",
+                json!({"type": "content_block_stop", "index": index}),
+            ))
+            .await;
+        }
+        self.terminal = true;
+        self.send(SseEvent::new(
+            "error",
+            json!({
+                "type": "error",
+                "error": {"type": error_type, "message": message}
+            }),
+        ))
+        .await;
+    }
+}
+
+/// Run a streamed web-search task only while its response receiver is alive.
+/// Dropping the future cancels an in-flight provider or MCP await, preventing
+/// detached work and additional metering after the client disconnects.
+async fn while_receiver_open<F>(sender: &mpsc::Sender<Bytes>, future: F) -> Option<F::Output>
+where
+    F: Future,
+{
+    // Keep the future in an owned pin so the cancellation branch can explicitly
+    // drop it before returning. This is important for cancellation-safe usage
+    // settlement: callers may inspect accounting immediately after this helper
+    // resolves.
+    let mut future = Box::pin(future);
+    let result = tokio::select! {
+        biased;
+        output = &mut future => Some(output),
+        _ = sender.closed() => None,
+    };
+    drop(future);
+    result
+}
+
+fn initial_stream_event(model: &str, input_tokens: i32) -> SseEvent {
+    let message_id = format!("msg_{}", &Uuid::new_v4().to_string().replace('-', "")[..24]);
+    SseEvent::new(
+        "message_start",
+        json!({
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": null,
+                "stop_sequence": null,
+                "usage": {
+                    "input_tokens": input_tokens.max(0),
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0
+                }
+            }
+        }),
+    )
+}
+
+fn render_channel_sse(initial_event: SseEvent, receiver: mpsc::Receiver<Bytes>) -> Response {
+    let initial = stream::iter([Ok::<Bytes, Infallible>(Bytes::from(
+        initial_event.to_sse_string(),
+    ))]);
+    let keepalive = interval_at(
+        Instant::now() + Duration::from_secs(WEB_SEARCH_PING_INTERVAL_SECS),
+        Duration::from_secs(WEB_SEARCH_PING_INTERVAL_SECS),
+    );
+    let updates = stream::unfold(
+        (receiver, keepalive),
+        |(mut receiver, mut keepalive)| async move {
+            tokio::select! {
+                item = receiver.recv() => item.map(|bytes| {
+                    (Ok::<Bytes, Infallible>(bytes), (receiver, keepalive))
+                }),
+                _ = keepalive.tick() => Some((
+                    Ok::<Bytes, Infallible>(Bytes::from(
+                        "event: ping\ndata: {\"type\":\"ping\"}\n\n",
+                    )),
+                    (receiver, keepalive),
+                )),
+            }
+        },
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .header(header::CONNECTION, "keep-alive")
+        .body(Body::from_stream(initial.chain(updates)))
+        .unwrap()
+}
+
+async fn response_error_details(response: Response) -> (String, String) {
+    let status = response.status();
+    let body = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap_or_default();
+    let value: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    let error_type = value
+        .pointer("/error/type")
+        .and_then(Value::as_str)
+        .unwrap_or("api_error")
+        .to_string();
+    let message = value
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("web_search agentic loop failed with HTTP {status}"));
+    (error_type, message)
+}
+
+fn without_web_search_presentation(content: Vec<Value>) -> Vec<Value> {
+    content
+        .into_iter()
+        .filter(|block| {
+            !matches!(
+                block.get("type").and_then(Value::as_str),
+                Some("server_tool_use" | "web_search_tool_result")
+            )
+        })
+        .collect()
+}
+
+/// Best-effort string extraction from a `catch_unwind` payload (`Box<dyn Any + Send>`).
+/// Panics almost always carry `&str` or `String` (the `panic!`/`unwrap`/`expect` message);
+/// anything else is reported as a fixed placeholder rather than failing to log at all.
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+async fn execute_web_search(
+    provider: &Arc<KiroProvider>,
+    tool_use: &CompletedToolUse,
+    group: Option<&str>,
+    final_round: bool,
+    emitter: &mut Option<&mut WebSearchSseEmitter>,
+) -> anyhow::Result<Option<WebSearchResults>> {
+    let query = tool_query(tool_use);
+    let pending = if let Some(emitter) = emitter.as_deref_mut() {
+        Some(emitter.begin_search(query.as_deref().unwrap_or("")).await)
+    } else {
+        None
+    };
+
+    let result = if let Some(query) = query {
+        log_normalized_web_search_query(tool_use, &query);
+        let (_, mcp_request) = websearch::create_mcp_request(&query);
+        match websearch::call_mcp_api(provider, &mcp_request, group).await {
+            Ok(response) => websearch::parse_search_results(&response),
+            Err(error) if is_no_results_mcp_error(&error) => {
+                tracing::warn!(
+                    final_round,
+                    "web_search MCP returned no results; continuing with an empty result"
+                );
+                None
+            }
+            Err(error) => {
+                // The MCP call itself failed: close the `server_tool_use` block
+                // opened above instead of leaving it dangling for the caller's
+                // terminal `error` event (every content_block_start must pair
+                // with a content_block_stop before a stream ends).
+                if let (Some(emitter), Some(pending)) = (emitter.as_deref_mut(), pending) {
+                    emitter.abort_search(pending).await;
+                }
+                return Err(error);
+            }
+        }
+    } else {
+        log_invalid_web_search_input(tool_use);
+        None
+    };
+
+    if let (Some(emitter), Some(pending)) = (emitter.as_deref_mut(), pending) {
+        emitter.complete_search(pending, &result).await;
+    }
+    Ok(result)
+}
+
 /// web_search loop entry point
 ///
 /// `stream_client`: whether the client wants SSE (true) or a single JSON response (false).
 pub(super) async fn run_web_search_loop(
     provider: Arc<KiroProvider>,
-    mut payload: MessagesRequest,
+    payload: MessagesRequest,
     hook: UsageRecordHook,
     stream_client: bool,
     group: Option<String>,
     tool_compatibility_mode: ToolCompatibilityMode,
 ) -> Response {
+    if !stream_client {
+        return run_web_search_loop_inner(
+            provider,
+            payload,
+            hook,
+            group,
+            tool_compatibility_mode,
+            None,
+        )
+        .await;
+    }
+
+    let initial_input_tokens = token::count_all_tokens(
+        payload.model.clone(),
+        payload.system.clone(),
+        payload.messages.clone(),
+        payload.tools.clone(),
+    ) as i32;
+    let initial_event = initial_stream_event(&payload.model, initial_input_tokens);
+    let (sender, receiver) = mpsc::channel(WEB_SEARCH_PROGRESS_CAPACITY);
+    tokio::spawn(async move {
+        let receiver_guard = sender.clone();
+        let mut emitter = WebSearchSseEmitter::new(sender);
+        // Guard against a panic anywhere in the agentic loop (upstream decode bug,
+        // MCP response parsing, etc.): without this, unwinding drops `emitter`
+        // (and its `sender`) with no terminal frame, so the client's SSE stream
+        // would just end silently instead of surfacing response.failed/error.
+        let Some(outcome) = while_receiver_open(
+            &receiver_guard,
+            AssertUnwindSafe(run_web_search_loop_inner(
+                provider,
+                payload,
+                hook,
+                group,
+                tool_compatibility_mode,
+                Some(&mut emitter),
+            ))
+            .catch_unwind(),
+        )
+        .await
+        else {
+            tracing::debug!("web_search SSE receiver disconnected; cancelling agentic loop");
+            return;
+        };
+        match outcome {
+            Ok(response) => {
+                if !emitter.terminal {
+                    let (error_type, message) = response_error_details(response).await;
+                    emitter.fail(&error_type, &message).await;
+                }
+            }
+            Err(panic) => {
+                tracing::error!(
+                    panic = %panic_message(&panic),
+                    "web_search agentic loop panicked"
+                );
+                if !emitter.terminal {
+                    emitter
+                        .fail("internal_error", "web_search agentic loop panicked")
+                        .await;
+                }
+            }
+        }
+    });
+
+    render_channel_sse(initial_event, receiver)
+}
+
+async fn run_web_search_loop_inner(
+    provider: Arc<KiroProvider>,
+    mut payload: MessagesRequest,
+    hook: UsageRecordHook,
+    group: Option<String>,
+    tool_compatibility_mode: ToolCompatibilityMode,
+    mut emitter: Option<&mut WebSearchSseEmitter>,
+) -> Response {
     let mut presentation: Vec<Value> = Vec::new();
-    let mut last_credential_id: u64 = 0;
-    let mut total_token_usage = TokenUsage::default();
-    let mut total_credits = 0.0;
+    let mut settlement = WebSearchUsageSettlement::new(hook);
     let mut latest_metering: Option<MeteringEvent> = None;
     let mut all_thinking = String::new();
 
@@ -768,27 +1288,24 @@ pub(super) async fn run_web_search_loop(
             {
                 Ok(v) => v,
                 Err(failure) => {
-                    if failure.credential_id != 0 {
-                        last_credential_id = failure.credential_id;
-                    }
                     if let Some(usage) = failure.token_usage {
-                        total_token_usage = total_token_usage.saturating_add(usage);
+                        settlement.add(failure.credential_id, usage, failure.credits);
+                    } else {
+                        settlement.add(
+                            failure.credential_id,
+                            TokenUsage::default(),
+                            failure.credits,
+                        );
                     }
-                    total_credits += failure.credits;
-                    record_aggregated_usage(
-                        &hook,
-                        last_credential_id,
-                        total_token_usage,
-                        total_credits,
-                        "error",
-                    );
+                    settlement.finish("error");
                     return failure.response;
                 }
             };
-            last_credential_id = credential_id;
-            total_token_usage = total_token_usage
-                .saturating_add(round.resolved_token_usage(round_fallback_input_tokens));
-            total_credits += round.credits;
+            settlement.add(
+                credential_id,
+                round.resolved_token_usage(round_fallback_input_tokens),
+                round.credits,
+            );
             // 跨 round 保留最近一次 meteringEvent，多 round 时取最后一次
             // (clone 以避免与 empty_tool_result_disposition 后续对 round 的借用冲突)。
             if let Some(ref m) = round.last_metering {
@@ -807,13 +1324,7 @@ pub(super) async fn run_web_search_loop(
                     continue;
                 }
                 EmptyToolResultDisposition::Fail => {
-                    record_aggregated_usage(
-                        &hook,
-                        last_credential_id,
-                        total_token_usage,
-                        total_credits,
-                        "error",
-                    );
+                    settlement.finish("error");
                     tracing::error!(
                         round = round_idx,
                         "upstream repeated an empty assistant turn after tool_result"
@@ -848,30 +1359,12 @@ pub(super) async fn run_web_search_loop(
             let mut searched: Vec<Option<WebSearchResults>> =
                 Vec::with_capacity(round.tool_uses.len());
             for tu in &round.tool_uses {
-                let Some(query) = tool_query(tu) else {
-                    log_invalid_web_search_input(tu);
-                    searched.push(None);
-                    continue;
-                };
-                log_normalized_web_search_query(tu, &query);
-                let (_id, mcp_request) = websearch::create_mcp_request(&query);
-                match websearch::call_mcp_api(&provider, &mcp_request, group.as_deref()).await {
-                    Ok(resp) => searched.push(websearch::parse_search_results(&resp)),
-                    Err(e) if is_no_results_mcp_error(&e) => {
-                        tracing::warn!(
-                            "web_search MCP returned no results; continuing with an empty result"
-                        );
-                        searched.push(None);
-                    }
+                match execute_web_search(&provider, tu, group.as_deref(), false, &mut emitter).await
+                {
+                    Ok(result) => searched.push(result),
                     Err(e) => {
                         tracing::warn!("web_search MCP call failed: {}", e);
-                        record_aggregated_usage(
-                            &hook,
-                            last_credential_id,
-                            total_token_usage,
-                            total_credits,
-                            "error",
-                        );
+                        settlement.finish("error");
                         return map_provider_error(e);
                     }
                 }
@@ -896,30 +1389,12 @@ pub(super) async fn run_web_search_loop(
         let mut searched: Vec<Option<WebSearchResults>> = Vec::with_capacity(round.tool_uses.len());
         for tu in &round.tool_uses {
             if tu.name == "web_search" {
-                let Some(query) = tool_query(tu) else {
-                    log_invalid_web_search_input(tu);
-                    searched.push(None);
-                    continue;
-                };
-                log_normalized_web_search_query(tu, &query);
-                let (_id, mcp_request) = websearch::create_mcp_request(&query);
-                match websearch::call_mcp_api(&provider, &mcp_request, group.as_deref()).await {
-                    Ok(resp) => searched.push(websearch::parse_search_results(&resp)),
-                    Err(e) if is_no_results_mcp_error(&e) => {
-                        tracing::warn!(
-                            "web_search MCP returned no results in final round; continuing with an empty result"
-                        );
-                        searched.push(None);
-                    }
+                match execute_web_search(&provider, tu, group.as_deref(), true, &mut emitter).await
+                {
+                    Ok(result) => searched.push(result),
                     Err(e) => {
                         tracing::warn!("web_search MCP call (final round) failed: {}", e);
-                        record_aggregated_usage(
-                            &hook,
-                            last_credential_id,
-                            total_token_usage,
-                            total_credits,
-                            "error",
-                        );
+                        settlement.finish("error");
                         return map_provider_error(e);
                     }
                 }
@@ -945,23 +1420,20 @@ pub(super) async fn run_web_search_loop(
             &content,
         );
 
-        let final_usage = total_token_usage.sanitized();
-        record_aggregated_usage(
-            &hook,
-            last_credential_id,
-            final_usage,
-            total_credits,
-            "success",
-        );
+        let final_usage = settlement.usage();
+        settlement.finish("success");
 
-        return if stream_client {
-            render_sse(
-                &payload.model,
-                content,
-                &stop_reason,
-                final_usage,
-                latest_metering.as_ref(),
-            )
+        return if let Some(emitter) = emitter.as_deref_mut() {
+            emitter
+                .finish(
+                    content,
+                    &stop_reason,
+                    final_usage,
+                    &all_thinking,
+                    latest_metering.as_ref(),
+                )
+                .await;
+            StatusCode::OK.into_response()
         } else {
             render_json(
                 &payload.model,
@@ -975,13 +1447,7 @@ pub(super) async fn run_web_search_loop(
     }
 
     // Theoretically unreachable (the loop always returns)
-    record_aggregated_usage(
-        &hook,
-        last_credential_id,
-        total_token_usage,
-        total_credits,
-        "error",
-    );
+    settlement.finish("error");
     (
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(ErrorResponse::new(
@@ -1037,30 +1503,8 @@ pub(crate) fn render_json(
     (StatusCode::OK, Json(body)).into_response()
 }
 
-/// SSE response (streaming): splits the final content into a sequence of Anthropic content_block events
-pub(crate) fn render_sse(
-    model: &str,
-    content: Vec<Value>,
-    stop_reason: &str,
-    token_usage: TokenUsage,
-    metering: Option<&MeteringEvent>,
-) -> Response {
-    let events = build_sse_events(model, content, stop_reason, token_usage, metering);
-    let stream = stream::iter(
-        events
-            .into_iter()
-            .map(|e| Ok::<Bytes, Infallible>(Bytes::from(e.to_sse_string()))),
-    );
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "text/event-stream")
-        .header(header::CACHE_CONTROL, "no-cache")
-        .header(header::CONNECTION, "keep-alive")
-        .body(Body::from_stream(stream))
-        .unwrap()
-}
-
 /// Renders the final content array into a sequence of SSE events
+#[cfg(test)]
 fn build_sse_events(
     model: &str,
     content: Vec<Value>,
@@ -1094,9 +1538,45 @@ fn build_sse_events(
         }),
     ));
 
-    for (index, block) in content.iter().enumerate() {
-        let index = index as i32;
+    let (content_events, _) = build_sse_content_events(&content, 0);
+    events.extend(content_events);
+
+    let mut message_delta_usage = json!({ "output_tokens": token_usage.output_tokens });
+    // 透传上游 meteringEvent 的 credit_* 字段（仅在拿到 meteringEvent 时）。
+    if let Some(m) = metering {
+        message_delta_usage["credit_usage"] = json!(m.usage);
+        message_delta_usage["credit_unit"] = json!(m.unit);
+        message_delta_usage["credit_unit_plural"] = json!(m.unit_plural);
+    }
+    events.push(SseEvent::new(
+        "message_delta",
+        json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason},
+            "usage": message_delta_usage
+        }),
+    ));
+    events.push(SseEvent::new(
+        "message_stop",
+        json!({"type": "message_stop"}),
+    ));
+
+    events
+}
+
+fn build_sse_content_events(content: &[Value], start_index: i32) -> (Vec<SseEvent>, i32) {
+    let mut events = Vec::new();
+    let mut next_index = start_index;
+    for block in content {
         let btype = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if !matches!(
+            btype,
+            "text" | "tool_use" | "server_tool_use" | "web_search_tool_result"
+        ) {
+            continue;
+        }
+        let index = next_index;
+        next_index += 1;
         match btype {
             "text" => {
                 let text = block.get("text").and_then(|v| v.as_str()).unwrap_or("");
@@ -1165,34 +1645,35 @@ fn build_sse_events(
             _ => {}
         }
     }
-
-    let mut message_delta_usage = json!({ "output_tokens": token_usage.output_tokens });
-    // 透传上游 meteringEvent 的 credit_* 字段（仅在拿到 meteringEvent 时）。
-    if let Some(m) = metering {
-        message_delta_usage["credit_usage"] = json!(m.usage);
-        message_delta_usage["credit_unit"] = json!(m.unit);
-        message_delta_usage["credit_unit_plural"] = json!(m.unit_plural);
-    }
-    events.push(SseEvent::new(
-        "message_delta",
-        json!({
-            "type": "message_delta",
-            "delta": {"stop_reason": stop_reason},
-            "usage": message_delta_usage
-        }),
-    ));
-    events.push(SseEvent::new(
-        "message_stop",
-        json!({"type": "message_stop"}),
-    ));
-
-    events
+    (events, next_index)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::anthropic::websearch::{WebSearchResult, WebSearchResults};
+
+    fn decode_sse(bytes: Bytes) -> (String, Value) {
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        let event = text
+            .lines()
+            .find_map(|line| line.strip_prefix("event: "))
+            .unwrap()
+            .to_string();
+        let data = text
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .unwrap();
+        (event, serde_json::from_str(data).unwrap())
+    }
+
+    fn drain_sse(receiver: &mut mpsc::Receiver<Bytes>) -> Vec<(String, Value)> {
+        let mut events = Vec::new();
+        while let Ok(bytes) = receiver.try_recv() {
+            events.push(decode_sse(bytes));
+        }
+        events
+    }
 
     fn tu(name: &str) -> CompletedToolUse {
         CompletedToolUse {
@@ -1245,6 +1726,322 @@ mod tests {
         assert!(!is_no_results_mcp_error(&anyhow::anyhow!(
             "MCP error: -32602 - Invalid tool parameters provided"
         )));
+    }
+
+    #[tokio::test]
+    async fn channel_response_exposes_message_start_before_background_progress() {
+        let (sender, receiver) = mpsc::channel(WEB_SEARCH_PROGRESS_CAPACITY);
+        let response = render_channel_sse(initial_stream_event("gpt-5.6-sol", 17), receiver);
+        let mut body = response.into_body().into_data_stream();
+
+        let first = tokio::time::timeout(Duration::from_millis(100), body.next())
+            .await
+            .expect("the initial SSE event must not wait for the background loop")
+            .expect("the response must contain an initial event")
+            .unwrap();
+        let (event, data) = decode_sse(first);
+        assert_eq!(event, "message_start");
+        assert_eq!(data["message"]["usage"]["input_tokens"], json!(17));
+
+        // Keep the sender alive through the assertion: the event came from the
+        // response prefix rather than from progress-channel completion.
+        drop(sender);
+    }
+
+    #[tokio::test]
+    async fn streaming_emitter_orders_progress_and_deduplicates_final_search() {
+        let (sender, mut receiver) = mpsc::channel(WEB_SEARCH_PROGRESS_CAPACITY);
+        let mut emitter = WebSearchSseEmitter::new(sender);
+
+        let pending = emitter.begin_search("Rust 2026").await;
+        let started = drain_sse(&mut receiver);
+        assert_eq!(started.len(), 1);
+        assert_eq!(started[0].0, "content_block_start");
+        assert_eq!(started[0].1["index"], json!(0));
+        assert_eq!(
+            started[0].1["content_block"]["type"],
+            json!("server_tool_use")
+        );
+        assert_eq!(
+            started[0].1["content_block"]["input"]["query"],
+            json!("Rust 2026")
+        );
+        assert!(receiver.try_recv().is_err(), "search remains in progress");
+
+        let results = fake_results("Rust 2026");
+        emitter.complete_search(pending, &results).await;
+        let mut events = started;
+        events.extend(drain_sse(&mut receiver));
+
+        let metering = metering_event(0.75);
+        emitter
+            .finish(
+                vec![
+                    json!({
+                        "type": "server_tool_use", "id": "duplicate",
+                        "name": "web_search", "input": {"query": "Rust 2026"}
+                    }),
+                    json!({
+                        "type": "web_search_tool_result",
+                        "content": [{"type": "web_search_result"}]
+                    }),
+                    json!({"type": "text", "text": "final answer"}),
+                    json!({
+                        "type": "tool_use", "id": "toolu_exec",
+                        "name": "exec", "input": {"cmd": "pwd"}
+                    }),
+                ],
+                "tool_use",
+                TokenUsage {
+                    uncached_input_tokens: 3,
+                    output_tokens: 5,
+                    cache_read_input_tokens: 7,
+                    cache_write_input_tokens: 4,
+                },
+                "search reasoning",
+                Some(&metering),
+            )
+            .await;
+        events.extend(drain_sse(&mut receiver));
+
+        assert_eq!(
+            1 + events
+                .iter()
+                .filter(|(event, _)| event == "message_start")
+                .count(),
+            1,
+            "message_start is emitted only by the channel response prefix"
+        );
+
+        let starts: Vec<&Value> = events
+            .iter()
+            .filter(|(event, _)| event == "content_block_start")
+            .map(|(_, data)| data)
+            .collect();
+        let start_indexes: Vec<i64> = starts
+            .iter()
+            .map(|data| data["index"].as_i64().unwrap())
+            .collect();
+        assert_eq!(start_indexes, vec![0, 1, 2, 3]);
+        assert_eq!(
+            starts
+                .iter()
+                .filter(|data| data["content_block"]["type"] == "server_tool_use")
+                .count(),
+            1,
+            "the final flush must not repeat an already streamed search"
+        );
+        assert_eq!(
+            starts
+                .iter()
+                .filter(|data| data["content_block"]["type"] == "web_search_tool_result")
+                .count(),
+            1,
+            "the final flush must not repeat an already streamed result"
+        );
+
+        let stops: Vec<i64> = events
+            .iter()
+            .filter(|(event, _)| event == "content_block_stop")
+            .map(|(_, data)| data["index"].as_i64().unwrap())
+            .collect();
+        assert_eq!(stops, vec![0, 1, 2, 3]);
+
+        let delta = events
+            .iter()
+            .find(|(event, _)| event == "message_delta")
+            .map(|(_, data)| data)
+            .unwrap();
+        assert_eq!(delta["delta"]["stop_reason"], json!("tool_use"));
+        assert_eq!(delta["usage"]["input_tokens"], json!(3));
+        assert_eq!(delta["usage"]["output_tokens"], json!(5));
+        assert_eq!(delta["usage"]["cache_creation_input_tokens"], json!(4));
+        assert_eq!(delta["usage"]["cache_read_input_tokens"], json!(7));
+        assert_eq!(delta["usage"]["credit_usage"], json!(0.75));
+        let reasoning_carrier = events
+            .iter()
+            .find(|(_, data)| data["kiro_thinking"] == "search reasoning")
+            .expect("reasoning must be attached before final visible content");
+        let reasoning_position = events
+            .iter()
+            .position(|event| std::ptr::eq(event, reasoning_carrier))
+            .unwrap();
+        let final_text_position = events
+            .iter()
+            .position(|(event, data)| {
+                event == "content_block_delta"
+                    && data["delta"]["type"] == "text_delta"
+                    && data["delta"]["text"] == "final answer"
+            })
+            .unwrap();
+        assert!(reasoning_position < final_text_position);
+        assert_eq!(events.last().unwrap().0, "message_stop");
+        assert!(emitter.terminal);
+    }
+
+    #[tokio::test]
+    async fn receiver_disconnect_cancels_in_flight_work() {
+        struct CancellationProbe(Option<tokio::sync::oneshot::Sender<()>>);
+
+        impl Drop for CancellationProbe {
+            fn drop(&mut self) {
+                if let Some(sender) = self.0.take() {
+                    let _ = sender.send(());
+                }
+            }
+        }
+
+        let (sender, receiver) = mpsc::channel::<Bytes>(1);
+        let (cancelled_sender, cancelled_receiver) = tokio::sync::oneshot::channel();
+        let probe = CancellationProbe(Some(cancelled_sender));
+        let in_flight = async move {
+            let _probe = probe;
+            futures::future::pending::<()>().await;
+        };
+
+        drop(receiver);
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            while_receiver_open(&sender, in_flight),
+        )
+        .await
+        .expect("closed receiver must cancel the in-flight future");
+        assert!(result.is_none());
+        tokio::time::timeout(Duration::from_millis(100), cancelled_receiver)
+            .await
+            .expect("in-flight future must be dropped")
+            .expect("cancellation probe must be notified");
+    }
+
+    #[tokio::test]
+    async fn receiver_disconnect_settles_accumulated_usage_once() {
+        let aggregator = Arc::new(crate::admin::usage_stats::UsageAggregator::new());
+        let hook = UsageRecordHook {
+            recorder: None,
+            aggregator: Some(aggregator.clone()),
+            client_keys: None,
+            key_id: 0,
+            model: "test-model".to_string(),
+            started_at: std::time::Instant::now(),
+        };
+        let (sender, receiver) = mpsc::channel::<Bytes>(1);
+        let in_flight = async move {
+            let mut settlement = WebSearchUsageSettlement::new(hook);
+            settlement.add(
+                7,
+                TokenUsage {
+                    uncached_input_tokens: 3,
+                    output_tokens: 5,
+                    cache_read_input_tokens: 7,
+                    cache_write_input_tokens: 4,
+                },
+                0.75,
+            );
+            futures::future::pending::<()>().await;
+        };
+
+        drop(receiver);
+        assert!(while_receiver_open(&sender, in_flight).await.is_none());
+
+        let overview = aggregator.overview();
+        assert_eq!(overview.today_calls, 1);
+        assert_eq!(overview.today_errors, 1);
+        assert_eq!(overview.today_input_tokens, 3);
+        assert_eq!(overview.today_output_tokens, 5);
+        assert_eq!(overview.today_credits, 0.75);
+    }
+
+    #[tokio::test]
+    async fn streaming_emitter_reports_background_failure_as_anthropic_error() {
+        let (sender, mut receiver) = mpsc::channel(WEB_SEARCH_PROGRESS_CAPACITY);
+        let mut emitter = WebSearchSseEmitter::new(sender);
+        emitter
+            .fail("upstream_error", "MCP connection failed")
+            .await;
+
+        let events = drain_sse(&mut receiver);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "error");
+        assert_eq!(events[0].1["error"]["type"], json!("upstream_error"));
+        assert_eq!(
+            events[0].1["error"]["message"],
+            json!("MCP connection failed")
+        );
+        assert!(emitter.terminal);
+
+        emitter.fail("api_error", "must not duplicate").await;
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn abort_search_closes_the_dangling_block_before_a_terminal_error() {
+        // Mirrors execute_web_search's error path: begin_search opens a
+        // server_tool_use block, the MCP call fails, abort_search must close
+        // it (content_block_stop only, no web_search_tool_result) BEFORE the
+        // caller's terminal `error` event — every content_block_start must be
+        // paired, exactly like stream.rs::generate_final_events closes open
+        // blocks ahead of a mid-stream tool error.
+        let (sender, mut receiver) = mpsc::channel(WEB_SEARCH_PROGRESS_CAPACITY);
+        let mut emitter = WebSearchSseEmitter::new(sender);
+
+        let pending = emitter.begin_search("Rust 2026").await;
+        let started = drain_sse(&mut receiver);
+        assert_eq!(started.len(), 1);
+        assert_eq!(started[0].0, "content_block_start");
+        let opened_index = started[0].1["index"].clone();
+
+        emitter.abort_search(pending).await;
+        emitter
+            .fail("upstream_error", "MCP connection failed")
+            .await;
+
+        let events = drain_sse(&mut receiver);
+        assert_eq!(
+            events.len(),
+            2,
+            "expected a stop for the opened block, then error"
+        );
+        assert_eq!(events[0].0, "content_block_stop");
+        assert_eq!(events[0].1["index"], opened_index);
+        assert_eq!(events[1].0, "error");
+        assert!(emitter.terminal);
+    }
+
+    #[tokio::test]
+    async fn background_panic_closes_open_block_before_terminal_error() {
+        // Regression for the tokio::spawn body: if the agentic loop panics,
+        // unwinding must not drop `emitter` (and its `sender`) with no
+        // terminal frame. Exercise the same catch_unwind + fail() shape used
+        // in run_web_search_loop's spawned task, with a future that panics
+        // standing in for a buggy loop body.
+        let (sender, mut receiver) = mpsc::channel(WEB_SEARCH_PROGRESS_CAPACITY);
+        tokio::spawn(async move {
+            let mut emitter = WebSearchSseEmitter::new(sender);
+            let outcome = std::panic::AssertUnwindSafe(async {
+                let _pending = emitter.begin_search("Rust 2026").await;
+                panic!("boom: simulated agentic loop bug");
+            })
+            .catch_unwind()
+            .await;
+            let Err(panic) = outcome;
+            if !emitter.terminal {
+                emitter.fail("internal_error", &panic_message(&panic)).await;
+            }
+        })
+        .await
+        .expect("the spawned task itself must not panic (catch_unwind absorbs it)");
+
+        let events = drain_sse(&mut receiver);
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].0, "content_block_start");
+        assert_eq!(events[1].0, "content_block_stop");
+        assert_eq!(events[0].1["index"], events[1].1["index"]);
+        assert_eq!(events[2].0, "error");
+        assert_eq!(events[2].1["error"]["type"], json!("internal_error"));
+        assert_eq!(
+            events[2].1["error"]["message"],
+            json!("boom: simulated agentic loop bug")
+        );
     }
 
     /// Build a known-tool-names set for build_flush_content tests.


### PR DESCRIPTION
## 背景

`/v1/responses` 之前会先等待内部 Anthropic 响应完整结束，再把结果合成为 Responses SSE。对 Codex 来说，这意味着：

- 普通生成无法及时收到文本和 reasoning 增量；
- WebSearch 多轮调用期间可能长时间没有下行数据，连接看起来像是断开或卡住；
- 客户端中断后，后台 provider/MCP 工作可能仍继续执行；
- 传输中断或工具参数 JSON 不完整时，流可能缺少明确的失败终态；
- 取消和异常路径上的 usage/trace 可能无法稳定结算。

本 PR 将 Responses API 改为真正消费内部 Anthropic SSE，并补齐 WebSearch 长连接、取消传播、终态事件和近期 Codex 工具协议兼容。

## 主要改动

### 1. Responses API 增量流式转换

- `stream: true` 时直接复用 Anthropic 流式链路，不再等待完整响应后合成 SSE；
- 增量解析 Anthropic SSE，兼容任意 chunk 边界和 CRLF；
- 实时转换并发送 Responses 生命周期事件，包括：
  - `response.created` / `response.in_progress`
  - 文本 delta/done
  - reasoning summary delta/done
  - function/custom tool call 参数 delta/done
  - output item added/done
  - `response.completed` / `response.incomplete` / `response.failed`
- 收到 Anthropic `message_stop` 后立即完成 Responses 流，不再依赖上游连接 EOF；
- 保留输入、输出、cache creation/read token 和 metering credits 等用量字段。

### 2. WebSearch 长连接稳定性

- 流式请求会立即返回 `message_start`，避免首包等待；
- 多轮搜索过程中实时发送搜索开始、结果和后续生成进度；
- provider/MCP 长时间等待期间定时发送 ping 保活事件；
- 使用有界 channel 提供背压，避免进度事件无限堆积；
- 下游客户端断开后取消正在进行的 provider/MCP future；
- 捕获后台 panic 和内部错误，并转换成明确的 Anthropic error / Responses failed 终态，避免 SSE 静默结束；
- 关闭尚未结束的内容块后再发送错误终态，维持事件顺序合法。

### 3. 流中断与结算语义

- 新增 stream settlement，在成功、传输错误和客户端取消路径上 exactly-once 记录 usage 与 trace；
- WebSearch 多轮请求聚合各轮 token/credits，并确保异常或取消时只结算一次；
- 上游 transport 中断不再伪装为正常 `message_stop`；
- 工具参数 JSON 不完整或非法时发送失败终态，避免 Codex 将半截参数当作完整工具调用执行；
- thinking block 在异常结束前补齐签名并按正确顺序关闭。

### 4. Codex Responses 协议兼容

- 支持 Codex 近期版本放在 input 中的 `additional_tools`；
- 支持 function、custom 和 namespace 工具声明，并在返回时恢复原始工具类型和名称；
- 转换并转发 `tool_choice`，其中 `none` 会明确禁用工具；
- 保留 `parallel_tool_calls`、工具声明和相关 response metadata；
- 转换 reasoning effort，并将上游 thinking 输出映射为 Responses reasoning item；
- 不再无条件注入 WebSearch：只有显式声明 hosted `web_search` 时才进入服务端 Kiro MCP WebSearch 流程；
- Codex 本地工具声明会转换后转发给 Kiro，工具调用结果仍由 Codex 本地执行。

### 5. 文档

更新 README 中 Responses API 的实现说明：当前 `stream: true` 已是上游 SSE 的增量转换，并补充 WebSearch 进度/保活和 Codex 工具转发行为。

## 对用户的影响

- Codex 可以更早看到文本、reasoning 和工具调用增量；
- WebSearch 等长耗时操作期间持续有连接活动，降低长时间静默导致的断线/超时概率；
- 用户中止请求后，服务端能够尽快取消无用后台工作；
- 中断和非法工具参数会得到明确失败终态，而不是静默结束或错误地标记成功；
- usage 和 trace 在断流、取消、多轮 WebSearch 等路径上更加可靠。

## 验证

- `cargo test --locked`：666 passed，0 failed（已合并最新 `master`）；
- `cargo build --release --locked`：通过；
- `rustfmt --edition 2024 --check`（4 个改动 Rust 文件）：通过；
- `git diff --check`：通过；
- 使用与当前 release 构建 SHA-256 完全一致的二进制在 8990 端口持续运行超过 30 小时；
- 运行期 trace 样本中 9 个流式请求全部成功，无失败记录。

## 边界说明

本 PR 重点处理 Responses 增量流式转换、transport-level 断流、客户端取消和 WebSearch 长时间静默。Kiro framed `Event::Error` 的既有统一传播行为不在本 PR 的完整覆盖范围内，可在后续改动中单独收敛。

