### PR TITLE
feat(admin): 按入口 Key 的用量分布与单 Key 积分上限

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented in this file. The format
 loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+主题：**客户端 Key 的用量可观测与配额治理**。新增「按入口 Key 的用量分布」视图，并支持为单个 Key 设置**最高使用积分（credit）上限**，达到上限后自动拒绝其请求。新增数据字段均 `serde(default)`，旧 `client_api_keys.json` 无需改动。
+
+### ✨ 新增 — 按入口 Key 用量分布
+
+- 新增 `GET /api/admin/stats/by-key`：按入口 Key 横向汇总所选时间窗内的调用次数、输入/输出/缓存 Token、异常数与 credit 计费量，附加 Key 名称。
+- 聚合层新增 `UsageAggregator::query_by_key`，复用既有的每桶 `by_key` 预聚合；启用**分组筛选**时按凭据白名单走 `by_key_credential` 求和，与「按上游凭据分布」的过滤口径一致。
+- 概览页新增「按入口 Key 分布」面板：柱状图（Top 12）+ 明细表（异常数飘红、附 credit 列）。该面板为横向对比，**不随上方「统计筛选」的单 Key 选择变化**，前端已加说明文案避免困惑。
+
+### ✨ 新增 — 单个 Key 最高使用积分上限
+
+- `ClientKey` 新增 `maxCredits` 字段（`None`/省略 = 不限制）。上限基于**累计 `totalCredits`** 判定，「重置统计」清零后即可重新计费。
+- 鉴权层新增 `verify_and_touch_ex`，返回 `Ok` / `OverLimit` / `NotFound` 三态；命中但已达上限的请求返回 **HTTP 429 `rate_limit_error`**（提示已用/上限），且**不累加调用次数**。
+- 新增 `POST /api/admin/client-keys/{id}/max-credits`（body `{ "maxCredits": <number|null> }`，`null` 取消限制）；创建 Key 时亦可通过 `maxCredits` 直接指定。入参强制为**非负有限数**；`0` 表示零预算（立即拒绝）。
+- Key 管理页新增「积分 / 上限」列：接近上限（≥80%）转琥珀、达到/超过转红；创建与编辑对话框均可设置或清除上限。
+
+### ⚠️ 行为说明 — 上限为「软配额」
+
+积分为**累计**判定，且 credit 由上游 `meteringEvent.usage` 在**请求结束时**才入账。因此上限是软约束：在某个 Key 逼近上限时，**并发进行中的多个请求会在各自入账前都通过上限检查**，实际用量可能超出上限，超出幅度取决于并发数与单次请求的 credit 量。此设计避免请求执行中途被打断；若需要更硬的约束，应叠加外部限流。被拒的 429 请求为提前返回，不写入用量日志与链路追踪。
+
 ## [0.7.6] - 2026-08-13
 
 主题：**修复 GPT-5.6 推理参数、OpenAI 会话缓存与 Token 用量统计，同时校正 Claude Code 会话隔离和 Opus 5 上下文窗口识别**。本版聚焦协议转换与计量准确性，不新增配置项或迁移步骤。

--- a/admin-ui/src/api/client-keys.ts
+++ b/admin-ui/src/api/client-keys.ts
@@ -58,6 +58,15 @@ export async function resetClientKeyStats(id: number): Promise<SuccessResponse> 
   return data
 }
 
+/** 设置或清除积分使用上限。maxCredits 传 null 表示取消限制 */
+export async function setClientKeyMaxCredits(
+  id: number,
+  maxCredits: number | null,
+): Promise<SuccessResponse> {
+  const { data } = await api.post<SuccessResponse>(`/client-keys/${id}/max-credits`, { maxCredits })
+  return data
+}
+
 export async function rotateClientKey(id: number): Promise<CreateClientKeyResponse> {
   const { data } = await api.post<CreateClientKeyResponse>(`/client-keys/${id}/rotate`)
   return data

--- a/admin-ui/src/api/stats.ts
+++ b/admin-ui/src/api/stats.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { storage } from '@/lib/storage'
 import type {
   CredentialDistribution,
+  KeyDistribution,
   ModelDistribution,
   OverviewStats,
   StatsFilter,
@@ -51,6 +52,14 @@ export async function getByModel(time: StatsTimeFilter, filter?: StatsFilter): P
 export async function getByCredential(time: StatsTimeFilter, filter?: StatsFilter): Promise<CredentialDistribution[]> {
   const { data } = await api.get<CredentialDistribution[]>('/stats/by-credential', {
     params: statsParams(time, filter),
+  })
+  return data
+}
+
+export async function getByKey(time: StatsTimeFilter, filter?: StatsFilter): Promise<KeyDistribution[]> {
+  // by-key 是横向对比所有 Key，忽略 keyId 过滤；仅透传时间窗与分组
+  const { data } = await api.get<KeyDistribution[]>('/stats/by-key', {
+    params: { ...time, ...(filter?.group ? { group: filter.group } : {}) },
   })
   return data
 }

--- a/admin-ui/src/components/charts/key-bar-chart.tsx
+++ b/admin-ui/src/components/charts/key-bar-chart.tsx
@@ -1,0 +1,113 @@
+import { memo, useMemo } from 'react'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts'
+import type { KeyDistribution } from '@/types/api'
+import { tooltipContentStyle, tooltipCursorStyle, tooltipItemStyle, tooltipLabelStyle } from './tooltip-style'
+import { formatNumber } from '@/lib/utils'
+
+interface Props {
+  data: KeyDistribution[]
+}
+
+interface ChartDatum {
+  calls: number
+  errors: number
+  fullLabel: string
+  inputTokens: number
+  label: string
+  outputTokens: number
+}
+
+function KeyBarChartImpl({ data }: Props) {
+  const formatted = useMemo(() => buildChartData(data), [data])
+
+  if (data.length === 0) {
+    return <EmptyKeyChart />
+  }
+
+  return <KeyChartContent data={formatted} />
+}
+
+function buildChartData(data: KeyDistribution[]): ChartDatum[] {
+  return data.slice(0, 12).map((d) => {
+    const fullLabel = d.name || `#${d.keyId}`
+    return {
+      calls: d.calls,
+      errors: d.errors,
+      fullLabel,
+      inputTokens: d.inputTokens,
+      label: truncateLabel(fullLabel),
+      outputTokens: d.outputTokens,
+    }
+  })
+}
+
+function EmptyKeyChart() {
+  return (
+    <div className="flex h-[180px] items-center justify-center text-sm text-muted-foreground sm:h-[260px]">
+      暂无数据
+    </div>
+  )
+}
+
+function KeyChartContent({ data }: { data: ChartDatum[] }) {
+  return (
+    <div className="h-[280px] sm:h-[340px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, left: -10, bottom: 52 }}>
+          {keyChartAxes()}
+          {keyChartTooltip()}
+          <Legend verticalAlign="top" align="right" height={28} wrapperStyle={{ fontSize: 12 }} />
+          {keyChartBars()}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+function keyChartAxes() {
+  return [
+    <CartesianGrid key="grid" strokeDasharray="3 3" className="stroke-border/50" />,
+    <XAxis
+      key="x"
+      dataKey="label"
+      tick={{ fontSize: 10 }}
+      angle={-30}
+      textAnchor="end"
+      interval={0}
+      height={64}
+    />,
+    <YAxis key="y" tick={{ fontSize: 11 }} tickFormatter={(v: number) => formatNumber(v)} width={42} />,
+  ]
+}
+
+function keyChartTooltip() {
+  return (
+    <Tooltip
+      contentStyle={tooltipContentStyle}
+      labelStyle={tooltipLabelStyle}
+      itemStyle={tooltipItemStyle}
+      cursor={tooltipCursorStyle}
+      formatter={(value: number) => formatNumber(value)}
+      labelFormatter={formatTooltipLabel}
+    />
+  )
+}
+
+function formatTooltipLabel(label: string, payload?: ReadonlyArray<{ payload?: ChartDatum }>) {
+  return payload?.[0]?.payload?.fullLabel ?? label
+}
+
+function keyChartBars() {
+  return [
+    <Bar key="input" dataKey="inputTokens" name="输入" stackId="a" fill="#6366f1" isAnimationActive={false} />,
+    <Bar key="output" dataKey="outputTokens" name="输出" stackId="a" fill="#f59e0b" isAnimationActive={false} />,
+  ]
+}
+
+export const KeyBarChart = memo(KeyBarChartImpl)
+
+/** 仅用于 X 轴展示：整体最长 18 字符，超出截断 */
+function truncateLabel(label: string): string {
+  if (label.length <= 18) return label
+  return label.slice(0, 17) + '…'
+}

--- a/admin-ui/src/components/client-keys-page.tsx
+++ b/admin-ui/src/components/client-keys-page.tsx
@@ -16,18 +16,51 @@ import {
 import {
   useClientKeys, useCreateClientKey, useDeleteClientKey,
   useSetClientKeyDisabled, useResetClientKeyStats, useUpdateClientKey,
-  useRotateClientKey,
+  useRotateClientKey, useSetClientKeyMaxCredits,
 } from '@/hooks/use-client-keys'
 import { useGroupOptions } from '@/hooks/use-groups'
 import { GroupSingleSelect } from '@/components/group-select'
 import type { ClientKeyItem, CreateClientKeyResponse } from '@/types/api'
-import { extractErrorMessage } from '@/lib/utils'
+import { extractErrorMessage, formatCredits } from '@/lib/utils'
 import { useConfirm } from '@/components/ui/confirm-dialog'
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + 'M'
   if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K'
   return n.toString()
+}
+
+/**
+ * 解析积分上限输入框：
+ * - 空字符串 → null（不限制）
+ * - 合法非负数 → number
+ * - 其它 → 'invalid'
+ */
+function parseMaxCreditsInput(raw: string): number | null | 'invalid' {
+  const t = raw.trim()
+  if (t === '') return null
+  const n = Number(t)
+  if (!Number.isFinite(n) || n < 0) return 'invalid'
+  return n
+}
+
+/** 渲染「已用积分 / 上限」列。无上限时仅显示已用量。 */
+function CreditsUsage({ used, max }: { used: number; max?: number }) {
+  if (max == null) {
+    return (
+      <span className="text-[12px] tabular-nums text-muted-foreground">
+        {formatCredits(used)} <span className="text-[11px]">/ 无限制</span>
+      </span>
+    )
+  }
+  const ratio = max > 0 ? used / max : 1
+  const over = used >= max
+  const color = over ? 'text-destructive' : ratio >= 0.8 ? 'text-amber-500' : 'text-foreground'
+  return (
+    <span className={`text-[12px] tabular-nums ${color}`} title={`已用 ${used} / 上限 ${max}`}>
+      {formatCredits(used)} <span className="text-[11px] text-muted-foreground">/ {formatCredits(max)}</span>
+    </span>
+  )
 }
 
 function formatRelative(ts?: string): string {
@@ -50,12 +83,14 @@ export function ClientKeysPage() {
   const resetStats = useResetClientKeyStats()
   const updateKey = useUpdateClientKey()
   const rotateKey = useRotateClientKey()
+  const setMaxCredits = useSetClientKeyMaxCredits()
   const confirm = useConfirm()
 
   const [createOpen, setCreateOpen] = useState(false)
   const [createName, setCreateName] = useState('')
   const [createDesc, setCreateDesc] = useState('')
   const [createGroup, setCreateGroup] = useState('')
+  const [createMaxCredits, setCreateMaxCredits] = useState('')
   const [createdKey, setCreatedKey] = useState<CreateClientKeyResponse | null>(null)
   const [showCreatedPlain, setShowCreatedPlain] = useState(true)
 
@@ -64,6 +99,7 @@ export function ClientKeysPage() {
   const [editName, setEditName] = useState('')
   const [editDesc, setEditDesc] = useState('')
   const [editGroup, setEditGroup] = useState('')
+  const [editMaxCredits, setEditMaxCredits] = useState('')
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -72,17 +108,24 @@ export function ClientKeysPage() {
       toast.error('请填写名称')
       return
     }
+    const maxCredits = parseMaxCreditsInput(createMaxCredits)
+    if (maxCredits === 'invalid') {
+      toast.error('积分上限必须是非负数')
+      return
+    }
     try {
       const res = await createKey.mutateAsync({
         name,
         description: createDesc.trim() || undefined,
         group: createGroup.trim() || undefined,
+        maxCredits: maxCredits ?? undefined,
       })
       setCreatedKey(res)
       setCreateOpen(false)
       setCreateName('')
       setCreateDesc('')
       setCreateGroup('')
+      setCreateMaxCredits('')
       setShowCreatedPlain(true)
     } catch (err) {
       toast.error('创建失败：' + extractErrorMessage(err))
@@ -164,17 +207,28 @@ export function ClientKeysPage() {
     setEditName(item.name)
     setEditDesc(item.description ?? '')
     setEditGroup(item.group ?? '')
+    setEditMaxCredits(item.maxCredits != null ? String(item.maxCredits) : '')
     setEditOpen(true)
   }
 
   const handleEditSave = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!editTarget) return
+    const maxCredits = parseMaxCreditsInput(editMaxCredits)
+    if (maxCredits === 'invalid') {
+      toast.error('积分上限必须是非负数')
+      return
+    }
     try {
       await updateKey.mutateAsync({
         id: editTarget.id,
         req: { name: editName.trim(), description: editDesc.trim(), group: editGroup.trim() },
       })
+      // 仅在上限发生变化时才调用额度接口，避免无谓写入
+      const prev = editTarget.maxCredits ?? null
+      if (maxCredits !== prev) {
+        await setMaxCredits.mutateAsync({ id: editTarget.id, maxCredits })
+      }
       toast.success('已更新')
       setEditOpen(false)
     } catch (err) {
@@ -223,7 +277,7 @@ export function ClientKeysPage() {
       ) : (
         <Card>
           <CardContent className="overflow-x-auto p-0">
-            <table className="w-full min-w-[920px] text-sm">
+            <table className="w-full min-w-[1040px] text-sm">
               <thead className="text-[12px] text-muted-foreground border-b border-border/60">
                 <tr className="whitespace-nowrap">
                   <th className="text-left font-medium px-4 py-3">ID</th>
@@ -234,6 +288,7 @@ export function ClientKeysPage() {
                   <th className="text-right font-medium px-4 py-3">总调用</th>
                   <th className="text-right font-medium px-4 py-3">输入</th>
                   <th className="text-right font-medium px-4 py-3">输出</th>
+                  <th className="text-right font-medium px-4 py-3">积分 / 上限</th>
                   <th className="text-left font-medium px-4 py-3">最后使用</th>
                   <th className="sticky right-0 z-20 min-w-[9.75rem] border-l border-border/60 bg-card px-4 py-3 text-right font-medium">
                     操作
@@ -297,6 +352,9 @@ export function ClientKeysPage() {
                     <td className="px-4 py-3 text-right tabular-nums">{k.totalCalls}</td>
                     <td className="px-4 py-3 text-right tabular-nums">{formatTokens(k.totalInputTokens)}</td>
                     <td className="px-4 py-3 text-right tabular-nums">{formatTokens(k.totalOutputTokens)}</td>
+                    <td className="px-4 py-3 text-right">
+                      <CreditsUsage used={k.totalCredits} max={k.maxCredits} />
+                    </td>
                     <td className="px-4 py-3 text-[12px] text-muted-foreground">
                       {formatRelative(k.lastUsedAt)}
                     </td>
@@ -390,6 +448,22 @@ export function ClientKeysPage() {
               />
               <p className="mt-1 text-[11px] text-muted-foreground">
                 绑定后该 Key 仅会使用含此分组的账号（严格隔离，分组内无可用账号时请求会失败）。
+              </p>
+            </div>
+            <div>
+              <label className="text-[12px] text-muted-foreground">积分上限（可选）</label>
+              <Input
+                type="number"
+                min="0"
+                step="any"
+                inputMode="decimal"
+                placeholder="留空表示不限制"
+                value={createMaxCredits}
+                onChange={(e) => setCreateMaxCredits(e.target.value)}
+                disabled={createKey.isPending}
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                累计使用的 credit 达到上限后，该 Key 的请求会被拒绝（HTTP 429）。重置统计后重新计费。
               </p>
             </div>
             <DialogFooter>
@@ -486,10 +560,26 @@ export function ClientKeysPage() {
                 绑定后仅调度该分组内账号（严格隔离）。选「不绑定」表示解除绑定。
               </p>
             </div>
+            <div>
+              <label className="text-[12px] text-muted-foreground">积分上限</label>
+              <Input
+                type="number"
+                min="0"
+                step="any"
+                inputMode="decimal"
+                placeholder="留空表示不限制"
+                value={editMaxCredits}
+                onChange={(e) => setEditMaxCredits(e.target.value)}
+                disabled={updateKey.isPending || setMaxCredits.isPending}
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                累计 credit 达到上限后该 Key 请求会被拒绝（HTTP 429）。清空则取消限制；重置统计可清零已用量。
+              </p>
+            </div>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setEditOpen(false)}>取消</Button>
-              <Button type="submit" disabled={updateKey.isPending}>
-                {updateKey.isPending ? '保存中…' : '保存'}
+              <Button type="submit" disabled={updateKey.isPending || setMaxCredits.isPending}>
+                {updateKey.isPending || setMaxCredits.isPending ? '保存中…' : '保存'}
               </Button>
             </DialogFooter>
           </form>

--- a/admin-ui/src/components/overview-page.tsx
+++ b/admin-ui/src/components/overview-page.tsx
@@ -3,12 +3,13 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Activity, Calendar, Coins, Cpu, KeyRound, Server } from 'lucide-react'
-import { useByCredential, useByModel, useOverview, useTimeSeries } from '@/hooks/use-stats'
+import { useByCredential, useByKey, useByModel, useOverview, useTimeSeries } from '@/hooks/use-stats'
 import { useClientKeys } from '@/hooks/use-client-keys'
 import { useGroupOptions } from '@/hooks/use-groups'
 import type {
   ClientKeyItem,
   CredentialDistribution,
+  KeyDistribution,
   ModelDistribution,
   StatsFilter,
   StatsGranularity,
@@ -19,6 +20,7 @@ import type {
 import { TimeSeriesChart } from '@/components/charts/time-series-chart'
 import { ModelPieChart } from '@/components/charts/model-pie-chart'
 import { CredentialBarChart } from '@/components/charts/credential-bar-chart'
+import { KeyBarChart } from '@/components/charts/key-bar-chart'
 import { cn, formatCredits, formatNumber } from '@/lib/utils'
 import { Input } from '@/components/ui/input'
 import {
@@ -83,9 +85,11 @@ export function OverviewPage() {
   const { data: series } = useTimeSeries(filters.timeFilter, filters.statsFilter)
   const { data: byModel } = useByModel(filters.timeFilter, filters.statsFilter)
   const { data: byCred } = useByCredential(filters.timeFilter, filters.statsFilter)
+  const { data: byKey } = useByKey(filters.timeFilter, filters.statsFilter)
   const seriesData = useMemo(() => series ?? [], [series])
   const modelData = useMemo(() => byModel ?? [], [byModel])
   const credData = useMemo(() => byCred ?? [], [byCred])
+  const keyData = useMemo(() => byKey ?? [], [byKey])
   const rangeStats = useMemo(() => aggregateSeries(seriesData), [seriesData])
   const selectedKeyLabel = selectedStatsKeyLabel(filters.keyFilter, keysData?.keys ?? [])
   const groupFilterActive = filters.groupFilter !== 'all'
@@ -128,6 +132,7 @@ export function OverviewPage() {
         timeText={timeLabel(filters.timeFilter)}
         groupFilterActive={groupFilterActive}
       />
+      <KeyPanel data={keyData} timeText={timeLabel(filters.timeFilter)} />
     </div>
   )
 }
@@ -618,6 +623,65 @@ function CredentialPanel({ data }: { data: CredentialDistribution[] }) {
         <CredentialBarChart data={data} />
       </CardContent>
     </Card>
+  )
+}
+
+function KeyPanel({ data, timeText }: { data: KeyDistribution[]; timeText: string }) {
+  return (
+    <Card className="mb-6">
+      <CardContent className="p-4 sm:p-5">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold tracking-tight">按入口 Key 分布</h2>
+            <p className="text-[12px] text-muted-foreground">各客户端 Key 在所选时间窗内的用量对比</p>
+          </div>
+          <span className="text-[11px] text-muted-foreground inline-flex items-center gap-1">
+            <KeyRound className="h-3 w-3" />Top {Math.min(data.length, 12)} · {timeText}
+          </span>
+        </div>
+        <KeyBarChart data={data} />
+        {data.length > 0 && <KeyTable data={data} />}
+      </CardContent>
+    </Card>
+  )
+}
+
+function KeyTable({ data }: { data: KeyDistribution[] }) {
+  return (
+    <div className="mt-3 max-h-40 overflow-auto text-[12px]">
+      <table className="min-w-[520px] w-full">
+        <thead className="text-muted-foreground">
+          <tr>
+            <th className="text-left font-medium pb-1">Key</th>
+            <th className="text-right font-medium">调用</th>
+            <th className="text-right font-medium">输入</th>
+            <th className="text-right font-medium">输出</th>
+            <th className="text-right font-medium">异常</th>
+            <th className="text-right font-medium">Credit</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((k) => (
+            <tr key={k.keyId} className="border-t border-border/40">
+              <td className="py-1 max-w-[200px] truncate" title={k.name}>
+                {k.name}
+              </td>
+              <td className="text-right tabular-nums">{formatNumber(k.calls)}</td>
+              <td className="text-right tabular-nums">{formatNumber(k.inputTokens)}</td>
+              <td className="text-right tabular-nums">{formatNumber(k.outputTokens)}</td>
+              <td className="text-right tabular-nums">
+                {k.errors > 0 ? (
+                  <span className="text-destructive">{formatNumber(k.errors)}</span>
+                ) : (
+                  '0'
+                )}
+              </td>
+              <td className="text-right tabular-nums">{formatCredits(k.credits)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }
 

--- a/admin-ui/src/components/overview-page.tsx
+++ b/admin-ui/src/components/overview-page.tsx
@@ -132,7 +132,11 @@ export function OverviewPage() {
         timeText={timeLabel(filters.timeFilter)}
         groupFilterActive={groupFilterActive}
       />
-      <KeyPanel data={keyData} timeText={timeLabel(filters.timeFilter)} />
+      <KeyPanel
+        data={keyData}
+        timeText={timeLabel(filters.timeFilter)}
+        keyFilterActive={filters.keyFilter !== 'all'}
+      />
     </div>
   )
 }
@@ -626,7 +630,15 @@ function CredentialPanel({ data }: { data: CredentialDistribution[] }) {
   )
 }
 
-function KeyPanel({ data, timeText }: { data: KeyDistribution[]; timeText: string }) {
+function KeyPanel({
+  data,
+  timeText,
+  keyFilterActive,
+}: {
+  data: KeyDistribution[]
+  timeText: string
+  keyFilterActive: boolean
+}) {
   return (
     <Card className="mb-6">
       <CardContent className="p-4 sm:p-5">
@@ -639,6 +651,12 @@ function KeyPanel({ data, timeText }: { data: KeyDistribution[]; timeText: strin
             <KeyRound className="h-3 w-3" />Top {Math.min(data.length, 12)} · {timeText}
           </span>
         </div>
+        {keyFilterActive && (
+          <p className="mb-3 rounded-md bg-sky-500/10 px-2.5 py-1.5 text-[11px] text-sky-600">
+            本面板为各入口 Key 的<strong className="mx-0.5">横向对比</strong>，不受上方「入口 Key 筛选」影响，
+            始终展示全部 Key。
+          </p>
+        )}
         <KeyBarChart data={data} />
         {data.length > 0 && <KeyTable data={data} />}
       </CardContent>

--- a/admin-ui/src/hooks/use-client-keys.ts
+++ b/admin-ui/src/hooks/use-client-keys.ts
@@ -7,6 +7,7 @@ import {
   setClientKeyDisabled,
   resetClientKeyStats,
   rotateClientKey,
+  setClientKeyMaxCredits,
 } from '@/api/client-keys'
 import type { CreateClientKeyRequest, UpdateClientKeyRequest } from '@/types/api'
 
@@ -64,6 +65,15 @@ export function useRotateClientKey() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => rotateClientKey(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['client-keys'] }),
+  })
+}
+
+export function useSetClientKeyMaxCredits() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, maxCredits }: { id: number; maxCredits: number | null }) =>
+      setClientKeyMaxCredits(id, maxCredits),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['client-keys'] }),
   })
 }

--- a/admin-ui/src/hooks/use-stats.ts
+++ b/admin-ui/src/hooks/use-stats.ts
@@ -1,5 +1,5 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { getByCredential, getByModel, getOverview, getTimeSeries } from '@/api/stats'
+import { getByCredential, getByKey, getByModel, getOverview, getTimeSeries } from '@/api/stats'
 import type { StatsFilter, StatsTimeFilter } from '@/types/api'
 
 /**
@@ -54,6 +54,15 @@ export function useByCredential(time: StatsTimeFilter, filter?: StatsFilter) {
   return useQuery({
     queryKey: ['stats', 'by-credential', ...timeKey(time), filter?.keyId ?? 'all', filter?.group ?? 'all'],
     queryFn: () => getByCredential(time, filter),
+    ...COMMON,
+  })
+}
+
+export function useByKey(time: StatsTimeFilter, filter?: StatsFilter) {
+  // by-key 横向对比所有 Key，仅受时间窗与分组影响（不随 keyId 变化）
+  return useQuery({
+    queryKey: ['stats', 'by-key', ...timeKey(time), filter?.group ?? 'all'],
+    queryFn: () => getByKey(time, filter),
     ...COMMON,
   })
 }

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -385,6 +385,10 @@ export interface ClientKeyItem {
   totalOutputTokens: number
   totalCacheCreationTokens: number
   totalCacheReadTokens: number
+  /** 累计 credit 使用量 */
+  totalCredits: number
+  /** 积分使用上限（未设置时为 undefined，表示不限制） */
+  maxCredits?: number
   /** 绑定的账号分组（未绑定时为 undefined） */
   group?: string
   /** 是否系统密钥（由 config.json apiKey 同步，不可删除、可轮换） */
@@ -400,6 +404,8 @@ export interface CreateClientKeyRequest {
   name: string
   description?: string
   group?: string
+  /** 积分使用上限（可选，不传表示不限制） */
+  maxCredits?: number
 }
 
 /** 创建响应：明文 Key 仅在此处返回一次 */
@@ -474,6 +480,18 @@ export interface CredentialDistribution {
   inputTokens: number
   outputTokens: number
   errors: number
+}
+
+export interface KeyDistribution {
+  keyId: number
+  name: string
+  calls: number
+  inputTokens: number
+  outputTokens: number
+  cacheCreationTokens: number
+  cacheReadTokens: number
+  errors: number
+  credits: number
 }
 
 // ============ 请求链路追踪 ============

--- a/src/admin/client_keys.rs
+++ b/src/admin/client_keys.rs
@@ -45,6 +45,12 @@ pub struct ClientKey {
     /// 累计 credit 计费量（meteringEvent.usage 累加）
     #[serde(default)]
     pub total_credits: f64,
+    /// 累计积分（credit）使用上限。None 表示不限制。
+    ///
+    /// 达到上限后该 Key 的后续请求会被鉴权层拒绝（HTTP 429）。上限基于累计
+    /// `total_credits`，通过「重置统计」清零后可重新计费。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_credits: Option<f64>,
     /// 绑定的账号分组名（可选）
     ///
     /// 设置后，用该 Key 发起的请求只会调度到 groups 包含此分组名的上游账号（严格隔离）。
@@ -55,6 +61,17 @@ pub struct ClientKey {
     /// 老数据无此字段，默认 false。
     #[serde(default, skip_serializing_if = "is_false")]
     pub is_system: bool,
+}
+
+/// 鉴权结果：区分「命中」「超额」「未命中」，供中间件返回不同 HTTP 状态。
+#[derive(Debug, Clone, PartialEq)]
+pub enum KeyAuth {
+    /// 命中且未超额，携带 Key id
+    Ok(u64),
+    /// 命中但已达积分上限
+    OverLimit { id: u64, used: f64, limit: f64 },
+    /// 未匹配到任何启用的 Key
+    NotFound,
 }
 
 /// `by_key` 仅用于判重；鉴权扫描 `entries` 并做常量时间比较。
@@ -177,6 +194,7 @@ impl ClientKeyManager {
             total_cache_creation_tokens: 0,
             total_cache_read_tokens: 0,
             total_credits: 0.0,
+            max_credits: None,
             group: group.filter(|g| !g.trim().is_empty()),
             is_system: false,
         };
@@ -220,6 +238,7 @@ impl ClientKeyManager {
                     total_cache_creation_tokens: 0,
                     total_cache_read_tokens: 0,
                     total_credits: 0.0,
+                    max_credits: None,
                     group: None,
                     is_system: true,
                 },
@@ -431,7 +450,20 @@ impl ClientKeyManager {
     }
 
     /// 不校验前缀，常量时间匹配所有启用 Key；命中后更新使用记录。
+    ///
+    /// 仅返回命中的 Key id（不含额度判定）。需要额度拦截时用 [`Self::verify_and_touch_ex`]。
+    #[allow(dead_code)] // 保留的兼容接口，生产路径已切换到 verify_and_touch_ex
     pub fn verify_and_touch(&self, presented: &str) -> Option<u64> {
+        match self.verify_and_touch_ex(presented) {
+            KeyAuth::Ok(id) => Some(id),
+            // 兼容旧语义：超额与未命中都视为 None
+            KeyAuth::OverLimit { .. } | KeyAuth::NotFound => None,
+        }
+    }
+
+    /// 常量时间匹配所有启用 Key；命中后若已达积分上限则返回 [`KeyAuth::OverLimit`]，
+    /// 否则累加调用次数并返回 [`KeyAuth::Ok`]。
+    pub fn verify_and_touch_ex(&self, presented: &str) -> KeyAuth {
         let mut inner = self.inner.write();
         let mut hit_id: Option<u64> = None;
         for (id, ck) in inner.entries.iter() {
@@ -443,13 +475,49 @@ impl ClientKeyManager {
                 // 不 break，继续完整扫描以保持常量时间
             }
         }
-        let id = hit_id?;
+        let Some(id) = hit_id else {
+            return KeyAuth::NotFound;
+        };
         if let Some(entry) = inner.entries.get_mut(&id) {
+            // 达到积分上限：拒绝，不累加调用次数
+            if let Some(limit) = entry.max_credits {
+                if entry.total_credits >= limit {
+                    return KeyAuth::OverLimit {
+                        id,
+                        used: entry.total_credits,
+                        limit,
+                    };
+                }
+            }
             entry.total_calls += 1;
             entry.last_used_at = Some(Utc::now().to_rfc3339());
         }
         // 不在每次请求都落盘（高频写入），由 record_usage / 定期 flush 持久化
-        Some(id)
+        KeyAuth::Ok(id)
+    }
+
+    /// 设置或清除单个 Key 的积分使用上限。`None` 表示取消限制。
+    ///
+    /// 传入 `Some(v)` 时会归一为非负有限值；小于 0 或非有限值一律拒绝为无效。
+    /// 返回 `false` 表示 Key 不存在或入参非法。
+    pub fn set_max_credits(&self, id: u64, max_credits: Option<f64>) -> bool {
+        if let Some(v) = max_credits {
+            if !v.is_finite() || v < 0.0 {
+                return false;
+            }
+        }
+        let mut inner = self.inner.write();
+        let updated = match inner.entries.get_mut(&id) {
+            Some(e) => {
+                e.max_credits = max_credits;
+                true
+            }
+            None => false,
+        };
+        if updated {
+            self.save_locked(&inner);
+        }
+        updated
     }
 
     /// 在请求结束时累计 Token 用量并落盘
@@ -557,6 +625,48 @@ mod tests {
         assert_eq!(e.total_output_tokens, 80);
         assert_eq!(e.total_cache_creation_tokens, 5);
         assert_eq!(e.total_cache_read_tokens, 10);
+    }
+
+    #[test]
+    fn max_credits_blocks_when_exceeded() {
+        let mgr = ClientKeyManager::new();
+        let entry = mgr.create("test".to_string(), None, None);
+        assert!(mgr.set_max_credits(entry.id, Some(2.0)));
+
+        // 未超额：正常放行
+        assert_eq!(mgr.verify_and_touch_ex(&entry.key), KeyAuth::Ok(entry.id));
+
+        // 累计到达上限后拒绝
+        mgr.record_usage(entry.id, 0, 0, 0, 0, 2.5);
+        match mgr.verify_and_touch_ex(&entry.key) {
+            KeyAuth::OverLimit { id, used, limit } => {
+                assert_eq!(id, entry.id);
+                assert!((used - 2.5).abs() < 1e-9);
+                assert!((limit - 2.0).abs() < 1e-9);
+            }
+            other => panic!("expected OverLimit, got {other:?}"),
+        }
+        // 旧接口兼容：超额返回 None
+        assert_eq!(mgr.verify_and_touch(&entry.key), None);
+
+        // 重置统计后恢复放行
+        assert!(mgr.reset_stats(entry.id));
+        assert_eq!(mgr.verify_and_touch_ex(&entry.key), KeyAuth::Ok(entry.id));
+
+        // 清除上限：不再拦截
+        mgr.record_usage(entry.id, 0, 0, 0, 0, 999.0);
+        assert!(mgr.set_max_credits(entry.id, None));
+        assert_eq!(mgr.verify_and_touch_ex(&entry.key), KeyAuth::Ok(entry.id));
+    }
+
+    #[test]
+    fn set_max_credits_rejects_invalid() {
+        let mgr = ClientKeyManager::new();
+        let entry = mgr.create("test".to_string(), None, None);
+        assert!(!mgr.set_max_credits(entry.id, Some(-1.0)));
+        assert!(!mgr.set_max_credits(entry.id, Some(f64::NAN)));
+        assert!(!mgr.set_max_credits(999, Some(5.0)));
+        assert!(mgr.set_max_credits(entry.id, Some(0.0)));
     }
 
     #[test]

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -896,6 +896,8 @@ fn key_to_item(k: &super::client_keys::ClientKey) -> ClientKeyItem {
         total_output_tokens: k.total_output_tokens,
         total_cache_creation_tokens: k.total_cache_creation_tokens,
         total_cache_read_tokens: k.total_cache_read_tokens,
+        total_credits: k.total_credits,
+        max_credits: k.max_credits,
         group: k.group.clone(),
         is_system: k.is_system,
     }
@@ -927,6 +929,18 @@ pub async fn create_client_key(
         )
             .into_response();
     }
+    // 校验积分上限（若提供）：必须是非负有限值
+    if let Some(v) = payload.max_credits {
+        if !v.is_finite() || v < 0.0 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(super::types::AdminErrorResponse::invalid_request(
+                    "maxCredits 必须是非负数",
+                )),
+            )
+                .into_response();
+        }
+    }
     let entry = state.client_keys.create(
         name.to_string(),
         payload
@@ -938,6 +952,10 @@ pub async fn create_client_key(
             .map(|g| g.trim().to_string())
             .filter(|g| !g.is_empty()),
     );
+    // 创建后若指定了上限则应用
+    if let Some(v) = payload.max_credits {
+        state.client_keys.set_max_credits(entry.id, Some(v));
+    }
     Json(CreateClientKeyResponse {
         id: entry.id,
         key: entry.key,
@@ -945,6 +963,43 @@ pub async fn create_client_key(
         created_at: entry.created_at,
     })
     .into_response()
+}
+
+/// POST /api/admin/client-keys/:id/max-credits
+/// 设置或清除单个 Key 的积分使用上限。body: { "maxCredits": <number|null> }
+pub async fn set_client_key_max_credits(
+    State(state): State<AdminState>,
+    Path(id): Path<u64>,
+    Json(payload): Json<super::types::SetClientKeyMaxCreditsRequest>,
+) -> impl IntoResponse {
+    use axum::http::StatusCode;
+    if let Some(v) = payload.max_credits {
+        if !v.is_finite() || v < 0.0 {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(super::types::AdminErrorResponse::invalid_request(
+                    "maxCredits 必须是非负数",
+                )),
+            )
+                .into_response();
+        }
+    }
+    if state.client_keys.set_max_credits(id, payload.max_credits) {
+        let msg = match payload.max_credits {
+            Some(v) => format!("Key #{} 积分上限已设为 {:.2}", id, v),
+            None => format!("Key #{} 已取消积分上限", id),
+        };
+        Json(SuccessResponse::new(msg)).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(super::types::AdminErrorResponse::not_found(format!(
+                "Key #{} 不存在",
+                id
+            ))),
+        )
+            .into_response()
+    }
 }
 
 /// DELETE /api/admin/client-keys/:id
@@ -1290,6 +1345,49 @@ pub async fn stats_by_credential(
                 "inputTokens": d.input_tokens,
                 "outputTokens": d.output_tokens,
                 "errors": d.errors,
+            })
+        })
+        .collect();
+    Json(enriched).into_response()
+}
+
+/// GET /api/admin/stats/by-key?range=24h|7d|30d&group=...
+/// 按入口 Key 横向汇总时间窗内用量，附加 Key 名称方便前端展示。
+pub async fn stats_by_key(
+    State(state): State<AdminState>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> axum::response::Response {
+    let window = match parse_stats_window(&params) {
+        Ok(w) => w,
+        Err(message) => return stats_bad_request(message),
+    };
+    let group = parse_group_filter(&params);
+    let cred_ids = group_to_cred_ids(&state, group.as_deref());
+    let data = state.usage_aggregator.query_by_key(window, cred_ids.as_ref());
+    // Key 名称解析：命中客户端 Key 名称表则取名称，否则回退 #id
+    let key_name_map: HashMap<u64, String> = state
+        .client_keys
+        .list()
+        .into_iter()
+        .map(|k| (k.id, k.name))
+        .collect();
+    let enriched: Vec<serde_json::Value> = data
+        .into_iter()
+        .map(|d| {
+            let name = key_name_map
+                .get(&d.key_id)
+                .cloned()
+                .unwrap_or_else(|| format!("#{}", d.key_id));
+            serde_json::json!({
+                "keyId": d.key_id,
+                "name": name,
+                "calls": d.calls,
+                "inputTokens": d.input_tokens,
+                "outputTokens": d.output_tokens,
+                "cacheCreationTokens": d.cache_creation_tokens,
+                "cacheReadTokens": d.cache_read_tokens,
+                "errors": d.errors,
+                "credits": d.credits,
             })
         })
         .collect();

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -22,12 +22,13 @@ use super::{
         poll_idc_relogin, poll_social_login, poll_social_relogin, pull_update_image,
         reset_all_success_count, reset_client_key_stats, reset_failure_count, reset_success_count,
         rollback_image_update, rotate_client_key, set_account_rpm_limit_config,
-        set_account_throttle_config,
-        set_client_key_disabled, set_credential_disabled, set_credential_overage,
+        set_account_throttle_config, set_client_key_disabled, set_client_key_max_credits,
+        set_credential_disabled, set_credential_overage,
         set_credential_priority, set_global_proxy, set_load_balancing_mode,
         set_log_governance_config, set_proxy_enabled, set_self_heal_config, set_update_config,
         start_idc_login, start_idc_relogin, start_social_login, start_social_relogin,
-        stats_by_credential, stats_by_model, stats_overview, stats_timeseries, test_model,
+        stats_by_credential, stats_by_key, stats_by_model, stats_overview, stats_timeseries,
+        test_model,
         trace_failure_stats, update_admin_key, update_client_key, update_credential, update_group,
         update_refresh_token,
     },
@@ -174,6 +175,10 @@ pub fn create_admin_router(state: AdminState) -> Router {
         )
         .route("/client-keys/{id}/disabled", post(set_client_key_disabled))
         .route(
+            "/client-keys/{id}/max-credits",
+            post(set_client_key_max_credits),
+        )
+        .route(
             "/client-keys/{id}/reset-stats",
             post(reset_client_key_stats),
         )
@@ -184,6 +189,7 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route("/stats/timeseries", get(stats_timeseries))
         .route("/stats/by-model", get(stats_by_model))
         .route("/stats/by-credential", get(stats_by_credential))
+        .route("/stats/by-key", get(stats_by_key))
         .route("/traces/failure-stats", get(trace_failure_stats))
         .route("/traces", get(list_traces))
         .layer(middleware::from_fn_with_state(

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -841,6 +841,11 @@ pub struct ClientKeyItem {
     pub total_output_tokens: u64,
     pub total_cache_creation_tokens: u64,
     pub total_cache_read_tokens: u64,
+    /// 累计 credit 使用量（用于与上限比较）
+    pub total_credits: f64,
+    /// 积分使用上限（None 表示不限制）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_credits: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
     /// 是否系统密钥（由 config.json apiKey 同步，不可删除、可轮换）
@@ -865,6 +870,9 @@ pub struct CreateClientKeyRequest {
     pub description: Option<String>,
     #[serde(default)]
     pub group: Option<String>,
+    /// 积分使用上限（可选；None / 省略表示不限制）
+    #[serde(default)]
+    pub max_credits: Option<f64>,
 }
 
 /// 创建客户端 Key 响应（明文 Key 仅在此处返回一次）
@@ -885,6 +893,15 @@ pub struct UpdateClientKeyRequest {
     pub description: Option<String>,
     #[serde(default)]
     pub group: Option<String>,
+}
+
+/// 设置客户端 Key 的积分使用上限
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetClientKeyMaxCreditsRequest {
+    /// 积分上限；null 或省略表示取消限制
+    #[serde(default)]
+    pub max_credits: Option<f64>,
 }
 
 // ============ IdC 设备授权登录 ============

--- a/src/admin/usage_stats.rs
+++ b/src/admin/usage_stats.rs
@@ -326,6 +326,20 @@ pub struct CredentialDistribution {
     pub errors: u64,
 }
 
+/// 入口 Key 分布
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyDistribution {
+    pub key_id: u64,
+    pub calls: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub errors: u64,
+    pub credits: f64,
+}
+
 /// 概览：今日 + 累计
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -550,6 +564,55 @@ impl UsageAggregator {
         out
     }
 
+    /// 入口 Key 分布
+    ///
+    /// 按 key 维度横向汇总时间窗内的用量。`cred_filter` 为 `Some` 时（分组筛选），
+    /// 仅统计命中白名单凭据的记录，走 `by_key_credential`；否则走预聚合的 `by_key`。
+    pub fn query_by_key(
+        &self,
+        window: StatsQueryWindow,
+        cred_filter: Option<&std::collections::HashSet<u64>>,
+    ) -> Vec<KeyDistribution> {
+        let inner = self.inner.read();
+        let buckets = select_buckets(&inner, window.granularity);
+        let mut acc: HashMap<u64, BucketStats> = HashMap::new();
+        for b in buckets.iter().filter(|b| bucket_in_window(b, window)) {
+            match cred_filter {
+                None => {
+                    for (key_id, stats) in &b.by_key {
+                        acc.entry(*key_id).or_default().add_stats(stats);
+                    }
+                }
+                Some(allow) => {
+                    for (key_id, group) in &b.by_key_credential {
+                        let entry = acc.entry(*key_id).or_default();
+                        for (cid, cs) in group {
+                            if allow.contains(cid) {
+                                entry.add_stats(cs);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let mut out: Vec<KeyDistribution> = acc
+            .into_iter()
+            .filter(|(_, stats)| stats.calls > 0)
+            .map(|(key_id, stats)| KeyDistribution {
+                key_id,
+                calls: stats.calls,
+                input_tokens: stats.input_tokens,
+                output_tokens: stats.output_tokens,
+                cache_creation_tokens: stats.cache_creation_tokens,
+                cache_read_tokens: stats.cache_read_tokens,
+                errors: stats.errors,
+                credits: stats.credits,
+            })
+            .collect();
+        out.sort_by(|a, b| b.calls.cmp(&a.calls));
+        out
+    }
+
     /// 概览（今日 + 最近 7 天）
     pub fn overview(&self) -> OverviewStats {
         let inner = self.inner.read();
@@ -753,6 +816,50 @@ mod tests {
         let by_cred = agg.query_by_credential(window, None, None);
         assert_eq!(by_cred.len(), 1);
         assert_eq!(by_cred[0].credential_id, 5);
+
+        let by_key = agg.query_by_key(window, None);
+        assert_eq!(by_key.len(), 1);
+        assert_eq!(by_key[0].key_id, 1);
+        assert_eq!(by_key[0].calls, 2);
+        assert_eq!(by_key[0].input_tokens, 2000);
+    }
+
+    #[test]
+    fn query_by_key_ranks_multiple_keys() {
+        let agg = UsageAggregator::new();
+        let now = Utc::now().to_rfc3339();
+        let mk = |key_id: u64, cred: u64, input: u64| UsageRecord {
+            ts: now.clone(),
+            key_id,
+            credential_id: cred,
+            model: "m".to_string(),
+            input_tokens: input,
+            output_tokens: 10,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            credits: 0.01,
+            duration_ms: 100,
+            status: "success".to_string(),
+        };
+        agg.ingest(&mk(1, 5, 100));
+        agg.ingest(&mk(2, 6, 300));
+        agg.ingest(&mk(2, 6, 300));
+
+        let window = StatsQueryWindow::preset(Range::Last24h, StatsGranularity::Hour);
+        let by_key = agg.query_by_key(window, None);
+        assert_eq!(by_key.len(), 2);
+        // key 2 调用更多 → 排在前面
+        assert_eq!(by_key[0].key_id, 2);
+        assert_eq!(by_key[0].calls, 2);
+        assert_eq!(by_key[0].input_tokens, 600);
+        assert_eq!(by_key[1].key_id, 1);
+
+        // 分组白名单只放行凭据 5 → 仅 key 1 命中
+        let allow: std::collections::HashSet<u64> = [5u64].into_iter().collect();
+        let filtered = agg.query_by_key(window, Some(&allow));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].key_id, 1);
+        assert_eq!(filtered[0].input_tokens, 100);
     }
 
     #[test]

--- a/src/anthropic/middleware.rs
+++ b/src/anthropic/middleware.rs
@@ -10,7 +10,7 @@ use axum::{
     response::{IntoResponse, Json, Response},
 };
 
-use crate::admin::client_keys::SharedClientKeyManager;
+use crate::admin::client_keys::{KeyAuth, SharedClientKeyManager};
 use crate::admin::trace_db::{SharedTraceStore, TraceKeySource};
 use crate::admin::usage_stats::{SharedAggregator, SharedRecorder};
 use crate::common::auth;
@@ -121,14 +121,27 @@ pub async fn auth_middleware(
     };
 
     if let Some(mgr) = &state.client_keys {
-        if let Some(id) = mgr.verify_and_touch(&presented) {
-            let group = mgr.group_of(id);
-            request.extensions_mut().insert(KeyContext {
-                key_id: id,
-                group,
-                key_source: TraceKeySource::ClientKey,
-            });
-            return next.run(request).await;
+        match mgr.verify_and_touch_ex(&presented) {
+            KeyAuth::Ok(id) => {
+                let group = mgr.group_of(id);
+                request.extensions_mut().insert(KeyContext {
+                    key_id: id,
+                    group,
+                    key_source: TraceKeySource::ClientKey,
+                });
+                return next.run(request).await;
+            }
+            KeyAuth::OverLimit { used, limit, .. } => {
+                let error = ErrorResponse::new(
+                    "rate_limit_error",
+                    format!(
+                        "该 API Key 已达到积分使用上限（已用 {:.2} / 上限 {:.2}），请联系管理员调整额度或重置统计",
+                        used, limit
+                    ),
+                );
+                return (StatusCode::TOO_MANY_REQUESTS, Json(error)).into_response();
+            }
+            KeyAuth::NotFound => {}
         }
     }
 


### PR DESCRIPTION
## 背景

Admin 现有的用量统计只能按上游凭据和模型维度查看，无法回答「哪个入口 Key 在消耗额度」。同时客户端 Key 只有启用/禁用开关，没有配额手段，单个 Key 失控时只能整体禁用。

本 PR 补上按入口 Key 的用量分布视图，以及单 Key 的最高使用积分上限。

## 改动

**按入口 Key 用量分布**

- 新增 `GET /api/admin/stats/by-key`：按入口 Key 汇总所选时间窗内的调用次数、输入/输出/缓存 Token、异常数与 credit 计费量，附带 Key 名称。
- 聚合层新增 `UsageAggregator::query_by_key`，复用既有的每桶 `by_key` 预聚合，不引入额外扫描。启用分组筛选时按凭据白名单走 `by_key_credential` 求和，与「按上游凭据分布」的过滤口径保持一致。
- 概览页新增「按入口 Key 分布」面板：Top 12 柱状图 + 明细表（异常数飘红，附 credit 列）。该面板是横向对比视图，**不随上方「统计筛选」的单 Key 选择变化**，已在 UI 上加了说明文案避免误解。

**单 Key 最高使用积分上限**

- `ClientKey` 新增 `maxCredits` 字段，`None` 或省略表示不限制。上限基于**累计 `totalCredits`** 判定，「重置统计」清零后可重新计费。
- 鉴权层新增 `verify_and_touch_ex`，返回 `Ok` / `OverLimit` / `NotFound` 三态。命中但已达上限的请求返回 **HTTP 429 `rate_limit_error`**（提示已用量与上限），且**不累加调用次数**。
- 新增 `POST /api/admin/client-keys/{id}/max-credits`，body `{ "maxCredits": <number|null> }`，传 `null` 取消限制。创建 Key 时也可直接指定 `maxCredits`。入参强制为非负有限数，`0` 表示零预算（立即拒绝）。
- Key 管理页新增「积分 / 上限」列：达到 80% 转琥珀色，达到或超过上限转红色。创建与编辑对话框均可设置或清除上限。

## 行为说明：上限是软配额

积分按**累计**判定，而 credit 由上游 `meteringEvent.usage` 在**请求结束时**才入账。因此这是软约束：某个 Key 逼近上限时，并发进行中的多个请求会在各自入账前都通过上限检查，实际用量可能超出上限，超出幅度取决于并发数与单次请求的 credit 量。

这个取舍是有意的，避免请求执行到中途被打断。需要更硬的约束应叠加外部限流。被拒的 429 请求属于提前返回，不写入用量日志与链路追踪。

## 兼容性

新增数据字段均为 `serde(default)`，已有的 `client_api_keys.json` 无需改动或迁移。未设置 `maxCredits` 的 Key 行为与之前完全一致。

## 验证

- `cargo check` 通过，`cargo test` 642 passed / 0 failed
- `admin-ui`: `tsc -b` 类型检查通过，`vite build` 构建成功
- CHANGELOG 条目放在 `[Unreleased]` 下，未改动 `Cargo.toml` 版本号，发版节奏交由维护者决定
