### PR TITLE
feat(admin-ui): 三页改造为运维控制台 + 凭据 metadata schema + 自定义模型管理

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -3,9 +3,17 @@
 ## 凭据元数据
 
 - 凭据元数据使用可扩展对象 `metadata`，固定字段 `type` 只接受 `normal` 或 `boom`。
+- 固定字段 `saleStatus` 表示账号在售状态，只接受 `not_for_sale`、`for_sale`、`sold`，
+  旧凭据默认 `not_for_sale`；它和 `type` 都只做运营标记，不参与调度，批量编辑也应支持。
+- 内置可选字段 `salePrice` 是非负数字，单位固定为 CNY；未设置时不展示，卡片按人民币
+  格式显示，单个编辑和批量编辑都应支持设置或清除。
 - 旧凭据或新增请求未携带 `metadata` 时，`metadata.type` 默认为 `normal`。
 - 未识别的 metadata 扩展键必须在读取、Admin API 编辑和持久化过程中保留。
 - `metadata.type` 当前仅用于运营标记，不参与优先级或负载均衡调度。
 - metadata 字段定义使用标准 JSON Schema，保存于 `config.json` 的
   `credentialMetadataSchema`；设置页负责维护 key、值类型、默认值和枚举 value。
 - 新增和编辑表单按 schema 动态渲染，后端按同一 schema 校验已登记字段，避免前后端规则漂移。
+- 凭据卡片用两列表格、紧凑列表用单行摘要展示全部 metadata：优先使用字段 title
+  和枚举 title，schema 外扩展字段回退显示原始 key，空值不占用卡片空间。
+- Schema 字段可用 `x-css` 配置卡片值样式；前后端都必须拒绝外链、脚本表达式和
+  会让内容脱离卡片边界的布局属性，避免自定义样式成为数据外传或界面劫持入口。

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,11 @@
+# 项目实现记录
+
+## 凭据元数据
+
+- 凭据元数据使用可扩展对象 `metadata`，固定字段 `type` 只接受 `normal` 或 `boom`。
+- 旧凭据或新增请求未携带 `metadata` 时，`metadata.type` 默认为 `normal`。
+- 未识别的 metadata 扩展键必须在读取、Admin API 编辑和持久化过程中保留。
+- `metadata.type` 当前仅用于运营标记，不参与优先级或负载均衡调度。
+- metadata 字段定义使用标准 JSON Schema，保存于 `config.json` 的
+  `credentialMetadataSchema`；设置页负责维护 key、值类型、默认值和枚举 value。
+- 新增和编辑表单按 schema 动态渲染，后端按同一 schema 校验已登记字段，避免前后端规则漂移。

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -4,8 +4,9 @@ import { LoginPage } from "@/components/login-page";
 import { Toaster } from "@/components/ui/sonner";
 import { ConfirmProvider } from "@/components/ui/confirm-dialog";
 import { Button } from "@/components/ui/button";
-import { Activity, KeyRound, Server, LogOut, Moon, Sun, ScrollText, FolderTree } from "lucide-react";
+import { Activity, KeyRound, Server, LogOut, Moon, Sun, ScrollText, FolderTree, SlidersHorizontal } from "lucide-react";
 import { TopbarTools } from "@/components/topbar-tools";
+import { tabFromHash } from "@/hooks/use-url-state";
 
 function GithubIcon({ className }: { className?: string }) {
   return (
@@ -43,8 +44,19 @@ const GroupsPage = lazy(() =>
     default: m.GroupsPage,
   })),
 );
+const SettingsPage = lazy(() =>
+  import("@/components/settings-page").then((m) => ({
+    default: m.SettingsPage,
+  })),
+);
 
-type Tab = "overview" | "credentials" | "keys" | "groups" | "traces";
+type Tab =
+  | "overview"
+  | "credentials"
+  | "keys"
+  | "groups"
+  | "traces"
+  | "settings";
 
 const TABS: {
   key: Tab;
@@ -82,16 +94,25 @@ const TABS: {
     mobileLabel: "日志",
     icon: <ScrollText className="h-3.5 w-3.5" />,
   },
+  {
+    key: "settings",
+    label: "设置",
+    mobileLabel: "设置",
+    icon: <SlidersHorizontal className="h-3.5 w-3.5" />,
+  },
 ];
 
 function readTabFromHash(): Tab {
-  const h = window.location.hash.replace(/^#\/?/, "");
+  // 走共享解析：hash 里现在可能带筛选查询串（#/traces?status=error），
+  // 直接全等比较会认不出 Tab。
+  const h = tabFromHash();
   if (
     h === "credentials" ||
     h === "keys" ||
     h === "groups" ||
     h === "overview" ||
-    h === "traces"
+    h === "traces" ||
+    h === "settings"
   )
     return h;
   return "overview";
@@ -378,6 +399,7 @@ function AppMain({ onLogout, tab }: { onLogout: () => void; tab: Tab }) {
         {tab === "keys" && <ClientKeysPage />}
         {tab === "groups" && <GroupsPage />}
         {tab === "traces" && <TraceLogPage />}
+        {tab === "settings" && <SettingsPage />}
       </Suspense>
     </main>
   );

--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -36,6 +36,7 @@ import type {
   UpdateCheckInfo,
   GitHubRateLimitInfo,
   UpdateAdminKeyRequest,
+  CredentialMetadataSchemaConfig,
 } from '@/types/api'
 
 // 创建 axios 实例
@@ -59,6 +60,23 @@ api.interceptors.request.use((config) => {
 // 获取所有凭据状态
 export async function getCredentials(): Promise<CredentialsStatusResponse> {
   const { data } = await api.get<CredentialsStatusResponse>('/credentials')
+  return data
+}
+
+export async function getCredentialMetadataSchema(): Promise<CredentialMetadataSchemaConfig> {
+  const { data } = await api.get<CredentialMetadataSchemaConfig>(
+    '/config/credential-metadata-schema',
+  )
+  return data
+}
+
+export async function setCredentialMetadataSchema(
+  config: CredentialMetadataSchemaConfig,
+): Promise<CredentialMetadataSchemaConfig> {
+  const { data } = await api.put<CredentialMetadataSchemaConfig>(
+    '/config/credential-metadata-schema',
+    config,
+  )
   return data
 }
 

--- a/admin-ui/src/api/credentials.ts
+++ b/admin-ui/src/api/credentials.ts
@@ -10,6 +10,7 @@ import type {
   SetPriorityRequest,
   AddCredentialRequest,
   AddCredentialResponse,
+  CustomModelItem,
   UpdateCredentialRequest,
   UpdateRefreshTokenRequest,
   ProxyPoolEntry,
@@ -561,6 +562,23 @@ export async function getGlobalProxy(): Promise<GlobalProxyResponse> {
 // 设置全局代理配置
 export async function setGlobalProxy(req: SetGlobalProxyRequest): Promise<SuccessResponse> {
   const { data } = await api.put<SuccessResponse>('/config/global-proxy', req)
+  return data
+}
+
+// 获取自定义模型配置
+export async function getCustomModels(): Promise<{ models: CustomModelItem[] }> {
+  const { data } = await api.get<{ models: CustomModelItem[] }>('/config/custom-models')
+  return data
+}
+
+// 批量替换自定义模型配置
+export async function setCustomModels(
+  req: { models: CustomModelItem[] },
+): Promise<{ models: CustomModelItem[] }> {
+  const { data } = await api.put<{ models: CustomModelItem[] }>(
+    '/config/custom-models',
+    req,
+  )
   return data
 }
 

--- a/admin-ui/src/api/traces.ts
+++ b/admin-ui/src/api/traces.ts
@@ -25,6 +25,9 @@ export async function getTraces(query: TraceQuery): Promise<TracePage> {
   if (query.model) params.model = query.model
   if (query.group) params.group = query.group
   if (query.onlyFailed) params.onlyFailed = 'true'
+  if (query.startTime != null) params.startTime = String(query.startTime)
+  if (query.endTime != null) params.endTime = String(query.endTime)
+  if (query.q) params.q = query.q
   if (query.limit != null) params.limit = String(query.limit)
   if (query.offset != null) params.offset = String(query.offset)
   const { data } = await api.get<TracePage>('/traces', { params })

--- a/admin-ui/src/components/add-credential-dialog.tsx
+++ b/admin-ui/src/components/add-credential-dialog.tsx
@@ -53,7 +53,10 @@ export function AddCredentialDialog({ open, onOpenChange, metadataSchema }: AddC
   const [endpoint, setEndpoint] = useState('')
   const [groups, setGroups] = useState<string[]>([])
   const [sourceChannel, setSourceChannel] = useState('')
-  const [metadata, setMetadata] = useState<CredentialMetadata>({ type: 'normal' })
+  const [metadata, setMetadata] = useState<CredentialMetadata>({
+    type: 'normal',
+    saleStatus: 'not_for_sale',
+  })
 
   const groupOptions = useGroupOptions()
 

--- a/admin-ui/src/components/add-credential-dialog.tsx
+++ b/admin-ui/src/components/add-credential-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { RegionSelect } from '@/components/region-select'
 import {
   Select,
   SelectTrigger,
@@ -224,28 +225,32 @@ export function AddCredentialDialog({ open, onOpenChange, metadataSchema }: AddC
             {/* Region 配置 */}
             <div className="space-y-2">
               <label className="text-sm font-medium">Region 配置</label>
-              <div className="grid grid-cols-2 gap-2">
-                <div>
-                  <Input
-                    id="authRegion"
-                    placeholder="Auth Region"
+              <div className="space-y-2">
+                <div className="space-y-1">
+                  <span className="text-xs text-muted-foreground">
+                    Auth Region（Token 刷新）
+                  </span>
+                  <RegionSelect
                     value={authRegion}
-                    onChange={(e) => setAuthRegion(e.target.value)}
+                    onChange={setAuthRegion}
+                    allowInherit
                     disabled={isPending}
                   />
                 </div>
-                <div>
-                  <Input
-                    id="apiRegion"
-                    placeholder="API Region"
+                <div className="space-y-1">
+                  <span className="text-xs text-muted-foreground">
+                    API Region（API 请求）
+                  </span>
+                  <RegionSelect
                     value={apiRegion}
-                    onChange={(e) => setApiRegion(e.target.value)}
+                    onChange={setApiRegion}
+                    allowInherit
                     disabled={isPending}
                   />
                 </div>
               </div>
               <p className="text-xs text-muted-foreground">
-                均可留空使用全局配置。Auth Region 用于 Token 刷新，API Region 用于 API 请求
+                选「跟随全局配置」即沿用 config.json 的 region；预设里没有的区域可直接手输
               </p>
             </div>
 

--- a/admin-ui/src/components/add-credential-dialog.tsx
+++ b/admin-ui/src/components/add-credential-dialog.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -20,15 +21,21 @@ import { useAddCredential } from '@/hooks/use-credentials'
 import { useGroupOptions } from '@/hooks/use-groups'
 import { extractErrorMessage } from '@/lib/utils'
 import { GroupMultiSelect } from '@/components/group-select'
+import {
+  CredentialMetadataEditor,
+  metadataDefaults,
+} from '@/components/credential-metadata-field'
+import type { CredentialMetadata, CredentialMetadataSchema } from '@/types/api'
 
 interface AddCredentialDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  metadataSchema?: CredentialMetadataSchema
 }
 
 type AuthMethod = 'social' | 'idc' | 'api_key' | 'external_idp'
 
-export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogProps) {
+export function AddCredentialDialog({ open, onOpenChange, metadataSchema }: AddCredentialDialogProps) {
   const [refreshToken, setRefreshToken] = useState('')
   const [kiroApiKey, setKiroApiKey] = useState('')
   const [authMethod, setAuthMethod] = useState<AuthMethod>('social')
@@ -46,10 +53,17 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
   const [endpoint, setEndpoint] = useState('')
   const [groups, setGroups] = useState<string[]>([])
   const [sourceChannel, setSourceChannel] = useState('')
+  const [metadata, setMetadata] = useState<CredentialMetadata>({ type: 'normal' })
 
   const groupOptions = useGroupOptions()
 
   const { mutate, isPending } = useAddCredential()
+
+  useEffect(() => {
+    if (open) {
+      setMetadata((current) => ({ ...metadataDefaults(metadataSchema), ...current }))
+    }
+  }, [open, metadataSchema])
 
   const resetForm = () => {
     setRefreshToken('')
@@ -69,6 +83,7 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
     setEndpoint('')
     setGroups([])
     setSourceChannel('')
+    setMetadata(metadataDefaults(metadataSchema))
   }
 
   const isApiKey = authMethod === 'api_key'
@@ -120,6 +135,7 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
         endpoint: endpoint.trim() || undefined,
         groups: groups,
         sourceChannel: sourceChannel.trim() || undefined,
+        metadata,
       },
       {
         onSuccess: (data) => {
@@ -139,6 +155,9 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
       <DialogContent className="sm:max-w-lg max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>添加凭据</DialogTitle>
+          <DialogDescription>
+            添加 OAuth、企业 SSO 或 API Key 凭据，并配置分组、Metadata 与代理。
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
@@ -379,6 +398,13 @@ export function AddCredentialDialog({ open, onOpenChange }: AddCredentialDialogP
                 可选。纯备注，标记账号来源/渠道，便于追踪
               </p>
             </div>
+
+            <CredentialMetadataEditor
+              schema={metadataSchema}
+              value={metadata}
+              onChange={setMetadata}
+              disabled={isPending}
+            />
 
             {/* 代理配置 */}
             <div className="space-y-2">

--- a/admin-ui/src/components/available-models-dialog.tsx
+++ b/admin-ui/src/components/available-models-dialog.tsx
@@ -6,6 +6,7 @@ import {
   Clock3,
   Loader2,
   Play,
+  Radio,
   RefreshCw,
 } from 'lucide-react'
 import {
@@ -47,6 +48,19 @@ function formatSelectionSource(data: AvailableModelsResponse) {
     case 'balanced':
       return `均衡选择凭据 #${data.id}`
   }
+}
+
+/** 毫秒时间戳 → 简短相对时间（如"刚刚"、"1分钟前"、"5分钟前"） */
+function relativeTime(ms: number): string {
+  const diffSecs = Math.max(0, Math.floor((Date.now() - ms) / 1000))
+  if (diffSecs < 10) return '刚刚'
+  if (diffSecs < 60) return `${diffSecs} 秒前`
+  const mins = Math.floor(diffSecs / 60)
+  if (mins < 60) return `${mins} 分钟前`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours} 小时前`
+  const days = Math.floor(hours / 24)
+  return `${days} 天前`
 }
 
 export function AvailableModelsDialog({
@@ -133,8 +147,16 @@ export function AvailableModelsDialog({
             </Button>
           </div>
           {query.data && (
-            <div className="text-xs text-muted-foreground">
-              {formatSelectionSource(query.data)}，共 {query.data.models.length} 个模型
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>{formatSelectionSource(query.data)}，共 {query.data.models.length} 个模型</span>
+              {query.dataUpdatedAt > 0 && (
+                <span className="inline-flex items-center gap-1 text-[11px]">
+                  <Radio className="h-3 w-3 text-emerald-500" />
+                  <span className="tabular-nums" title={new Date(query.dataUpdatedAt).toLocaleString('zh-CN')}>
+                    实时 · {relativeTime(query.dataUpdatedAt)}
+                  </span>
+                </span>
+              )}
             </div>
           )}
         </DialogHeader>

--- a/admin-ui/src/components/batch-edit-credential-dialog.tsx
+++ b/admin-ui/src/components/batch-edit-credential-dialog.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/credential-metadata-field'
 import { updateCredential } from '@/api/credentials'
 import type {
+  CredentialMetadata,
   CredentialMetadataSchema,
   CredentialSaleStatus,
   CredentialStatusItem,
@@ -27,6 +28,13 @@ import type {
 } from '@/types/api'
 
 type GroupMode = 'replace' | 'add' | 'remove'
+
+/** 状态接口的 metadata 带展示信息；批量编辑提交时只发送实际值。 */
+function metadataValues(metadata: CredentialStatusItem['metadata']): CredentialMetadata {
+  return Object.fromEntries(
+    Object.entries(metadata ?? {}).map(([key, detail]) => [key, detail.value]),
+  ) as CredentialMetadata
+}
 
 interface BatchEditCredentialDialogProps {
   open: boolean
@@ -123,8 +131,8 @@ export function BatchEditCredentialDialog({
       if (editGroups) req.groups = computeGroups(c.groups ?? [])
       if (editSource) req.sourceChannel = sourceChannel.trim()
       if (editType || editSaleStatus || editSalePrice) {
-        const metadata = {
-          ...c.metadata,
+        const metadata: CredentialMetadata = {
+          ...metadataValues(c.metadata),
           ...(editType ? { type: credentialType } : {}),
           ...(editSaleStatus ? { saleStatus } : {}),
         }

--- a/admin-ui/src/components/batch-edit-credential-dialog.tsx
+++ b/admin-ui/src/components/batch-edit-credential-dialog.tsx
@@ -18,7 +18,13 @@ import {
   metadataFieldDefault,
 } from '@/components/credential-metadata-field'
 import { updateCredential } from '@/api/credentials'
-import type { CredentialMetadataSchema, CredentialStatusItem, CredentialType, UpdateCredentialRequest } from '@/types/api'
+import type {
+  CredentialMetadataSchema,
+  CredentialSaleStatus,
+  CredentialStatusItem,
+  CredentialType,
+  UpdateCredentialRequest,
+} from '@/types/api'
 
 type GroupMode = 'replace' | 'add' | 'remove'
 
@@ -58,6 +64,10 @@ export function BatchEditCredentialDialog({
   const [sourceChannel, setSourceChannel] = useState('')
   const [editType, setEditType] = useState(false)
   const [credentialType, setCredentialType] = useState<CredentialType>('normal')
+  const [editSaleStatus, setEditSaleStatus] = useState(false)
+  const [saleStatus, setSaleStatus] = useState<CredentialSaleStatus>('not_for_sale')
+  const [editSalePrice, setEditSalePrice] = useState(false)
+  const [salePrice, setSalePrice] = useState('')
 
   const [running, setRunning] = useState(false)
   const [progress, setProgress] = useState({ current: 0, total: 0 })
@@ -71,6 +81,12 @@ export function BatchEditCredentialDialog({
       setSourceChannel('')
       setEditType(false)
       setCredentialType(metadataFieldDefault(metadataSchema, 'type', 'normal') as CredentialType)
+      setEditSaleStatus(false)
+      setSaleStatus(
+        metadataFieldDefault(metadataSchema, 'saleStatus', 'not_for_sale') as CredentialSaleStatus,
+      )
+      setEditSalePrice(false)
+      setSalePrice('')
       setRunning(false)
       setProgress({ current: 0, total: 0 })
     }
@@ -84,8 +100,17 @@ export function BatchEditCredentialDialog({
   }
 
   const handleApply = async () => {
-    if (!editGroups && !editSource && !editType) {
+    if (!editGroups && !editSource && !editType && !editSaleStatus && !editSalePrice) {
       toast.error('请至少开启一项要修改的字段')
+      return
+    }
+    const parsedSalePrice = salePrice.trim() === '' ? undefined : Number(salePrice)
+    if (
+      editSalePrice
+      && parsedSalePrice !== undefined
+      && (!Number.isFinite(parsedSalePrice) || parsedSalePrice < 0)
+    ) {
+      toast.error('销售价格必须是大于或等于 0 的数字')
       return
     }
     setRunning(true)
@@ -97,7 +122,18 @@ export function BatchEditCredentialDialog({
       const req: UpdateCredentialRequest = {}
       if (editGroups) req.groups = computeGroups(c.groups ?? [])
       if (editSource) req.sourceChannel = sourceChannel.trim()
-      if (editType) req.metadata = { ...c.metadata, type: credentialType }
+      if (editType || editSaleStatus || editSalePrice) {
+        const metadata = {
+          ...c.metadata,
+          ...(editType ? { type: credentialType } : {}),
+          ...(editSaleStatus ? { saleStatus } : {}),
+        }
+        if (editSalePrice) {
+          if (parsedSalePrice === undefined) delete metadata.salePrice
+          else metadata.salePrice = parsedSalePrice
+        }
+        req.metadata = metadata
+      }
       try {
         await updateCredential(c.id, req)
         ok++
@@ -195,6 +231,58 @@ export function BatchEditCredentialDialog({
                   disabled={running}
                 />
                 <p className="text-[11px] text-muted-foreground">其他扩展字段保持不变。</p>
+              </>
+            )}
+          </div>
+
+          {/* 在售状态区 */}
+          <div className="space-y-3 rounded-xl border border-border/60 p-3">
+            <label className="flex items-center justify-between">
+              <span className="text-sm font-medium">修改在售状态</span>
+              <Switch
+                checked={editSaleStatus}
+                onCheckedChange={setEditSaleStatus}
+                disabled={running}
+              />
+            </label>
+            {editSaleStatus && (
+              <>
+                <CredentialMetadataField
+                  schema={metadataSchema}
+                  fieldKey="saleStatus"
+                  value={saleStatus}
+                  onValueChange={(value) => setSaleStatus(value as CredentialSaleStatus)}
+                  disabled={running}
+                />
+                <p className="text-[11px] text-muted-foreground">其他扩展字段保持不变。</p>
+              </>
+            )}
+          </div>
+
+          {/* 销售价格区 */}
+          <div className="space-y-3 rounded-xl border border-border/60 p-3">
+            <label className="flex items-center justify-between">
+              <span className="text-sm font-medium">修改销售价格（CNY）</span>
+              <Switch
+                checked={editSalePrice}
+                onCheckedChange={setEditSalePrice}
+                disabled={running}
+              />
+            </label>
+            {editSalePrice && (
+              <>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={salePrice}
+                  onChange={(event) => setSalePrice(event.target.value)}
+                  placeholder="留空表示清除价格"
+                  disabled={running}
+                />
+                <p className="text-[11px] text-muted-foreground">
+                  应用到所有选中账号，卡片中按人民币格式显示。
+                </p>
               </>
             )}
           </div>

--- a/admin-ui/src/components/batch-edit-credential-dialog.tsx
+++ b/admin-ui/src/components/batch-edit-credential-dialog.tsx
@@ -13,8 +13,12 @@ import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
 import { GroupMultiSelect } from '@/components/group-select'
+import {
+  CredentialMetadataField,
+  metadataFieldDefault,
+} from '@/components/credential-metadata-field'
 import { updateCredential } from '@/api/credentials'
-import type { CredentialStatusItem } from '@/types/api'
+import type { CredentialMetadataSchema, CredentialStatusItem, CredentialType, UpdateCredentialRequest } from '@/types/api'
 
 type GroupMode = 'replace' | 'add' | 'remove'
 
@@ -25,6 +29,7 @@ interface BatchEditCredentialDialogProps {
   credentials: CredentialStatusItem[]
   /** 现有分组选项（去重聚合） */
   groupOptions: string[]
+  metadataSchema?: CredentialMetadataSchema
   /** 完成后回调（清空选择等） */
   onDone: () => void
 }
@@ -40,6 +45,7 @@ export function BatchEditCredentialDialog({
   onOpenChange,
   credentials,
   groupOptions,
+  metadataSchema,
   onDone,
 }: BatchEditCredentialDialogProps) {
   const queryClient = useQueryClient()
@@ -50,6 +56,8 @@ export function BatchEditCredentialDialog({
 
   const [editSource, setEditSource] = useState(false)
   const [sourceChannel, setSourceChannel] = useState('')
+  const [editType, setEditType] = useState(false)
+  const [credentialType, setCredentialType] = useState<CredentialType>('normal')
 
   const [running, setRunning] = useState(false)
   const [progress, setProgress] = useState({ current: 0, total: 0 })
@@ -61,6 +69,8 @@ export function BatchEditCredentialDialog({
       setGroups([])
       setEditSource(false)
       setSourceChannel('')
+      setEditType(false)
+      setCredentialType(metadataFieldDefault(metadataSchema, 'type', 'normal') as CredentialType)
       setRunning(false)
       setProgress({ current: 0, total: 0 })
     }
@@ -74,7 +84,7 @@ export function BatchEditCredentialDialog({
   }
 
   const handleApply = async () => {
-    if (!editGroups && !editSource) {
+    if (!editGroups && !editSource && !editType) {
       toast.error('请至少开启一项要修改的字段')
       return
     }
@@ -84,9 +94,10 @@ export function BatchEditCredentialDialog({
     let fail = 0
     for (let i = 0; i < credentials.length; i++) {
       const c = credentials[i]
-      const req: Record<string, unknown> = {}
+      const req: UpdateCredentialRequest = {}
       if (editGroups) req.groups = computeGroups(c.groups ?? [])
       if (editSource) req.sourceChannel = sourceChannel.trim()
+      if (editType) req.metadata = { ...c.metadata, type: credentialType }
       try {
         await updateCredential(c.id, req)
         ok++
@@ -164,6 +175,26 @@ export function BatchEditCredentialDialog({
                   disabled={running}
                 />
                 <p className="text-[11px] text-muted-foreground">纯备注，标记账号来源/渠道。</p>
+              </>
+            )}
+          </div>
+
+          {/* 账号类型区 */}
+          <div className="space-y-3 rounded-xl border border-border/60 p-3">
+            <label className="flex items-center justify-between">
+              <span className="text-sm font-medium">修改账号类型</span>
+              <Switch checked={editType} onCheckedChange={setEditType} disabled={running} />
+            </label>
+            {editType && (
+              <>
+                <CredentialMetadataField
+                  schema={metadataSchema}
+                  fieldKey="type"
+                  value={credentialType}
+                  onValueChange={(value) => setCredentialType(value as CredentialType)}
+                  disabled={running}
+                />
+                <p className="text-[11px] text-muted-foreground">其他扩展字段保持不变。</p>
               </>
             )}
           </div>

--- a/admin-ui/src/components/batch-import-dialog.tsx
+++ b/admin-ui/src/components/batch-import-dialog.tsx
@@ -17,7 +17,12 @@ import {
   type BatchImportItemEvent,
   type BatchImportSummary,
 } from '@/api/credentials'
-import type { AddCredentialRequest, CredentialMetadata, CredentialType } from '@/types/api'
+import type {
+  AddCredentialRequest,
+  CredentialMetadata,
+  CredentialSaleStatus,
+  CredentialType,
+} from '@/types/api'
 import { extractErrorMessage, sha256Hex, normalizeImportAuthMethod } from '@/lib/utils'
 import {
   metadataFieldDefault,
@@ -157,9 +162,17 @@ export function BatchImportDialog({ open, onOpenChange }: BatchImportDialogProps
           updateResult(i, { status: 'failed', error: 'metadata.type 不符合当前 schema' })
           continue
         }
+        const saleStatus = cred.metadata?.saleStatus
+          ?? metadataFieldDefault(metadataSchema, 'saleStatus', 'not_for_sale')
+        const saleStatusValues = metadataFieldValues(metadataSchema, 'saleStatus')
+        if (saleStatusValues.length > 0 && !saleStatusValues.includes(saleStatus)) {
+          updateResult(i, { status: 'failed', error: 'metadata.saleStatus 不符合当前 schema' })
+          continue
+        }
         const metadata: CredentialMetadata = {
           ...cred.metadata,
           type: metadataType as CredentialType,
+          saleStatus: saleStatus as CredentialSaleStatus,
         }
 
         // 若凭据未指定代理且代理池有可用代理，随机分配一个

--- a/admin-ui/src/components/batch-import-dialog.tsx
+++ b/admin-ui/src/components/batch-import-dialog.tsx
@@ -17,8 +17,12 @@ import {
   type BatchImportItemEvent,
   type BatchImportSummary,
 } from '@/api/credentials'
-import type { AddCredentialRequest } from '@/types/api'
+import type { AddCredentialRequest, CredentialMetadata, CredentialType } from '@/types/api'
 import { extractErrorMessage, sha256Hex, normalizeImportAuthMethod } from '@/lib/utils'
+import {
+  metadataFieldDefault,
+  metadataFieldValues,
+} from '@/components/credential-metadata-field'
 
 interface BatchImportDialogProps {
   open: boolean
@@ -45,6 +49,7 @@ interface CredentialInput {
   tokenEndpoint?: string
   issuerUrl?: string
   scopes?: string
+  metadata?: Partial<CredentialMetadata>
 }
 
 interface VerificationResult {
@@ -144,6 +149,19 @@ export function BatchImportDialog({ open, onOpenChange }: BatchImportDialogProps
       for (let i = 0; i < credentials.length; i++) {
         const cred = credentials[i]
 
+        const metadataSchema = existingCredentials?.metadataSchema
+        const metadataType = cred.metadata?.type
+          ?? metadataFieldDefault(metadataSchema, 'type', 'normal')
+        const typeValues = metadataFieldValues(metadataSchema, 'type')
+        if (typeValues.length > 0 && !typeValues.includes(metadataType)) {
+          updateResult(i, { status: 'failed', error: 'metadata.type 不符合当前 schema' })
+          continue
+        }
+        const metadata: CredentialMetadata = {
+          ...cred.metadata,
+          type: metadataType as CredentialType,
+        }
+
         // 若凭据未指定代理且代理池有可用代理，随机分配一个
         if (!cred.proxyUrl?.trim() && enabledProxies.length > 0) {
           const picked = enabledProxies[Math.floor(Math.random() * enabledProxies.length)]
@@ -184,6 +202,7 @@ export function BatchImportDialog({ open, onOpenChange }: BatchImportDialogProps
               proxyUrl: cred.proxyUrl?.trim() || undefined,
               proxyUsername: cred.proxyUsername?.trim() || undefined,
               proxyPassword: cred.proxyPassword?.trim() || undefined,
+              metadata,
             },
           })
         } else {
@@ -239,6 +258,7 @@ export function BatchImportDialog({ open, onOpenChange }: BatchImportDialogProps
               proxyUrl: cred.proxyUrl?.trim() || undefined,
               proxyUsername: cred.proxyUsername?.trim() || undefined,
               proxyPassword: cred.proxyPassword?.trim() || undefined,
+              metadata,
             },
           })
         }

--- a/admin-ui/src/components/console/bulk-bar.tsx
+++ b/admin-ui/src/components/console/bulk-bar.tsx
@@ -20,7 +20,7 @@ export function BulkBar({
   if (count === 0) return null
 
   return (
-    <div className="pointer-events-none sticky bottom-5 z-40 flex justify-center px-4">
+    <div className="pointer-events-none sticky bottom-6 z-40 flex justify-center px-4 mt-8 sm:mt-10 mb-2">
       <div className="console-bulkbar console-scope pointer-events-auto flex max-w-full flex-wrap items-center gap-2.5 sm:gap-3 rounded-full border border-border/80 bg-card/95 px-4 py-2.5 shadow-apple-xl backdrop-blur-2xl">
         <span className="pl-1 text-xs font-medium whitespace-nowrap text-foreground/90">
           已选 <span className="console-num font-bold text-primary">{count}</span> {noun}

--- a/admin-ui/src/components/console/bulk-bar.tsx
+++ b/admin-ui/src/components/console/bulk-bar.tsx
@@ -3,12 +3,6 @@ import { Button } from '@/components/ui/button'
 
 /**
  * 吸底批量操作栏。
- *
- * 解决现状里两个具体问题：
- * 1. 批量验活 / 刷新 Token / 恢复异常 藏在「更多」二级菜单里，选完还要再点两层
- * 2. 操作区在页面顶部，选中若干行、滚到列表中段后，操作入口已经滚出视野
- *
- * 所以它常驻底部：选中 > 0 时滑入，操作直接摆在表面，不再折叠。
  */
 export function BulkBar({
   count,
@@ -26,22 +20,24 @@ export function BulkBar({
   if (count === 0) return null
 
   return (
-    <div className="pointer-events-none sticky bottom-4 z-40 flex justify-center px-4">
-      <div className="console-bulkbar console-scope pointer-events-auto flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/70 bg-card/95 px-3 py-2 shadow-apple-lg backdrop-blur-xl">
-        <span className="pl-1 text-[13px] whitespace-nowrap">
-          已选 <span className="console-num font-semibold">{count}</span> {noun}
+    <div className="pointer-events-none sticky bottom-5 z-40 flex justify-center px-4">
+      <div className="console-bulkbar console-scope pointer-events-auto flex max-w-full flex-wrap items-center gap-2.5 sm:gap-3 rounded-full border border-border/80 bg-card/95 px-4 py-2.5 shadow-apple-xl backdrop-blur-2xl">
+        <span className="pl-1 text-xs font-medium whitespace-nowrap text-foreground/90">
+          已选 <span className="console-num font-bold text-primary">{count}</span> {noun}
         </span>
-        <span className="mx-0.5 h-5 w-px bg-border/70" />
-        {children}
-        <span className="mx-0.5 h-5 w-px bg-border/70" />
+        <span className="mx-1 h-4 w-px bg-border/70 shrink-0" />
+        <div className="flex flex-wrap items-center gap-2 sm:gap-2.5">
+          {children}
+        </div>
+        <span className="mx-1 h-4 w-px bg-border/70 shrink-0" />
         <Button
           size="icon"
           variant="ghost"
           onClick={onClear}
           title="取消选择（Esc）"
-          className="h-7 w-7"
+          className="h-8 w-8 rounded-full hover:bg-accent shrink-0 text-muted-foreground hover:text-foreground"
         >
-          <X className="h-3.5 w-3.5" />
+          <X className="h-4 w-4" />
         </Button>
       </div>
     </div>

--- a/admin-ui/src/components/console/bulk-bar.tsx
+++ b/admin-ui/src/components/console/bulk-bar.tsx
@@ -1,0 +1,49 @@
+import { X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * 吸底批量操作栏。
+ *
+ * 解决现状里两个具体问题：
+ * 1. 批量验活 / 刷新 Token / 恢复异常 藏在「更多」二级菜单里，选完还要再点两层
+ * 2. 操作区在页面顶部，选中若干行、滚到列表中段后，操作入口已经滚出视野
+ *
+ * 所以它常驻底部：选中 > 0 时滑入，操作直接摆在表面，不再折叠。
+ */
+export function BulkBar({
+  count,
+  onClear,
+  children,
+  noun = '项',
+}: {
+  count: number
+  onClear: () => void
+  /** 批量动作按钮 */
+  children: React.ReactNode
+  /** 计数单位，如「个凭据」 */
+  noun?: string
+}) {
+  if (count === 0) return null
+
+  return (
+    <div className="pointer-events-none sticky bottom-4 z-40 flex justify-center px-4">
+      <div className="console-bulkbar console-scope pointer-events-auto flex max-w-full flex-wrap items-center gap-2 rounded-full border border-border/70 bg-card/95 px-3 py-2 shadow-apple-lg backdrop-blur-xl">
+        <span className="pl-1 text-[13px] whitespace-nowrap">
+          已选 <span className="console-num font-semibold">{count}</span> {noun}
+        </span>
+        <span className="mx-0.5 h-5 w-px bg-border/70" />
+        {children}
+        <span className="mx-0.5 h-5 w-px bg-border/70" />
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={onClear}
+          title="取消选择（Esc）"
+          className="h-7 w-7"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/components/console/credential-label.tsx
+++ b/admin-ui/src/components/console/credential-label.tsx
@@ -15,23 +15,27 @@ export function CredentialLabel({
   email,
   className,
   idClassName,
+  showId = true,
 }: {
   id: number
   email?: string | null
   className?: string
   idClassName?: string
+  showId?: boolean
 }) {
   return (
     <span className={cn('inline-flex min-w-0 items-baseline gap-1.5', className)}>
-      <span
-        className={cn(
-          'console-num shrink-0 text-[0.85em] font-normal text-muted-foreground/70',
-          idClassName,
-        )}
-        title={`凭据 ID ${id} —— 日志与链路里以 #${id} 指代`}
-      >
-        #{id}
-      </span>
+      {showId && (
+        <span
+          className={cn(
+            'console-num shrink-0 text-[0.85em] font-normal text-muted-foreground/70',
+            idClassName,
+          )}
+          title={`凭据 ID ${id} —— 日志与链路里以 #${id} 指代`}
+        >
+          #{id}
+        </span>
+      )}
       <span className="min-w-0 truncate">
         {email || <span className="text-muted-foreground">未设置邮箱</span>}
       </span>

--- a/admin-ui/src/components/console/credential-label.tsx
+++ b/admin-ui/src/components/console/credential-label.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * 凭据标识：`#id` + 邮箱。
+ *
+ * 为什么把 id 摆到明面上：日志页的故障转移链路、每跳明细、批量操作的结果提示，
+ * 全都以 `#id` 称呼凭据（邮箱太长，塞不进那些紧凑位置）。但凭据行此前只显示邮箱，
+ * 于是"日志里那个 #9 是谁"得靠数据库或猜。把 id 常驻在邮箱左侧，这条线就接上了。
+ *
+ * 视觉上 id 明确从属：等宽、弱化、字号更小，邮箱仍是主读物。用等宽是因为列表视图里
+ * id 会纵向堆叠，非等宽数字会参差不齐。
+ */
+export function CredentialLabel({
+  id,
+  email,
+  className,
+  idClassName,
+}: {
+  id: number
+  email?: string | null
+  className?: string
+  idClassName?: string
+}) {
+  return (
+    <span className={cn('inline-flex min-w-0 items-baseline gap-1.5', className)}>
+      <span
+        className={cn(
+          'console-num shrink-0 text-[0.85em] font-normal text-muted-foreground/70',
+          idClassName,
+        )}
+        title={`凭据 ID ${id} —— 日志与链路里以 #${id} 指代`}
+      >
+        #{id}
+      </span>
+      <span className="min-w-0 truncate">
+        {email || <span className="text-muted-foreground">未设置邮箱</span>}
+      </span>
+    </span>
+  )
+}

--- a/admin-ui/src/components/console/credential-state.ts
+++ b/admin-ui/src/components/console/credential-state.ts
@@ -1,0 +1,266 @@
+import type { BalanceResponse, CredentialStatusItem } from '@/types/api'
+import type { RailTone } from './rail'
+
+/**
+ * 凭据状态判定 —— 凭据页「处置意图」列的大脑，也是本次重设计的签名元素。
+ *
+ * 改造前每行右侧是一个 `⋯` 菜单，8 个菜单项固定不变。这把判断责任推给了用户：
+ * 面对一个"冷却中"的凭据，得先知道冷却是什么、再在菜单里认出「解除冷却」这一项。
+ * 菜单是通用容器，它对每一行说的话都一样。
+ *
+ * 这里换成：每行状态唯一决定一个**具名动作**。冷却中就写「解除冷却」，超额禁用就写
+ * 「查看余额」，鉴权失败就写「重新登录」。界面替用户完成了那一步判断。
+ *
+ * 这个映射之所以不是通用表格模式，是因为它来自凭据这个域里真实存在的几种状态
+ * 和各自唯一的处置手段 —— 换个项目它就不成立。
+ *
+ * `⋯` 菜单保留为二级入口，只是不再是唯一入口。
+ */
+export type CredentialState =
+  | 'current' // 当前优先，正在服务
+  | 'throttled' // 账号级风控冷却中，会自行恢复
+  | 'quotaDisabled' // 因超额被禁用
+  | 'quotaExceeded' // 已超额但仍启用
+  | 'authFailed' // 鉴权 / token 失效类禁用
+  | 'suspended' // 账号封禁
+  | 'refreshFailing' // token 刷新在失败，但还没到禁用阈值
+  | 'manualDisabled' // 手动禁用
+  | 'otherDisabled' // 其他原因禁用
+  | 'healthy'
+
+/** 处置动作的语义类型，由调用方映射到具体 handler */
+export type DispositionAction =
+  | 'clearThrottle'
+  | 'viewBalance'
+  | 'relogin'
+  | 'enable'
+  | 'refreshToken'
+  | 'viewFailures'
+  | 'none'
+
+export interface CredentialDisposition {
+  state: CredentialState
+  tone: RailTone
+  /** 状态的中文说明，用于徽章 / 悬浮提示 */
+  stateLabel: string
+  /** 处置按钮文案；null 表示无需处置 */
+  actionLabel: string | null
+  action: DispositionAction
+  /** 处置按钮是否为破坏性操作 */
+  destructive?: boolean
+}
+
+/** 鉴权 / token 类禁用原因 —— 这些必须重新登录才能恢复 */
+const AUTH_REASONS = new Set([
+  'InvalidRefreshToken',
+  'TooManyRefreshFailures',
+  'InvalidConfig',
+])
+
+function isQuotaExceeded(balance?: BalanceResponse | null): boolean {
+  if (!balance) return false
+  return balance.remaining <= 0 || balance.usagePercentage >= 100
+}
+
+/**
+ * 判定一个凭据当前处于哪种状态、下一步该做什么。
+ *
+ * 判定顺序即优先级：先看"是否被禁用且为什么"，再看"是否冷却中"，最后才是软状态。
+ * 一个凭据可能同时超额且冷却，此时禁用原因更需要人处置，排在前面。
+ */
+export function getDisposition(
+  c: CredentialStatusItem,
+  balance?: BalanceResponse | null,
+  throttleRemaining = c.throttledRemainingSecs ?? 0,
+): CredentialDisposition {
+  const reason = c.disabledReason
+
+  if (c.disabled) {
+    if (reason === 'QuotaExceeded') {
+      return {
+        state: 'quotaDisabled',
+        tone: 'warn',
+        stateLabel: '已禁用 · 已超额',
+        // 超额不会自己好，但也不是"修一下就能用"——先看清余额和重置时间再决定
+        actionLabel: '查看余额',
+        action: 'viewBalance',
+      }
+    }
+    if (reason === 'Suspended') {
+      return {
+        state: 'suspended',
+        tone: 'dead',
+        stateLabel: '已禁用 · 账号封禁',
+        actionLabel: '重新登录',
+        action: 'relogin',
+      }
+    }
+    if (reason && AUTH_REASONS.has(reason)) {
+      return {
+        state: 'authFailed',
+        tone: 'dead',
+        stateLabel:
+          reason === 'InvalidRefreshToken'
+            ? '已禁用 · Token 失效'
+            : reason === 'TooManyRefreshFailures'
+              ? '已禁用 · 刷新失败过多'
+              : '已禁用 · 配置无效',
+        actionLabel: '重新登录',
+        action: 'relogin',
+      }
+    }
+    if (reason === 'TooManyFailures') {
+      return {
+        state: 'otherDisabled',
+        tone: 'dead',
+        stateLabel: '已禁用 · 失败过多',
+        // 失败原因未必是凭据本身的问题，先看失败日志再决定要不要放回去
+        actionLabel: '查看失败',
+        action: 'viewFailures',
+      }
+    }
+    if (reason === 'Manual' || !reason) {
+      return {
+        state: 'manualDisabled',
+        tone: 'dead',
+        stateLabel: reason ? '已禁用 · 手动禁用' : '已禁用',
+        actionLabel: '启用',
+        action: 'enable',
+      }
+    }
+    return {
+      state: 'otherDisabled',
+      tone: 'dead',
+      stateLabel: `已禁用 · ${reason}`,
+      actionLabel: '启用',
+      action: 'enable',
+    }
+  }
+
+  // 未禁用但在风控冷却中：会自己恢复，所以是 cool 而非 warn
+  if (throttleRemaining > 0) {
+    return {
+      state: 'throttled',
+      tone: 'cool',
+      stateLabel: '风控冷却中',
+      actionLabel: '解除冷却',
+      action: 'clearThrottle',
+    }
+  }
+
+  if (isQuotaExceeded(balance)) {
+    return {
+      state: 'quotaExceeded',
+      tone: 'warn',
+      stateLabel: '已超额（仍在调度）',
+      actionLabel: '查看余额',
+      action: 'viewBalance',
+    }
+  }
+
+  // 刷新在失败但还没到禁用阈值 —— 这是唯一能提前干预的窗口
+  if (c.refreshFailureCount > 0) {
+    return {
+      state: 'refreshFailing',
+      tone: 'warn',
+      stateLabel: `Token 刷新失败 ${c.refreshFailureCount} 次`,
+      actionLabel: '刷新 Token',
+      action: 'refreshToken',
+    }
+  }
+
+  if (c.isCurrent) {
+    return {
+      state: 'current',
+      tone: 'ok',
+      stateLabel: '当前优先',
+      actionLabel: null,
+      action: 'none',
+    }
+  }
+
+  return {
+    state: 'healthy',
+    tone: 'none',
+    stateLabel: '正常',
+    actionLabel: null,
+    action: 'none',
+  }
+}
+
+/** 状态账条的分段计数 */
+export interface CredentialCounts {
+  healthy: number
+  current: number
+  throttled: number
+  quota: number
+  dead: number
+  total: number
+}
+
+export function countByState(
+  credentials: CredentialStatusItem[],
+  balanceOf: (c: CredentialStatusItem) => BalanceResponse | null | undefined,
+): CredentialCounts {
+  const counts: CredentialCounts = {
+    healthy: 0,
+    current: 0,
+    throttled: 0,
+    quota: 0,
+    dead: 0,
+    total: credentials.length,
+  }
+  for (const c of credentials) {
+    const { state } = getDisposition(c, balanceOf(c))
+    switch (state) {
+      case 'current':
+        counts.current += 1
+        counts.healthy += 1
+        break
+      case 'healthy':
+      case 'refreshFailing':
+        counts.healthy += 1
+        break
+      case 'throttled':
+        counts.throttled += 1
+        break
+      case 'quotaExceeded':
+      case 'quotaDisabled':
+        counts.quota += 1
+        break
+      default:
+        counts.dead += 1
+    }
+  }
+  return counts
+}
+
+/** 状态账条各段对应的筛选键 */
+export type StateFilter = '' | 'healthy' | 'throttled' | 'quota' | 'dead'
+
+/** 某凭据是否命中状态筛选 */
+export function matchesStateFilter(
+  c: CredentialStatusItem,
+  balance: BalanceResponse | null | undefined,
+  filter: StateFilter,
+): boolean {
+  if (!filter) return true
+  const { state } = getDisposition(c, balance)
+  switch (filter) {
+    case 'healthy':
+      return state === 'healthy' || state === 'current' || state === 'refreshFailing'
+    case 'throttled':
+      return state === 'throttled'
+    case 'quota':
+      return state === 'quotaExceeded' || state === 'quotaDisabled'
+    case 'dead':
+      return (
+        state === 'authFailed' ||
+        state === 'suspended' ||
+        state === 'manualDisabled' ||
+        state === 'otherDisabled'
+      )
+    default:
+      return true
+  }
+}

--- a/admin-ui/src/components/console/data-table.tsx
+++ b/admin-ui/src/components/console/data-table.tsx
@@ -1,0 +1,421 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { Columns3, Check } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+import { railClass, type RailTone } from './rail'
+
+/**
+ * 运维密集表格 —— 凭据 / 日志共用。
+ *
+ * 与「卡片」形态的分工：卡片是看的，表格是做的。所以这里的每个取舍都偏向
+ * 「一屏能扫多少行」和「手不离键盘能不能走完」：
+ *
+ * - 行高 34px、字号 12.5px（`.console-table`，见 index.css）
+ * - sticky 表头，长列表滚动时列名不丢
+ * - 左侧 3px 状态色轨代替整行染色：既标状态，又不牺牲文字对比度
+ * - 行内操作 hover 才显形（`.console-row-actions`），静默时不干扰扫读
+ * - j/k 移动游标、Enter 打开详情、x 切换选中、Esc 清空
+ * - 可选列进列控制菜单并记住选择，避免 12 列硬挤出横向滚动
+ */
+export interface ConsoleColumn<T> {
+  id: string
+  header: string
+  cell: (row: T) => ReactNode
+  /** 默认隐藏，需要时从列控制菜单里打开 */
+  optional?: boolean
+  /** 数值列右对齐，配合 .console-num 做纵向对齐 */
+  align?: 'right'
+  /** 表头 title 提示 */
+  hint?: string
+}
+
+export interface ConsoleTableProps<T> {
+  rows: T[]
+  columns: ConsoleColumn<T>[]
+  rowKey: (row: T) => number | string
+  /** 行状态 → 左侧色轨；不给则无轨 */
+  tone?: (row: T) => RailTone
+  /** 开启行选中（复选框列 + x 键） */
+  selectable?: boolean
+  selected?: Set<number | string>
+  onSelectedChange?: (next: Set<number | string>) => void
+  /** 点击行 / 按 Enter 触发，通常用来开详情抽屉 */
+  onRowActivate?: (row: T) => void
+  /** 行右侧的处置动作，hover / 游标行才显形 */
+  rowActions?: (row: T) => ReactNode
+  /** 列可见性持久化 key；不给则不显示列控制菜单 */
+  columnsStorageKey?: string
+  loading?: boolean
+  empty?: ReactNode
+  /** 表格上方右侧的额外控件（与列控制菜单同一行） */
+  toolbar?: ReactNode
+}
+
+/** 列可见性：默认隐藏 optional 列，选择记到 localStorage */
+function useColumnVisibility<T>(
+  columns: ConsoleColumn<T>[],
+  storageKey?: string,
+) {
+  const defaults = useMemo(
+    () => columns.filter((c) => !c.optional).map((c) => c.id),
+    [columns],
+  )
+
+  const [visible, setVisible] = useState<string[]>(() => {
+    if (!storageKey) return defaults
+    try {
+      const raw = localStorage.getItem(storageKey)
+      if (!raw) return defaults
+      const parsed = JSON.parse(raw) as string[]
+      // 与当前列定义求交集：列改名 / 删除后不会残留脏 id
+      const known = new Set(columns.map((c) => c.id))
+      const kept = parsed.filter((id) => known.has(id))
+      return kept.length > 0 ? kept : defaults
+    } catch {
+      return defaults
+    }
+  })
+
+  const toggle = useCallback(
+    (id: string) => {
+      setVisible((prev) => {
+        const next = prev.includes(id)
+          ? prev.filter((x) => x !== id)
+          : [...prev, id]
+        // 至少留一列，否则表格退化成空壳
+        if (next.length === 0) return prev
+        if (storageKey) {
+          try {
+            localStorage.setItem(storageKey, JSON.stringify(next))
+          } catch {
+            /* 隐私模式下 localStorage 可能不可写，忽略 */
+          }
+        }
+        return next
+      })
+    },
+    [storageKey],
+  )
+
+  // 按列定义原顺序输出，不受用户勾选顺序影响
+  const ordered = useMemo(
+    () => columns.filter((c) => visible.includes(c.id)),
+    [columns, visible],
+  )
+
+  return { ordered, visible, toggle }
+}
+
+/**
+ * 键盘导航：j/k 移动游标、Enter 激活、x 切换选中、Esc 清空选中。
+ *
+ * 只在表格容器获得焦点（或焦点在表格内）时生效，且输入框内不劫持按键 ——
+ * 否则用户在搜索框里打 "j" 会意外跳行。
+ */
+function useRowKeyboard<T>(opts: {
+  rows: T[]
+  rowKey: (row: T) => number | string
+  cursor: number
+  setCursor: (n: number) => void
+  onRowActivate?: (row: T) => void
+  selectable?: boolean
+  selected?: Set<number | string>
+  onSelectedChange?: (next: Set<number | string>) => void
+}) {
+  const {
+    rows,
+    rowKey,
+    cursor,
+    setCursor,
+    onRowActivate,
+    selectable,
+    selected,
+    onSelectedChange,
+  } = opts
+
+  return useCallback(
+    (e: React.KeyboardEvent) => {
+      const target = e.target as HTMLElement
+      // 输入类控件内不劫持按键
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return
+      }
+      if (rows.length === 0) return
+
+      const move = (delta: number) => {
+        e.preventDefault()
+        const next = Math.min(Math.max(cursor + delta, 0), rows.length - 1)
+        setCursor(next)
+      }
+
+      switch (e.key) {
+        case 'j':
+        case 'ArrowDown':
+          move(1)
+          break
+        case 'k':
+        case 'ArrowUp':
+          move(-1)
+          break
+        case 'Enter':
+          if (cursor >= 0 && rows[cursor] && onRowActivate) {
+            e.preventDefault()
+            onRowActivate(rows[cursor])
+          }
+          break
+        case 'x':
+          if (selectable && cursor >= 0 && rows[cursor] && onSelectedChange) {
+            e.preventDefault()
+            const key = rowKey(rows[cursor])
+            const next = new Set(selected ?? [])
+            if (next.has(key)) next.delete(key)
+            else next.add(key)
+            onSelectedChange(next)
+          }
+          break
+        case 'Escape':
+          if (selectable && onSelectedChange && (selected?.size ?? 0) > 0) {
+            e.preventDefault()
+            onSelectedChange(new Set())
+          }
+          break
+      }
+    },
+    [
+      rows,
+      rowKey,
+      cursor,
+      setCursor,
+      onRowActivate,
+      selectable,
+      selected,
+      onSelectedChange,
+    ],
+  )
+}
+
+export function ConsoleTable<T>({
+  rows,
+  columns,
+  rowKey,
+  tone,
+  selectable = false,
+  selected,
+  onSelectedChange,
+  onRowActivate,
+  rowActions,
+  columnsStorageKey,
+  loading = false,
+  empty,
+  toolbar,
+}: ConsoleTableProps<T>) {
+  const { ordered, visible, toggle } = useColumnVisibility(
+    columns,
+    columnsStorageKey,
+  )
+  const [cursor, setCursor] = useState(-1)
+  const bodyRef = useRef<HTMLTableSectionElement | null>(null)
+
+  // 行数变化后把游标夹回合法范围，而不是复位。
+  //
+  // 依赖 rows.length 而非 rows：rows 通常是 `data?.records ?? []`，每次渲染都是新的
+  // 数组标识，用它做依赖会让游标被反复清零——30 秒自动刷新一到，j/k 走到哪就丢在哪。
+  // 夹取还顺带处理了列表变短（筛选收紧、记录被删）时游标越界的情况。
+  useEffect(() => {
+    setCursor((prev) => (prev < 0 ? prev : Math.min(prev, rows.length - 1)))
+  }, [rows.length])
+
+  // 游标移动时把行滚进视野
+  useEffect(() => {
+    if (cursor < 0 || !bodyRef.current) return
+    const tr = bodyRef.current.children[cursor] as HTMLElement | undefined
+    tr?.scrollIntoView({ block: 'nearest' })
+  }, [cursor])
+
+  const onKeyDown = useRowKeyboard({
+    rows,
+    rowKey,
+    cursor,
+    setCursor,
+    onRowActivate,
+    selectable,
+    selected,
+    onSelectedChange,
+  })
+
+  const allSelected =
+    rows.length > 0 && rows.every((r) => selected?.has(rowKey(r)))
+
+  const toggleAll = () => {
+    if (!onSelectedChange) return
+    const next = new Set(selected ?? [])
+    if (allSelected) rows.forEach((r) => next.delete(rowKey(r)))
+    else rows.forEach((r) => next.add(rowKey(r)))
+    onSelectedChange(next)
+  }
+
+  const toggleOne = (key: number | string) => {
+    if (!onSelectedChange) return
+    const next = new Set(selected ?? [])
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    onSelectedChange(next)
+  }
+
+  const hasHiddenOption = columns.some((c) => c.optional)
+
+  return (
+    <div className="console-scope space-y-2">
+      {(toolbar || (columnsStorageKey && hasHiddenOption)) && (
+        <div className="flex items-center justify-end gap-2">
+          {toolbar}
+          {columnsStorageKey && hasHiddenOption && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm" variant="outline" title="选择显示的列">
+                  <Columns3 className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">列</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuLabel>显示的列</DropdownMenuLabel>
+                {columns.map((c) => (
+                  <DropdownMenuItem
+                    key={c.id}
+                    onSelect={(e) => {
+                      e.preventDefault()
+                      toggle(c.id)
+                    }}
+                    className="gap-2"
+                  >
+                    <span className="flex h-4 w-4 items-center justify-center">
+                      {visible.includes(c.id) && <Check className="h-3.5 w-3.5" />}
+                    </span>
+                    <span>{c.header}</span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      )}
+
+      <div
+        className="overflow-x-auto rounded-xl border border-border/60 bg-card/80 backdrop-blur-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        role="group"
+        aria-label="数据表格，j / k 移动，Enter 查看详情"
+      >
+        <table className="console-table">
+          <thead>
+            <tr>
+              {selectable && (
+                <th className="w-9 pl-3">
+                  <Checkbox
+                    checked={allSelected}
+                    onCheckedChange={toggleAll}
+                    aria-label="全选当前页"
+                  />
+                </th>
+              )}
+              {ordered.map((c) => (
+                <th
+                  key={c.id}
+                  title={c.hint}
+                  className={c.align === 'right' ? 'text-right' : undefined}
+                >
+                  {c.header}
+                </th>
+              ))}
+              {rowActions && <th className="w-px" />}
+            </tr>
+          </thead>
+          <tbody ref={bodyRef}>
+            {rows.map((row, i) => {
+              const key = rowKey(row)
+              const isSelected = selected?.has(key) ?? false
+              return (
+                <tr
+                  key={key}
+                  data-selected={isSelected || undefined}
+                  data-cursor={cursor === i || undefined}
+                  className={cn(onRowActivate && 'cursor-pointer')}
+                  onClick={() => {
+                    setCursor(i)
+                    onRowActivate?.(row)
+                  }}
+                >
+                  {selectable && (
+                    <td
+                      className={cn('pl-3', tone && railClass(tone(row)))}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Checkbox
+                        checked={isSelected}
+                        onCheckedChange={() => toggleOne(key)}
+                        aria-label="选中此行"
+                      />
+                    </td>
+                  )}
+                  {ordered.map((c, ci) => (
+                    <td
+                      key={c.id}
+                      className={cn(
+                        c.align === 'right' && 'text-right',
+                        // 无复选框列时，色轨落在第一个数据列上
+                        !selectable && ci === 0 && tone && railClass(tone(row)),
+                      )}
+                    >
+                      {c.cell(row)}
+                    </td>
+                  ))}
+                  {rowActions && (
+                    <td
+                      className="pr-3 text-right"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <div className="console-row-actions flex items-center justify-end gap-1">
+                        {rowActions(row)}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+
+        {loading && rows.length === 0 && (
+          <div className="p-6 text-center text-[13px] text-muted-foreground">
+            加载中…
+          </div>
+        )}
+        {!loading && rows.length === 0 && (
+          <div className="p-8 text-center text-[13px] text-muted-foreground">
+            {empty ?? '没有匹配的记录'}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/components/console/detail-drawer.tsx
+++ b/admin-ui/src/components/console/detail-drawer.tsx
@@ -1,0 +1,118 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * 右侧详情抽屉。
+ *
+ * 替掉日志页的「展开行」：展开会把表格行高从 34px 顶到几百 px，下方所有行
+ * 位置突变，滚动位置随之跳一下 —— 想对比相邻两条记录时尤其难受。抽屉把详情
+ * 移到侧面，表格布局始终稳定，左侧列表和右侧详情能同时看。
+ *
+ * 基于 Radix Dialog：焦点陷阱、Esc 关闭、滚动锁都是现成的，只把定位从居中
+ * 改成贴右侧全高。
+ */
+export function DetailDrawer({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  children,
+  footer,
+  width = 'max-w-xl',
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: React.ReactNode
+  subtitle?: React.ReactNode
+  children: React.ReactNode
+  footer?: React.ReactNode
+  /** tailwind 宽度类 */
+  width?: string
+}) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/25 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          className={cn(
+            'console-drawer console-scope fixed right-0 top-0 z-50 flex h-full w-[calc(100%-1.5rem)] flex-col border-l border-border/60 bg-card/95 shadow-apple-lg backdrop-blur-2xl backdrop-saturate-150',
+            width,
+          )}
+        >
+          <div className="flex items-start gap-3 border-b border-border/60 px-4 py-3">
+            <div className="min-w-0 flex-1">
+              <DialogPrimitive.Title className="truncate text-[15px] font-semibold tracking-tight">
+                {title}
+              </DialogPrimitive.Title>
+              {subtitle && (
+                <DialogPrimitive.Description className="mt-0.5 truncate text-xs text-muted-foreground">
+                  {subtitle}
+                </DialogPrimitive.Description>
+              )}
+            </div>
+            <DialogPrimitive.Close
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-secondary/80 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              title="关闭（Esc）"
+            >
+              <X className="h-3.5 w-3.5" />
+              <span className="sr-only">关闭</span>
+            </DialogPrimitive.Close>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">{children}</div>
+
+          {footer && (
+            <div className="flex items-center justify-end gap-2 border-t border-border/60 px-4 py-3">
+              {footer}
+            </div>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}
+
+/** 抽屉内的键值明细行 —— 详情面板的基本排版单元 */
+export function DrawerField({
+  label,
+  children,
+  mono = false,
+}: {
+  label: string
+  children: React.ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1.5 text-[13px]">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span className={cn('min-w-0 text-right', mono && 'console-num')}>
+        {children}
+      </span>
+    </div>
+  )
+}
+
+/** 抽屉内的分区标题 */
+export function DrawerSection({
+  title,
+  children,
+  trailing,
+}: {
+  title: string
+  children: React.ReactNode
+  trailing?: React.ReactNode
+}) {
+  return (
+    <section className="py-2">
+      <div className="mb-1.5 flex items-center gap-2">
+        <h4 className="text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+          {title}
+        </h4>
+        <span className="h-px flex-1 bg-border/60" />
+        {trailing}
+      </div>
+      {children}
+    </section>
+  )
+}

--- a/admin-ui/src/components/console/priority-preview.tsx
+++ b/admin-ui/src/components/console/priority-preview.tsx
@@ -1,0 +1,88 @@
+import { useCredentials } from '@/hooks/use-credentials'
+
+/**
+ * 优先级编辑时的队列位置预览 —— 优先级这件事的签名元素。
+ *
+ * 要解决的困惑很具体：面对一个写着 `0` 的输入框，用户无法判断改成 `5` 是让这个号
+ * 更早还是更晚被用到。界面从头到尾没说过方向。
+ *
+ * 常规做法是在标签上补一句「（数字越小越优先）」。但那只是把规则背给用户听，而且
+ * 每一行都要重复一遍；用户仍然得自己在脑子里把规则套到当前这堆数字上，才知道
+ * 「我这个 5 到底排第几」。
+ *
+ * 这里换个路子：不解释规则，直接显示后果。输入 5 的当下就告诉他「排在 bob@x.com
+ * 之后 · 第 3 / 8 位」。方向感是从相邻是谁里读出来的，不需要先理解规则。
+ *
+ * 排序口径与后端 `select_by_priority` 对齐：priority 升序，同值再按 id 升序。
+ * 已禁用的凭据不参与调度，因此不计入队列。
+ */
+
+/** 邻居的展示名。与凭据行一致地带上 #id，指认的是同一个东西。 */
+function label(email: string | undefined, id: number): string {
+  return email ? `#${id} ${email}` : `#${id}`
+}
+
+export function PriorityPreview({
+  credentialId,
+  draft,
+  disabled,
+}: {
+  credentialId: number
+  /** 输入框里的原始字符串，未必是合法数字 */
+  draft: string
+  /** 该凭据当前是否已禁用 */
+  disabled: boolean
+}) {
+  // 读 react-query 缓存里的凭据全集（与列表同一个 queryKey，不会额外发请求）
+  const { data } = useCredentials()
+
+  const n = Number(draft)
+  if (draft.trim() === '' || !Number.isInteger(n) || n < 0) {
+    return (
+      <span className="text-[11px] text-muted-foreground">
+        填 0 或更大的整数
+      </span>
+    )
+  }
+
+  if (disabled) {
+    return (
+      <span className="text-[11px] text-muted-foreground">
+        已禁用，暂不参与排队
+      </span>
+    )
+  }
+
+  const all = data?.credentials ?? []
+  // 把草稿值套进去重排，算出这次改动之后它落在第几位
+  const queue = all
+    .filter((c) => !c.disabled)
+    .map((c) => (c.id === credentialId ? { ...c, priority: n } : c))
+    .sort((a, b) => a.priority - b.priority || a.id - b.id)
+
+  const idx = queue.findIndex((c) => c.id === credentialId)
+  if (idx < 0) {
+    return null
+  }
+
+  const prev = queue[idx - 1]
+  const ahead = idx // 排在它前面的个数
+
+  return (
+    <span className="text-[11px] leading-tight text-muted-foreground">
+      {ahead === 0 ? (
+        <span className="font-medium text-emerald-600 dark:text-emerald-400">
+          最先使用
+        </span>
+      ) : (
+        <>
+          排在 <span className="text-foreground">{label(prev.email, prev.id)}</span>{' '}
+          之后
+        </>
+      )}
+      <span className="mx-1 text-muted-foreground/50">·</span>
+      第 <span className="console-num text-foreground">{idx + 1}</span> /{' '}
+      <span className="console-num">{queue.length}</span> 位
+    </span>
+  )
+}

--- a/admin-ui/src/components/console/rail.ts
+++ b/admin-ui/src/components/console/rail.ts
@@ -1,0 +1,96 @@
+/**
+ * 状态色轨 —— 凭据行 / 日志行 / 设置项共用的一套异常语言。
+ *
+ * 设计前提：异常在三个页面里必须是同一个视觉信号，否则用户要为每个页面
+ * 重新学一遍配色。四档的划分不是随意的深浅，每档对应一种**处置期待**：
+ *
+ * - `ok`   健康，无需处置
+ * - `warn` 需要人介入，且不会自行恢复（超额、额度耗尽）
+ * - `cool` 会自行恢复，等待即可（账号级风控冷却）
+ * - `dead` 已失效，必须处置才能复用（鉴权失败、禁用、网络错误）
+ *
+ * `warn` 与 `cool` 分色的信息量就在这里：橙色代表"等它自己好"，
+ * 琥珀代表"你得去做点什么"。CSS 变量定义见 index.css 的 `--rail-*`。
+ */
+export type RailTone = 'ok' | 'warn' | 'cool' | 'dead' | 'none'
+
+const RAIL_CLASS: Record<RailTone, string> = {
+  ok: 'console-rail rail-ok',
+  warn: 'console-rail rail-warn',
+  cool: 'console-rail rail-cool',
+  dead: 'console-rail rail-dead',
+  none: '',
+}
+
+/** 色轨 class（用在 `<tr>` 的首个 `<td>` 或整行容器上） */
+export function railClass(tone: RailTone): string {
+  return RAIL_CLASS[tone]
+}
+
+const BORDER_CLASS: Record<RailTone, string> = {
+  ok: 'border-l-[3px] border-l-emerald-500',
+  warn: 'border-l-[3px] border-l-amber-500',
+  cool: 'border-l-[3px] border-l-orange-500',
+  dead: 'border-l-[3px] border-l-red-500',
+  none: 'border-l-[3px] border-l-transparent',
+}
+
+/**
+ * 色轨的 border 变体。
+ *
+ * `.console-rail` 走 inset box-shadow，在表格单元格里最省事；但用在已经带 `ring-1`
+ * 的容器上会打架 —— ring 也是 box-shadow 实现的，两者互相覆盖。这个变体用 border-left，
+ * 与 ring 可以共存。凭据列表行用它，表格单元格用 `railClass`。
+ */
+export function railBorderClass(tone: RailTone): string {
+  return BORDER_CLASS[tone]
+}
+
+const DOT_CLASS: Record<RailTone, string> = {
+  ok: 'bg-emerald-500',
+  warn: 'bg-amber-500',
+  cool: 'bg-orange-500',
+  dead: 'bg-red-500',
+  none: 'bg-muted-foreground/40',
+}
+
+/** 同一语义的圆点色（用于紧凑位置，如链路节点） */
+export function railDotClass(tone: RailTone): string {
+  return DOT_CLASS[tone]
+}
+
+const TEXT_CLASS: Record<RailTone, string> = {
+  ok: 'text-emerald-600 dark:text-emerald-400',
+  warn: 'text-amber-600 dark:text-amber-400',
+  cool: 'text-orange-600 dark:text-orange-400',
+  dead: 'text-red-600 dark:text-red-400',
+  none: 'text-muted-foreground',
+}
+
+/** 同一语义的文字色 */
+export function railTextClass(tone: RailTone): string {
+  return TEXT_CLASS[tone]
+}
+
+/**
+ * 日志失败分类 → 色轨。与 trace 的 `outcome` / `errorType` 取值对齐。
+ */
+export function outcomeTone(outcome: string): RailTone {
+  switch (outcome) {
+    case 'success':
+      return 'ok'
+    case 'quota_exhausted':
+    case 'stream_interrupted':
+      return 'warn'
+    case 'account_throttled':
+      return 'cool'
+    case 'auth_failed':
+    case 'network_error':
+    case 'bad_request':
+      return 'dead'
+    case 'transient':
+      return 'none'
+    default:
+      return 'none'
+  }
+}

--- a/admin-ui/src/components/console/rail.ts
+++ b/admin-ui/src/components/console/rail.ts
@@ -59,6 +59,24 @@ export function railDotClass(tone: RailTone): string {
   return DOT_CLASS[tone]
 }
 
+const CHIP_CLASS: Record<RailTone, string> = {
+  ok: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+  warn: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  cool: 'border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-400',
+  dead: 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
+  none: 'border-border bg-secondary/60 text-muted-foreground',
+}
+
+/**
+ * 色轨的「实心块」变体：淡底 + 同色描边 + 同色文字。
+ *
+ * 存在的理由是尺度而非样式 —— 3px 的左边框在网格卡片里太细，扫读时得聚焦才能读出
+ * 状态。同一个 tone 在边框、序号章、余额条上各出现一次，眼睛在任一尺度上都能接住。
+ */
+export function railChipClass(tone: RailTone): string {
+  return CHIP_CLASS[tone]
+}
+
 const TEXT_CLASS: Record<RailTone, string> = {
   ok: 'text-emerald-600 dark:text-emerald-400',
   warn: 'text-amber-600 dark:text-amber-400',

--- a/admin-ui/src/components/console/setting-row.tsx
+++ b/admin-ui/src/components/console/setting-row.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Check, Loader2 } from 'lucide-react'
+import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+/**
+ * 设置行原语 —— 设置页所有配置项的唯一排版与保存范式。
+ *
+ * 现状的问题不是"设置藏得深"，而是**保存语义不一致**：顶栏下拉里，开关是点了
+ * 立即生效、预设按钮是点了立即生效、数字输入却要再点一个「保存」；而反馈全靠
+ * toast 转述，行内看不出这条改没改成。同一个面板里三种保存方式，手感自然是断的。
+ *
+ * 这里统一成一条规则：**所有配置即时保存，状态显示在它自己那一行**。
+ * - 开关 / 分段选择：点击即提交
+ * - 数字 / 文本：失焦或 Enter 提交，Esc 撤回；不再有独立保存按钮
+ * - 提交中行尾转圈，成功后打勾停留 1.5s
+ *
+ * 于是 toast 只用于报错。成功不需要弹窗告知 —— 行内那个勾已经说完了。
+ */
+export function SettingRow({
+  label,
+  hint,
+  children,
+  pending,
+  saved,
+  disabled,
+  className,
+}: {
+  label: string
+  hint?: React.ReactNode
+  children: React.ReactNode
+  pending?: boolean
+  saved?: boolean
+  disabled?: boolean
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-start justify-between gap-x-4 gap-y-2 border-b border-border/50 py-3 last:border-b-0',
+        disabled && 'opacity-55',
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1 basis-56">
+        <div className="flex items-center gap-1.5 text-[13.5px] font-medium">
+          {label}
+          {pending && (
+            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+          )}
+          {!pending && saved && (
+            <Check className="h-3.5 w-3.5 text-emerald-500" />
+          )}
+        </div>
+        {hint && (
+          <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+            {hint}
+          </p>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">{children}</div>
+    </div>
+  )
+}
+
+/**
+ * 按字段追踪保存态。
+ *
+ * 一个分区通常只有一个 mutation（比如自愈的 4 个字段都走 `useSetSelfHealConfig`），
+ * 它的 `isPending` 是**分区级**的。直接把它铺给每一行会造成两个假象：改一个开关时
+ * 同分区其余行也跟着转圈、跟着打勾 —— 5 行都宣称自己保存了，实际只有 1 行。
+ *
+ * 这里用 `Set` 而不是单个"当前字段"变量：同分区连着改两个字段时（先切开关、紧接着
+ * 改数字），单变量会被后者覆盖，等前者结算时会把仍在飞行中的后者的转圈错误地清掉。
+ *
+ * 打勾只挂在 `onSuccess`：失败时不该出现成功标记，报错交给 toast。
+ */
+export function useFieldSaver<TVars>(
+  mutate: (
+    vars: TVars,
+    opts: { onSuccess?: () => void; onError?: (err: unknown) => void },
+  ) => void,
+  onError: (err: unknown) => void,
+) {
+  const [saving, setSaving] = useState<Set<string>>(new Set())
+  const [saved, setSaved] = useState<Set<string>>(new Set())
+  // 卸载后不再 setState，也避免残留的定时器
+  const timers = useRef<number[]>([])
+  useEffect(
+    () => () => {
+      timers.current.forEach((t) => window.clearTimeout(t))
+    },
+    [],
+  )
+
+  const mark = (set: Set<string>, field: string, on: boolean) => {
+    const next = new Set(set)
+    if (on) next.add(field)
+    else next.delete(field)
+    return next
+  }
+
+  const save = useCallback(
+    (field: string, vars: TVars) => {
+      setSaving((s) => mark(s, field, true))
+      mutate(vars, {
+        onSuccess: () => {
+          setSaving((s) => mark(s, field, false))
+          setSaved((s) => mark(s, field, true))
+          const t = window.setTimeout(() => {
+            setSaved((s) => mark(s, field, false))
+          }, 1500)
+          timers.current.push(t)
+        },
+        onError: (err) => {
+          setSaving((s) => mark(s, field, false))
+          onError(err)
+        },
+      })
+    },
+    [mutate, onError],
+  )
+
+  return {
+    save,
+    isSaving: (field: string) => saving.has(field),
+    isSaved: (field: string) => saved.has(field),
+    /** 分区内是否有任何字段在保存中（用于整区禁用） */
+    busy: saving.size > 0,
+  }
+}
+
+/** 开关型设置：点击即提交 */
+export function SettingSwitch({
+  label,
+  hint,
+  checked,
+  onChange,
+  pending,
+  saved,
+  disabled,
+}: {
+  label: string
+  hint?: React.ReactNode
+  checked: boolean
+  onChange: (next: boolean) => void
+  pending?: boolean
+  /** 该字段刚保存成功（由 useFieldSaver 按字段给出），不是分区级状态 */
+  saved?: boolean
+  disabled?: boolean
+}) {
+  return (
+    <SettingRow label={label} hint={hint} pending={pending} saved={saved}>
+      <Switch
+        checked={checked}
+        disabled={disabled || pending}
+        onCheckedChange={onChange}
+        aria-label={label}
+      />
+    </SettingRow>
+  )
+}
+
+/**
+ * 数值型设置：失焦 / Enter 提交，Esc 撤回。
+ *
+ * 不设保存按钮是有意的 —— 一个数字输入配一个按钮，等于把"我改完了"这件
+ * 本来就明确的事再确认一遍。越界时不提交并回弹到上次有效值。
+ */
+export function SettingNumber({
+  label,
+  hint,
+  value,
+  onCommit,
+  min,
+  max,
+  unit,
+  pending,
+  saved,
+  disabled,
+  presets,
+  /** 展示值转换（如秒 → 分钟） */
+  toDisplay = (v) => v,
+  fromDisplay = (v) => v,
+}: {
+  label: string
+  hint?: React.ReactNode
+  value: number
+  onCommit: (next: number) => void
+  min: number
+  max: number
+  unit?: string
+  pending?: boolean
+  /** 该字段刚保存成功（由 useFieldSaver 按字段给出） */
+  saved?: boolean
+  disabled?: boolean
+  /** 常用值快捷按钮，单位与展示值一致 */
+  presets?: number[]
+  toDisplay?: (raw: number) => number
+  fromDisplay?: (display: number) => number
+}) {
+  const display = toDisplay(value)
+  const [draft, setDraft] = useState(String(display))
+  const [invalid, setInvalid] = useState(false)
+
+  // 外部值变化（他处修改 / 刷新）时同步草稿
+  useEffect(() => {
+    setDraft(String(display))
+    setInvalid(false)
+  }, [display])
+
+  const commit = () => {
+    const n = Number(draft)
+    if (!Number.isFinite(n) || n < min || n > max) {
+      setInvalid(true)
+      setDraft(String(display))
+      window.setTimeout(() => setInvalid(false), 1200)
+      return
+    }
+    if (n === display) return
+    onCommit(fromDisplay(n))
+  }
+
+  return (
+    <SettingRow label={label} hint={hint} pending={pending} saved={saved}>
+      {presets && presets.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1">
+          {presets.map((p) => (
+            <Button
+              key={p}
+              size="sm"
+              variant={display === p ? 'default' : 'outline'}
+              className="h-7 px-2 text-xs"
+              disabled={disabled || pending}
+              onClick={() => {
+                if (display !== p) onCommit(fromDisplay(p))
+              }}
+            >
+              {p}
+            </Button>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-1.5">
+        <Input
+          type="number"
+          min={min}
+          max={max}
+          value={draft}
+          disabled={disabled || pending}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.currentTarget.blur()
+            } else if (e.key === 'Escape') {
+              setDraft(String(display))
+              e.currentTarget.blur()
+            }
+          }}
+          className={cn(
+            'console-num h-8 w-20 text-right text-[13px]',
+            invalid && 'border-destructive focus-visible:border-destructive',
+          )}
+          title={`${min} ~ ${max}`}
+        />
+        {unit && (
+          <span className="text-xs text-muted-foreground">{unit}</span>
+        )}
+      </div>
+    </SettingRow>
+  )
+}
+
+/** 分段选择：点击即提交，适合 2~4 个互斥选项 */
+export function SettingSegments<T extends string>({
+  label,
+  hint,
+  value,
+  options,
+  onChange,
+  pending,
+  saved,
+  disabled,
+}: {
+  label: string
+  hint?: React.ReactNode
+  value: T
+  options: { value: T; label: string; hint?: string }[]
+  onChange: (next: T) => void
+  pending?: boolean
+  /** 该字段刚保存成功（由 useFieldSaver 按字段给出） */
+  saved?: boolean
+  disabled?: boolean
+}) {
+  return (
+    <SettingRow label={label} hint={hint} pending={pending} saved={saved}>
+      <div className="inline-flex h-8 items-center rounded-full border border-border bg-card/60 p-0.5">
+        {options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            title={o.hint}
+            disabled={disabled || pending}
+            aria-pressed={value === o.value}
+            onClick={() => {
+              if (value !== o.value) onChange(o.value)
+            }}
+            className={cn(
+              'inline-flex h-7 items-center rounded-full px-3 text-[12.5px] transition-colors disabled:opacity-50',
+              value === o.value
+                ? 'bg-background text-foreground shadow-apple-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </SettingRow>
+  )
+}
+
+/** 只读观测行：展示运行时状态，不可编辑 */
+export function SettingReadout({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <SettingRow label={label} hint={hint}>
+      <span className="console-num text-[13px] text-muted-foreground">
+        {children}
+      </span>
+    </SettingRow>
+  )
+}
+
+/** 设置分区容器 */
+export function SettingGroup({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description?: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="console-scope">
+      <div className="mb-1">
+        <h3 className="text-[15px] font-semibold tracking-tight">{title}</h3>
+        {description && (
+          <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <div>{children}</div>
+    </section>
+  )
+}

--- a/admin-ui/src/components/console/status-strip.tsx
+++ b/admin-ui/src/components/console/status-strip.tsx
@@ -1,0 +1,130 @@
+import { cn } from '@/lib/utils'
+import { railDotClass, type RailTone } from './rail'
+
+/**
+ * 状态标签条 —— 凭据列表的表头兼筛选器。
+ *
+ * 两轮设计的经过值得记一下。最初把顶部三张大数字统计卡换成了一条 28px 的细账条，
+ * 省下约 140px 首屏。但省过头了：这一页最主要的筛选控件被做成了 12.5px 的说明文字，
+ * 看上去像图注而不是可点的东西；而且它待在标题下方，与它筛选的那个列表之间还隔着
+ * 两行工具栏 —— 想按状态过滤的人未必会想到去点它。
+ *
+ * 现在改成贴着列表的标签页：
+ * - **紧邻**：它就是列表的表头，中间不再隔任何东西，改哪个数字影响哪片区域一目了然
+ * - **显眼**：34px 行高、计数用 15px 半粗等宽，激活项带底边线；标签页这个形状本身
+ *   就在说"我是切换视图的"，不需要额外提示
+ * - 底边线用该状态的色轨色：选中「冷却」时，下面那些行的左侧橙色轨与上面的橙色底线
+ *   是同一个信号，颜色把表头和它筛出来的行系在一起
+ *
+ * 补了一个「全部」标签。原先靠"再点一次激活项来取消"，那是个藏起来的操作 ——
+ * 用户看不出还能退回全集。
+ */
+export interface StatusSegment {
+  /** 段标签，如「可用」「冷却」 */
+  label: string
+  count: number
+  tone: RailTone
+  /** 点击后的筛选动作；不给则该段不可点 */
+  onClick?: () => void
+  /** 该段当前是否为激活的筛选条件 */
+  active?: boolean
+  hint?: string
+}
+
+/** 激活项底边线用色轨色，与被筛出的行左侧色轨对应 */
+const ACTIVE_BORDER: Record<RailTone, string> = {
+  ok: 'border-emerald-500',
+  warn: 'border-amber-500',
+  cool: 'border-orange-500',
+  dead: 'border-red-500',
+  none: 'border-primary',
+}
+
+export function StatusStrip({
+  segments,
+  className,
+  trailing,
+}: {
+  segments: StatusSegment[]
+  className?: string
+  /** 右侧附加内容（如调度模式、总数） */
+  trailing?: React.ReactNode
+}) {
+  // 计数为 0 的状态也保留：'冷却 0' 本身是有用的信息（当前没有被风控的号），
+  // 而标签忽隐忽现会让这一行的位置不停跳动。
+  return (
+    <div
+      className={cn(
+        'console-scope flex flex-wrap items-end gap-x-0.5 gap-y-1 border-b border-border/60',
+        className,
+      )}
+    >
+      {segments.map((s) => {
+        const clickable = !!s.onClick
+        const inner = (
+          <>
+            {s.tone !== 'none' && (
+              <span
+                className={cn(
+                  'h-1.5 w-1.5 shrink-0 rounded-full',
+                  railDotClass(s.tone),
+                  // 非激活且为 0 时弱化圆点，避免一排彩点抢注意力
+                  !s.active && s.count === 0 && 'opacity-40',
+                )}
+              />
+            )}
+            <span>{s.label}</span>
+            <span
+              className={cn(
+                'console-num text-[15px] font-semibold leading-none',
+                s.active
+                  ? 'text-foreground'
+                  : s.count === 0
+                    ? 'text-muted-foreground/50'
+                    : 'text-foreground/80',
+              )}
+            >
+              {s.count}
+            </span>
+          </>
+        )
+
+        if (!clickable) {
+          return (
+            <span
+              key={s.label}
+              title={s.hint}
+              className="inline-flex h-[34px] items-center gap-1.5 border-b-2 border-transparent px-3 text-[13px] text-muted-foreground"
+            >
+              {inner}
+            </span>
+          )
+        }
+
+        return (
+          <button
+            key={s.label}
+            type="button"
+            onClick={s.onClick}
+            title={s.hint}
+            aria-pressed={s.active}
+            className={cn(
+              'inline-flex h-[34px] items-center gap-1.5 border-b-2 px-3 text-[13px] transition-colors',
+              '-mb-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40',
+              s.active
+                ? cn('font-medium text-foreground', ACTIVE_BORDER[s.tone])
+                : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground',
+            )}
+          >
+            {inner}
+          </button>
+        )
+      })}
+      {trailing && (
+        <div className="ml-auto flex items-center gap-2 self-center pb-1 pl-2">
+          {trailing}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/admin-ui/src/components/console/status-strip.tsx
+++ b/admin-ui/src/components/console/status-strip.tsx
@@ -2,13 +2,10 @@ import { cn } from '@/lib/utils'
 import { railDotClass, type RailTone } from './rail'
 
 export interface StatusSegment {
-  /** 段标签，如「可用」「冷却」 */
   label: string
   count: number
   tone: RailTone
-  /** 点击后的筛选动作；不给则该段不可点 */
   onClick?: () => void
-  /** 该段当前是否为激活的筛选条件 */
   active?: boolean
   hint?: string
 }
@@ -20,44 +17,34 @@ export function StatusStrip({
 }: {
   segments: StatusSegment[]
   className?: string
-  /** 右侧附加内容（如调度模式、总数） */
   trailing?: React.ReactNode
 }) {
   return (
     <div
       className={cn(
-        'console-scope flex flex-wrap items-center justify-between gap-3 py-1',
+        'console-scope flex flex-wrap items-center justify-between gap-3',
         className,
       )}
     >
-      {/* 现代 Apple / Shadcn 极简分段控制卡片 (Segmented Control Bar) */}
-      <div className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-xl border border-border/50 bg-muted/40 p-1 backdrop-blur-sm">
+      <div className="flex max-w-full flex-wrap items-center gap-2">
         {segments.map((s) => {
           const clickable = !!s.onClick
+
           const inner = (
             <>
               {s.tone !== 'none' && (
                 <span
                   className={cn(
-                    'h-2 w-2 shrink-0 rounded-full transition-transform',
-                    railDotClass(s.tone),
-                    !s.active && s.count === 0 && 'opacity-40',
+                    'h-2 w-2 shrink-0 rounded-full',
+                    s.active ? 'bg-current' : railDotClass(s.tone),
+                    !s.active && s.count === 0 && 'opacity-30',
                   )}
                 />
               )}
-              <span className="font-medium">{s.label}</span>
-              <span
-                className={cn(
-                  'console-num font-mono text-[11px] font-bold leading-none px-1.5 py-0.5 rounded-md transition-colors',
-                  s.active
-                    ? 'bg-primary/10 text-primary'
-                    : s.count === 0
-                      ? 'text-muted-foreground/40'
-                      : 'text-foreground/70 bg-background/50',
-                )}
-              >
+              <span className="text-xs font-semibold tabular-nums">
                 {s.count}
               </span>
+              <span>{s.label}</span>
             </>
           )
 
@@ -66,7 +53,7 @@ export function StatusStrip({
               <span
                 key={s.label}
                 title={s.hint}
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-xs text-muted-foreground"
+                className="inline-flex items-center gap-1.5 px-3 h-8 text-xs text-muted-foreground"
               >
                 {inner}
               </span>
@@ -81,10 +68,11 @@ export function StatusStrip({
               title={s.hint}
               aria-pressed={s.active}
               className={cn(
-                'inline-flex h-8 items-center gap-1.5 rounded-lg px-3 text-xs transition-all duration-200 select-none cursor-pointer',
+                'inline-flex items-center gap-1.5 px-3 h-8 text-xs font-medium rounded-full border transition-all duration-200 select-none cursor-pointer',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
                 s.active
-                  ? 'bg-background font-semibold text-foreground shadow-apple-sm border border-border/50'
-                  : 'text-muted-foreground hover:bg-background/50 hover:text-foreground',
+                  ? 'bg-card border-border text-foreground shadow-sm'
+                  : 'bg-card/60 border-border text-muted-foreground backdrop-blur hover:bg-card hover:text-foreground',
               )}
             >
               {inner}

--- a/admin-ui/src/components/console/status-strip.tsx
+++ b/admin-ui/src/components/console/status-strip.tsx
@@ -1,24 +1,6 @@
 import { cn } from '@/lib/utils'
 import { railDotClass, type RailTone } from './rail'
 
-/**
- * 状态标签条 —— 凭据列表的表头兼筛选器。
- *
- * 两轮设计的经过值得记一下。最初把顶部三张大数字统计卡换成了一条 28px 的细账条，
- * 省下约 140px 首屏。但省过头了：这一页最主要的筛选控件被做成了 12.5px 的说明文字，
- * 看上去像图注而不是可点的东西；而且它待在标题下方，与它筛选的那个列表之间还隔着
- * 两行工具栏 —— 想按状态过滤的人未必会想到去点它。
- *
- * 现在改成贴着列表的标签页：
- * - **紧邻**：它就是列表的表头，中间不再隔任何东西，改哪个数字影响哪片区域一目了然
- * - **显眼**：34px 行高、计数用 15px 半粗等宽，激活项带底边线；标签页这个形状本身
- *   就在说"我是切换视图的"，不需要额外提示
- * - 底边线用该状态的色轨色：选中「冷却」时，下面那些行的左侧橙色轨与上面的橙色底线
- *   是同一个信号，颜色把表头和它筛出来的行系在一起
- *
- * 补了一个「全部」标签。原先靠"再点一次激活项来取消"，那是个藏起来的操作 ——
- * 用户看不出还能退回全集。
- */
 export interface StatusSegment {
   /** 段标签，如「可用」「冷却」 */
   label: string
@@ -31,15 +13,6 @@ export interface StatusSegment {
   hint?: string
 }
 
-/** 激活项底边线用色轨色，与被筛出的行左侧色轨对应 */
-const ACTIVE_BORDER: Record<RailTone, string> = {
-  ok: 'border-emerald-500',
-  warn: 'border-amber-500',
-  cool: 'border-orange-500',
-  dead: 'border-red-500',
-  none: 'border-primary',
-}
-
 export function StatusStrip({
   segments,
   className,
@@ -50,78 +23,78 @@ export function StatusStrip({
   /** 右侧附加内容（如调度模式、总数） */
   trailing?: React.ReactNode
 }) {
-  // 计数为 0 的状态也保留：'冷却 0' 本身是有用的信息（当前没有被风控的号），
-  // 而标签忽隐忽现会让这一行的位置不停跳动。
   return (
     <div
       className={cn(
-        'console-scope flex flex-wrap items-end gap-x-0.5 gap-y-1 border-b border-border/60',
+        'console-scope flex flex-wrap items-center justify-between gap-3 py-1',
         className,
       )}
     >
-      {segments.map((s) => {
-        const clickable = !!s.onClick
-        const inner = (
-          <>
-            {s.tone !== 'none' && (
+      {/* 现代 Apple / Shadcn 极简分段控制卡片 (Segmented Control Bar) */}
+      <div className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-xl border border-border/50 bg-muted/40 p-1 backdrop-blur-sm">
+        {segments.map((s) => {
+          const clickable = !!s.onClick
+          const inner = (
+            <>
+              {s.tone !== 'none' && (
+                <span
+                  className={cn(
+                    'h-2 w-2 shrink-0 rounded-full transition-transform',
+                    railDotClass(s.tone),
+                    !s.active && s.count === 0 && 'opacity-40',
+                  )}
+                />
+              )}
+              <span className="font-medium">{s.label}</span>
               <span
                 className={cn(
-                  'h-1.5 w-1.5 shrink-0 rounded-full',
-                  railDotClass(s.tone),
-                  // 非激活且为 0 时弱化圆点，避免一排彩点抢注意力
-                  !s.active && s.count === 0 && 'opacity-40',
+                  'console-num font-mono text-[11px] font-bold leading-none px-1.5 py-0.5 rounded-md transition-colors',
+                  s.active
+                    ? 'bg-primary/10 text-primary'
+                    : s.count === 0
+                      ? 'text-muted-foreground/40'
+                      : 'text-foreground/70 bg-background/50',
                 )}
-              />
-            )}
-            <span>{s.label}</span>
-            <span
+              >
+                {s.count}
+              </span>
+            </>
+          )
+
+          if (!clickable) {
+            return (
+              <span
+                key={s.label}
+                title={s.hint}
+                className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-xs text-muted-foreground"
+              >
+                {inner}
+              </span>
+            )
+          }
+
+          return (
+            <button
+              key={s.label}
+              type="button"
+              onClick={s.onClick}
+              title={s.hint}
+              aria-pressed={s.active}
               className={cn(
-                'console-num text-[15px] font-semibold leading-none',
+                'inline-flex h-8 items-center gap-1.5 rounded-lg px-3 text-xs transition-all duration-200 select-none cursor-pointer',
                 s.active
-                  ? 'text-foreground'
-                  : s.count === 0
-                    ? 'text-muted-foreground/50'
-                    : 'text-foreground/80',
+                  ? 'bg-background font-semibold text-foreground shadow-apple-sm border border-border/50'
+                  : 'text-muted-foreground hover:bg-background/50 hover:text-foreground',
               )}
             >
-              {s.count}
-            </span>
-          </>
-        )
-
-        if (!clickable) {
-          return (
-            <span
-              key={s.label}
-              title={s.hint}
-              className="inline-flex h-[34px] items-center gap-1.5 border-b-2 border-transparent px-3 text-[13px] text-muted-foreground"
-            >
               {inner}
-            </span>
+            </button>
           )
-        }
+        })}
+      </div>
 
-        return (
-          <button
-            key={s.label}
-            type="button"
-            onClick={s.onClick}
-            title={s.hint}
-            aria-pressed={s.active}
-            className={cn(
-              'inline-flex h-[34px] items-center gap-1.5 border-b-2 px-3 text-[13px] transition-colors',
-              '-mb-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40',
-              s.active
-                ? cn('font-medium text-foreground', ACTIVE_BORDER[s.tone])
-                : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground',
-            )}
-          >
-            {inner}
-          </button>
-        )
-      })}
       {trailing && (
-        <div className="ml-auto flex items-center gap-2 self-center pb-1 pl-2">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {trailing}
         </div>
       )}

--- a/admin-ui/src/components/console/time-range.tsx
+++ b/admin-ui/src/components/console/time-range.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import { Clock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+
+/**
+ * 时间范围选择器。
+ *
+ * 日志页此前缺的就是这个维度 —— 排查现场的第一句话通常是"刚才那几分钟发生了
+ * 什么"，而不是"给我看最近 50 条"。预设覆盖了实际会用到的档：出事当下看 15 分钟，
+ * 复盘看 1 小时 / 24 小时，追趋势看 7 天。
+ *
+ * 相对时间（"最近 N 分钟"）而非绝对区间是默认档，因为它在自动刷新下语义稳定：
+ * 30 秒后重新拉取时窗口跟着滑动，看到的仍然是"最近 15 分钟"。
+ */
+export interface TimeRange {
+  /** 相对窗口分钟数；null = 不限时间 */
+  minutes: number | null
+}
+
+export const TIME_PRESETS: { label: string; minutes: number | null }[] = [
+  { label: '最近 15 分钟', minutes: 15 },
+  { label: '最近 1 小时', minutes: 60 },
+  { label: '最近 24 小时', minutes: 60 * 24 },
+  { label: '最近 7 天', minutes: 60 * 24 * 7 },
+  { label: '不限时间', minutes: null },
+]
+
+const MAX_CUSTOM_MINUTES = 60 * 24 * 90
+
+export function rangeLabel(range: TimeRange): string {
+  const hit = TIME_PRESETS.find((p) => p.minutes === range.minutes)
+  if (hit) return hit.label
+  const m = range.minutes!
+  if (m % (60 * 24) === 0) return `最近 ${m / (60 * 24)} 天`
+  if (m % 60 === 0) return `最近 ${m / 60} 小时`
+  return `最近 ${m} 分钟`
+}
+
+/** 把相对窗口换算成后端要的起始毫秒时间戳；null = 不传 */
+export function rangeToStartMs(range: TimeRange, now = Date.now()): number | null {
+  if (range.minutes == null) return null
+  return now - range.minutes * 60_000
+}
+
+export function TimeRangePicker({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: TimeRange
+  onChange: (next: TimeRange) => void
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [custom, setCustom] = useState('')
+  const [invalid, setInvalid] = useState(false)
+
+  const submitCustom = (e: React.FormEvent) => {
+    e.preventDefault()
+    const n = parseInt(custom, 10)
+    if (!Number.isFinite(n) || n < 1 || n > MAX_CUSTOM_MINUTES) {
+      setInvalid(true)
+      window.setTimeout(() => setInvalid(false), 1200)
+      return
+    }
+    onChange({ minutes: n })
+    setCustom('')
+    setOpen(false)
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={disabled}
+          title="按时间范围筛选"
+        >
+          <Clock className="h-3.5 w-3.5" />
+          {rangeLabel(value)}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>时间范围</DropdownMenuLabel>
+        <div className="grid gap-1 px-2 pb-2">
+          {TIME_PRESETS.map((p) => (
+            <Button
+              key={p.label}
+              size="sm"
+              variant={value.minutes === p.minutes ? 'default' : 'ghost'}
+              className="h-7 justify-start px-2 text-xs"
+              onClick={() => {
+                onChange({ minutes: p.minutes })
+                setOpen(false)
+              }}
+            >
+              {p.label}
+            </Button>
+          ))}
+        </div>
+        <DropdownMenuLabel className="pt-0">自定义</DropdownMenuLabel>
+        <form onSubmit={submitCustom} className="flex items-center gap-1.5 px-2 pb-2">
+          <Input
+            type="number"
+            min={1}
+            max={MAX_CUSTOM_MINUTES}
+            placeholder="分钟"
+            value={custom}
+            onChange={(e) => setCustom(e.target.value)}
+            className={cn(
+              'console-num h-7 text-xs',
+              invalid && 'border-destructive',
+            )}
+          />
+          <Button
+            type="submit"
+            size="sm"
+            variant="outline"
+            className="h-7 text-xs"
+            disabled={!custom.trim()}
+          >
+            应用
+          </Button>
+        </form>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -77,7 +77,6 @@ import { getDisposition } from "@/components/console/credential-state";
 import {
   railBorderClass,
   railChipClass,
-  railTextClass,
 } from "@/components/console/rail";
 import { PriorityPreview } from "@/components/console/priority-preview";
 import { CredentialLabel } from "@/components/console/credential-label";
@@ -657,13 +656,6 @@ export function CredentialCard({
   const subscriptionBadge = subscriptionTitle ? (
     <SubscriptionBadge title={subscriptionTitle} />
   ) : null;
-
-  const isIdle = disposition.state === "healthy" || disposition.state === "current";
-  const dispatchStatus = isIdle
-    ? "空闲"
-    : `${disposition.stateLabel}${
-        isThrottled ? ` · 剩 ${formatThrottleCountdown(throttleRemaining)}` : ""
-      }`;
 
   const metadataItems = metadataEntries(credential, metadataSchema);
   const renderMetadataRows = (items: typeof metadataItems) =>
@@ -1262,17 +1254,6 @@ export function CredentialCard({
             <div className="space-y-1 border-t border-border/40 pt-3 px-3 text-[12px]">
               <CardSectionTitle icon={Activity}>运行与账号信息</CardSectionTitle>
               {groupingBlock && <div className="py-1">{groupingBlock}</div>}
-              <LedgerRow label="调配状态">
-                <span
-                  className={`font-medium ${
-                    isIdle
-                      ? "text-emerald-700 dark:text-emerald-400"
-                      : railTextClass(disposition.tone)
-                  }`}
-                >
-                  {dispatchStatus}
-                </span>
-              </LedgerRow>
               <LedgerRow label="凭据类型">
                 <span className="font-semibold">{authLabel}</span>
               </LedgerRow>

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -188,27 +188,13 @@ function metadataValueLabel(value: unknown): string {
   }
 }
 
-/** schema oneOf 中匹配 value 的 title。如 "normal" → "正常号"。 */
-function resolveOneOfLabel(
-  schema: CredentialMetadataSchema | undefined,
-  key: string,
-  value: unknown,
-): string | undefined {
-  const field = schema?.properties?.[key];
-  if (!field?.oneOf) return undefined;
-  const match = field.oneOf.find((opt) => opt.const === value);
-  return match?.title;
-}
-
 function metadataEntries(
   credential: CredentialStatusItem,
-  schema?: CredentialMetadataSchema,
 ) {
   const metadata = credential.metadata ?? {};
   return Object.entries(metadata).flatMap(([key, detail]) => {
     const rawValue = detail.value;
     if (rawValue == null || rawValue === "") return [];
-    const oneOfLabel = resolveOneOfLabel(schema, key, rawValue);
     return [
       {
         key,
@@ -220,7 +206,7 @@ function metadataEntries(
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,
               })}`
-            : oneOfLabel ?? metadataValueLabel(rawValue),
+            : detail.valueLabel ?? metadataValueLabel(rawValue),
         emphasized: key === "type" && rawValue === "boom",
       },
     ];
@@ -353,12 +339,10 @@ function getDisabledReasonStyle(reason?: string | null): {
 
 function MetadataSummary({
   credential,
-  metadataSchema,
 }: {
   credential: CredentialStatusItem;
-  metadataSchema?: CredentialMetadataSchema;
 }) {
-  const entries = metadataEntries(credential, metadataSchema);
+  const entries = metadataEntries(credential);
   if (entries.length === 0) return null;
 
   return (
@@ -661,7 +645,7 @@ export function CredentialCard({
     <SubscriptionBadge title={subscriptionTitle} />
   ) : null;
 
-  const metadataItems = metadataEntries(credential, metadataSchema);
+  const metadataItems = metadataEntries(credential);
   const renderMetadataRows = (items: typeof metadataItems) =>
     items.map((entry) => (
       <LedgerRow
@@ -858,7 +842,7 @@ export function CredentialCard({
             </span>
           )}
         </div>
-        <MetadataSummary credential={credential} metadataSchema={metadataSchema} />
+        <MetadataSummary credential={credential} />
       </div>
 
       <div className="hidden shrink-0 items-center gap-6 lg:flex">

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -203,7 +203,7 @@ function metadataEntries(
   credential: CredentialStatusItem,
   schema?: CredentialMetadataSchema,
 ) {
-  const metadata = credential.metadata ?? { type: "normal" as const };
+  const metadata = credential.metadata ?? {};
   const schemaKeys = Object.keys(schema?.properties ?? {});
   const extraKeys = Object.keys(metadata)
     .filter((key) => !schemaKeys.includes(key))
@@ -212,9 +212,9 @@ function metadataEntries(
   return [...schemaKeys, ...extraKeys]
     .filter((key, index, keys) => keys.indexOf(key) === index)
     .flatMap((key) => {
-      const value = metadata[key];
-      if (value == null || value === "") return [];
       const field = schema?.properties[key];
+      const value = metadata[key] ?? field?.default;
+      if (value == null || value === "") return [];
       return [
         {
           key,

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -15,6 +15,15 @@ import {
   ScrollText,
   Boxes,
   Wallet,
+  CheckCircle2,
+  ChevronRight,
+  Activity,
+  Key,
+  Globe,
+  Server,
+  Layers,
+  Sparkles,
+  Flag,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -66,7 +75,11 @@ import { CredentialFailuresDialog } from "@/components/credential-failures-dialo
 import { AvailableModelsDialog } from "@/components/available-models-dialog";
 import { BalanceDialog } from "@/components/balance-dialog";
 import { getDisposition } from "@/components/console/credential-state";
-import { railBorderClass } from "@/components/console/rail";
+import {
+  railBorderClass,
+  railChipClass,
+  railTextClass,
+} from "@/components/console/rail";
 import { PriorityPreview } from "@/components/console/priority-preview";
 import { CredentialLabel } from "@/components/console/credential-label";
 import { metadataCssToStyle } from "@/lib/credential-metadata-style";
@@ -84,6 +97,8 @@ interface CredentialCardProps {
   view?: "card" | "list";
   /** 字段排序开启时禁用拖拽调优先级（隐藏拖拽手柄） */
   dragDisabled?: boolean;
+  /** 开发预览卡：仅展示，不发起任何凭据操作。 */
+  preview?: boolean;
   metadataSchema?: CredentialMetadataSchema;
 }
 
@@ -101,21 +116,23 @@ function formatLastUsed(lastUsedAt: string | null): string {
   return `${Math.floor(h / 24)} 天前`;
 }
 
-/** 添加时间用绝对日期展示（凭据的创建时刻是固定事实，相对时间意义不大） */
+/** 添加时间用绝对时刻展示 */
 function formatCreatedAt(createdAt: string | null | undefined): string {
   if (!createdAt) return "未知";
   const date = new Date(createdAt);
   if (Number.isNaN(date.getTime())) return "未知";
-  return date.toLocaleDateString("zh-CN", {
+  return date.toLocaleString("zh-CN", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
   });
 }
 
-/** 完整时间戳，用于 hover 提示 */
 function formatCreatedAtFull(createdAt: string | null | undefined): string {
-  if (!createdAt) return "添加时间未知（该凭据在此功能上线前导入）";
+  if (!createdAt) return "添加时间未知";
   const date = new Date(createdAt);
   if (Number.isNaN(date.getTime())) return "添加时间未知";
   return `添加于 ${date.toLocaleString("zh-CN")}`;
@@ -130,7 +147,12 @@ function formatNumber(n: number): string {
 
 function formatResetDate(ts: number | null): string {
   if (!ts) return "未知";
-  return new Date(ts * 1000).toLocaleString("zh-CN");
+  return new Date(ts * 1000).toLocaleString("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 /** 把秒数格式化为 `mm:ss` 或 `hh:mm:ss` */
@@ -141,6 +163,21 @@ function formatThrottleCountdown(secs: number): string {
   const s = total % 60;
   const pad = (n: number) => String(n).padStart(2, "0");
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}
+
+function proxyDisplayLabel(proxyUrl: string): string {
+  try {
+    const { host } = new URL(proxyUrl);
+    return host || maskProxyUrl(proxyUrl);
+  } catch {
+    return maskProxyUrl(proxyUrl);
+  }
+}
+
+function endpointDisplayLabel(endpoint: string): string {
+  if (endpoint === "ide") return "IDE 端点";
+  if (endpoint === "cli") return "CLI 端点";
+  return endpoint;
 }
 
 function metadataValueLabel(
@@ -162,10 +199,6 @@ function metadataValueLabel(
   }
 }
 
-/**
- * Schema 字段优先按配置顺序展示，未登记的扩展字段随后按 key 排序。
- * 空值不占卡片空间，但 false 和 0 都是有效 metadata，必须保留。
- */
 function metadataEntries(
   credential: CredentialStatusItem,
   schema?: CredentialMetadataSchema,
@@ -182,120 +215,87 @@ function metadataEntries(
       const value = metadata[key];
       if (value == null || value === "") return [];
       const field = schema?.properties[key];
-      return [{
-        key,
-        label: field?.title?.trim() || key,
-        value: key === "salePrice" && typeof value === "number"
-          ? `¥${value.toLocaleString("zh-CN", {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}`
-          : metadataValueLabel(value, field),
-        emphasized: key === "type" && value === "boom",
-        style: metadataCssToStyle(field?.["x-css"]),
-      }];
+      return [
+        {
+          key,
+          label: field?.title?.trim() || key,
+          value:
+            key === "salePrice" && typeof value === "number"
+              ? `¥${value.toLocaleString("zh-CN", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}`
+              : metadataValueLabel(value, field),
+          emphasized: key === "type" && value === "boom",
+          style: metadataCssToStyle(field?.["x-css"]),
+        },
+      ];
     });
 }
 
-function MetadataSummary({
-  credential,
-  schema,
-  compact = false,
+
+
+/** 账目行 —— 标签在左，值贴右边缘 */
+function LedgerRow({
+  label,
+  hint,
+  title,
+  icon: Icon,
+  children,
 }: {
-  credential: CredentialStatusItem;
-  schema?: CredentialMetadataSchema;
-  compact?: boolean;
+  label: string;
+  hint?: string;
+  title?: string;
+  icon?: React.ElementType;
+  children: React.ReactNode;
 }) {
-  const entries = metadataEntries(credential, schema);
-  if (entries.length === 0) return null;
-
-  if (compact) {
-    return (
-      <div
-        className="mt-1 flex min-w-0 items-center gap-1 overflow-hidden"
-        aria-label="凭据 Metadata"
-      >
-        {entries.map((entry) => (
-          <span
-            key={entry.key}
-            className={`inline-flex min-w-0 max-w-full shrink-0 items-center overflow-hidden rounded-md border px-1.5 py-0.5 text-[11px] ${
-              entry.emphasized
-                ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-                : "border-border/60 bg-muted/45 text-foreground"
-            }`}
-            title={`${entry.label}: ${entry.value}`}
-            style={entry.style}
-          >
-            <span className="shrink-0 text-muted-foreground">{entry.label}</span>
-            <span className="mx-1 text-border">·</span>
-            <span className="max-w-40 truncate font-medium">{entry.value}</span>
-          </span>
-        ))}
-      </div>
-    );
-  }
-
   return (
-    <div
-      className="min-w-0 overflow-hidden rounded-xl border border-border/60"
-      aria-label="凭据 Metadata"
-    >
-      <div className="bg-muted/50 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        Metadata
-      </div>
-      <table className="w-full table-fixed text-[12px]">
-        <colgroup>
-          <col className="w-[38%]" />
-          <col />
-        </colgroup>
-        <tbody>
-          {entries.map((entry) => (
-            <tr key={entry.key} className="border-t border-border/50">
-              <th
-                scope="row"
-                className="bg-muted/20 px-3 py-1.5 text-left font-normal text-muted-foreground"
-                title={entry.key === entry.label ? undefined : `key: ${entry.key}`}
-              >
-                <span className="block truncate">{entry.label}</span>
-              </th>
-              <td
-                className={`px-3 py-1.5 font-medium ${
-                  entry.emphasized
-                    ? "bg-amber-500/[0.07] text-amber-700 dark:text-amber-300"
-                    : "text-foreground"
-                }`}
-                title={entry.value}
-                style={entry.style}
-              >
-                <span className="block truncate">{entry.value}</span>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2.5 gap-y-0.5 py-0.5">
+      <dt className="flex shrink-0 items-center gap-1.5" title={title}>
+        {Icon && <Icon className="h-3.5 w-3.5 text-muted-foreground/70" />}
+        <span className="text-[12px] font-normal tracking-normal text-muted-foreground">
+          {label}
+        </span>
+        {hint && (
+          <span className="text-[10px] text-muted-foreground/50">{hint}</span>
+        )}
+      </dt>
+      <dd className="min-w-0 break-all text-right text-[12px] leading-4 text-foreground/90 font-medium">
+        {children}
+      </dd>
     </div>
   );
 }
 
-/**
- * 紧凑超额状态胶囊 — 与订阅徽章并列展示，不占整行
- * 三态：已开（绿色实色）/ 未开（中性细描边）/ 不支持（灰色虚边小字）
- */
+function CardSectionTitle({
+  children,
+  icon: Icon,
+}: {
+  children: React.ReactNode;
+  icon?: React.ElementType;
+}) {
+  return (
+    <h3 className="flex items-center gap-1.5 text-[11px] font-semibold leading-4 uppercase tracking-wider text-muted-foreground/80">
+      {Icon && <Icon className="h-3.5 w-3.5 opacity-70" />}
+      {children}
+    </h3>
+  );
+}
+
 function OverageStatusPill({ balance }: { balance: BalanceResponse }) {
   const cap = balance.overageCapable;
   const on = balance.overageEnabled === true;
 
-  // 不支持的订阅：极弱化
   if (cap === false) return null;
 
   if (on) {
     return (
       <span
-        className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 h-6 text-[11px] font-medium text-emerald-700 dark:text-emerald-400"
+        className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 dark:text-emerald-400 border border-emerald-500/30"
         title="此账号已开启超额"
       >
-        <Zap className="h-3 w-3" />
-        超额
+        <Zap className="h-2.5 w-2.5 fill-current" />
+        超额开启
       </span>
     );
   }
@@ -303,35 +303,26 @@ function OverageStatusPill({ balance }: { balance: BalanceResponse }) {
   if (cap === true) {
     return (
       <span
-        className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-transparent px-2 h-6 text-[11px] font-medium text-amber-600 dark:text-amber-400"
+        className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400"
         title="此账号支持超额但当前未开启"
       >
-        <ZapOff className="h-3 w-3" />
-        未开
+        <ZapOff className="h-2.5 w-2.5" />
+        超额未开
       </span>
     );
   }
 
-  // 未知：低调灰色，hover 看原始值
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-full border border-dashed border-border/60 bg-transparent px-2 h-6 text-[11px] text-muted-foreground"
-      title={
-        balance.overageCapabilityRaw
-          ? `overageCapability = ${balance.overageCapabilityRaw}`
-          : "上游未返回 overageCapability"
-      }
+      className="inline-flex items-center gap-1 rounded-full border border-dashed border-border/60 bg-transparent px-2 py-0.5 text-[10px] text-muted-foreground"
+      title="上游未返回超额能力状态"
     >
-      <ZapOff className="h-3 w-3" />
+      <ZapOff className="h-2.5 w-2.5 opacity-60" />
       未知
     </span>
   );
 }
 
-/**
- * 把后端返回的 disabledReason 字符串映射为更直观的中文徽标
- * （颜色/文案/排序权重，越靠前越显眼）
- */
 function getDisabledReasonStyle(reason?: string | null): {
   label: string;
   variant: "destructive" | "warning" | "outline" | "secondary";
@@ -357,6 +348,41 @@ function getDisabledReasonStyle(reason?: string | null): {
   }
 }
 
+function MetadataSummary({
+  credential,
+  schema,
+}: {
+  credential: CredentialStatusItem;
+  schema?: CredentialMetadataSchema;
+}) {
+  const entries = metadataEntries(credential, schema);
+  if (entries.length === 0) return null;
+
+  return (
+    <div
+      className="mt-1 flex min-w-0 items-center gap-1 overflow-hidden"
+      aria-label="凭据 Metadata"
+    >
+      {entries.map((entry) => (
+        <span
+          key={entry.key}
+          className={`inline-flex min-w-0 max-w-full shrink-0 items-center overflow-hidden rounded-md border px-1.5 py-0.5 text-[11px] ${
+            entry.emphasized
+              ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+              : "border-border/60 bg-muted/45 text-foreground"
+          }`}
+          title={`${entry.label}: ${entry.value}`}
+          style={entry.style}
+        >
+          <span className="shrink-0 text-muted-foreground">{entry.label}</span>
+          <span className="mx-1 text-border">·</span>
+          <span className="max-w-40 truncate font-medium">{entry.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export function CredentialCard({
   credential,
   selected,
@@ -367,6 +393,7 @@ export function CredentialCard({
   failureStats,
   view = "card",
   dragDisabled = false,
+  preview = false,
   metadataSchema,
 }: CredentialCardProps) {
   const [editingPriority, setEditingPriority] = useState(false);
@@ -380,6 +407,7 @@ export function CredentialCard({
   const [showFailuresDialog, setShowFailuresDialog] = useState(false);
   const [showModelsDialog, setShowModelsDialog] = useState(false);
   const [showBalanceDialog, setShowBalanceDialog] = useState(false);
+  const [connectionExpanded, setConnectionExpanded] = useState(false);
 
   const setDisabled = useSetDisabled();
   const setPriority = useSetPriority();
@@ -390,7 +418,6 @@ export function CredentialCard({
   const clearThrottle = useClearThrottle();
   const queryClient = useQueryClient();
 
-  // 拖拽排序：手柄触发，整卡随拖动位移
   const {
     attributes,
     listeners,
@@ -402,13 +429,10 @@ export function CredentialCard({
   } = useSortable({ id: credential.id, disabled: dragDisabled });
   const dragStyle: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
-    // 拖拽中关掉过渡，避免 Card 基类的 transition-all 把每帧 transform 动画化导致"不跟手"；
-    // 非拖拽态保留 dnd-kit 的归位过渡。
     transition: isDragging ? "none" : transition,
     zIndex: isDragging ? 20 : undefined,
   };
 
-  // 后端冷却剩余秒数会在 30s 拉取间隔之间过时，本地用 setInterval 自然递减以让倒计时连续。
   const [throttleRemaining, setThrottleRemaining] = useState<number>(
     credential.throttledRemainingSecs ?? 0,
   );
@@ -422,6 +446,7 @@ export function CredentialCard({
     }, 1000);
     return () => window.clearInterval(t);
   }, [throttleRemaining]);
+
   const handleClearThrottle = useCallback(() => {
     clearThrottle.mutate(credential.id, {
       onSuccess: (res) => {
@@ -431,6 +456,7 @@ export function CredentialCard({
       onError: (err) => toast.error("解除失败: " + extractErrorMessage(err)),
     });
   }, [clearThrottle, credential.id]);
+
   const [overageBusy, setOverageBusy] = useState(false);
   const handleSetOverage = async (enabled: boolean) => {
     setOverageBusy(true);
@@ -450,7 +476,6 @@ export function CredentialCard({
   };
 
   const handleToggleDisabled = () => {
-    // 当前为禁用态 → 这次操作是“启用”，启用成功后顺带刷新一次余额
     const willEnable = credential.disabled;
     setDisabled.mutate(
       { id: credential.id, disabled: !credential.disabled },
@@ -540,11 +565,8 @@ export function CredentialCard({
   const reasonStyle = getDisabledReasonStyle(credential.disabledReason);
   const isThrottled = !credential.disabled && throttleRemaining > 0;
 
-  // 状态判定与处置意图 —— 与日志页共用同一套四档色轨语义，
-  // 判定逻辑集中在 console/credential-state.ts，卡片与列表行只负责渲染。
   const disposition = getDisposition(credential, balance, throttleRemaining);
 
-  /** 处置意图 → 具体 handler。语义类型在 credential-state 里定义，落地在这里。 */
   const runDisposition = () => {
     switch (disposition.action) {
       case "clearThrottle":
@@ -570,11 +592,6 @@ export function CredentialCard({
     }
   };
 
-  /**
-   * 处置按钮：这一行当前唯一该做的事。
-   *
-   * 只在需要处置时出现，健康行不显示 —— 空着本身就是信息："这行不用管"。
-   */
   const dispositionButton = disposition.actionLabel ? (
     <Button
       size="sm"
@@ -586,13 +603,13 @@ export function CredentialCard({
         (disposition.action === "refreshToken" && forceRefresh.isPending)
       }
       title={`${disposition.stateLabel} → ${disposition.actionLabel}`}
-      className="h-7 whitespace-nowrap px-2.5 text-xs"
+      className="h-7 whitespace-nowrap px-3 text-xs font-medium border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300 hover:bg-amber-500/20"
     >
+      <Sparkles className="mr-1 h-3 w-3" />
       {disposition.actionLabel}
     </Button>
   ) : null;
 
-  // 卡片与列表行共用的状态描边 / 灰化（当前优先 · 超额 · 冷却 · 禁用）
   const stateClasses = [
     credential.isCurrent ? "ring-2 ring-primary/60 shadow-apple-lg" : "",
     !credential.disabled && isQuotaExceeded ? "ring-1 ring-amber-500/60" : "",
@@ -602,113 +619,98 @@ export function CredentialCard({
     isThrottled
       ? "ring-1 ring-orange-500/60 bg-orange-50/40 dark:bg-orange-500/[0.04]"
       : "",
-    credential.disabled && !disabledByQuota ? "opacity-70" : "",
+    credential.disabled && !disabledByQuota ? "opacity-75" : "",
   ]
     .filter(Boolean)
     .join(" ");
 
-  // 订阅 / 状态 / 鉴权等徽章 —— 卡片头部与列表行共用。
-  // Metadata 独立展示，避免把账号属性和运行状态混为一谈。
-  const badges = (
+  // 仅在有异常状态时呈现精简的状态标签，避免常规状态下出现杂乱胶囊
+  const statusBadges = (
     <>
-      {balance?.subscriptionTitle && (
-        <SubscriptionBadge
-          title={balance.subscriptionTitle}
-          className="max-w-full"
-        />
-      )}
-      {credential.isCurrent && <Badge variant="success">当前优先</Badge>}
-      {/* 禁用状态：合并 "已禁用" + 中文化的原因，单个 Badge 更醒目 */}
       {credential.disabled && reasonStyle && (
-        <Badge variant={reasonStyle.variant}>已禁用 · {reasonStyle.label}</Badge>
+        <Badge variant={reasonStyle.variant} className="text-[11px]">
+          已禁用 · {reasonStyle.label}
+        </Badge>
       )}
       {credential.disabled && !reasonStyle && (
-        <Badge variant="destructive">已禁用</Badge>
+        <Badge variant="destructive" className="text-[11px]">已禁用</Badge>
       )}
-      {/* 仍启用但已经达到上限：黄色"已超额"徽章 */}
       {!credential.disabled && isQuotaExceeded && (
-        <Badge variant="warning">已超额</Badge>
+        <Badge variant="warning" className="text-[11px]">已超额</Badge>
       )}
       {isThrottled && (
         <Badge
           variant="warning"
-          className="bg-orange-500/15 text-orange-700 dark:text-orange-300 border-orange-500/30"
-          title="账号级风控冷却中（429 + suspicious activity），到期或手动解除后恢复调度"
+          className="bg-orange-500/15 text-orange-700 dark:text-orange-300 border-orange-500/30 text-[11px]"
+          title="账号级风控冷却中"
         >
-          <Clock className="mr-1 h-3 w-3" />
+          <Clock className="mr-1 h-3 w-3 inline" />
           冷却 {formatThrottleCountdown(throttleRemaining)}
         </Badge>
       )}
-      {credential.authMethod && <Badge variant="secondary">{authLabel}</Badge>}
-      {/* 配置元信息合并为单个徽章，减少换行：endpoint · ARN */}
-      {(credential.endpoint || credential.hasProfileArn) && (
-        <Badge
-          variant="outline"
-          className="max-w-full truncate"
-          title={
-            credential.hasProfileArn ? "endpoint / 已配置 Profile ARN" : "endpoint"
-          }
-        >
-          {[credential.endpoint, credential.hasProfileArn ? "ARN" : null]
-            .filter(Boolean)
-            .join(" · ")}
-        </Badge>
-      )}
-      {/* 分组与来源不在这里：它们不是状态，见下方 groupingBlock */}
     </>
   );
 
-  const groups = credential.groups ?? [];
+  const hasStatusBadges =
+    credential.disabled || isQuotaExceeded || isThrottled;
 
-  /**
-   * 归属模块：分组 + 来源渠道。
-   *
-   * 原先这两样和「已禁用」「冷却」「Builder ID」挤在同一串徽章里，但它们回答的是
-   * 完全不同的问题 —— 那些说的是"这个号现在怎么了"（会变，要处置），分组说的是
-   * "这个号归谁用"（人为归档，稳定）。混在一起的后果是：想按分组扫一眼时，眼睛
-   * 得在一排形状相同的胶囊里挑出哪几个是分组，因为它们长得一模一样。
-   *
-   * 拆成独立一块并加上字段名，分组就有了固定位置：不用读内容也知道去哪儿看。
-   */
+  const subscriptionTitle = balance?.subscriptionTitle ?? credential.subscriptionTitle;
+  const subscriptionBadge = subscriptionTitle ? (
+    <SubscriptionBadge title={subscriptionTitle} />
+  ) : null;
+
+  const isIdle = disposition.state === "healthy" || disposition.state === "current";
+  const dispatchStatus = isIdle
+    ? "空闲"
+    : `${disposition.stateLabel}${
+        isThrottled ? ` · 剩 ${formatThrottleCountdown(throttleRemaining)}` : ""
+      }`;
+
+  const metadataItems = metadataEntries(credential, metadataSchema);
+  const renderMetadataRows = (items: typeof metadataItems) =>
+    items.map((entry) => (
+      <LedgerRow
+        key={entry.key}
+        label={entry.label}
+        title={entry.key === entry.label ? undefined : `key: ${entry.key}`}
+      >
+        <span
+          className={`font-medium ${
+            entry.emphasized ? "text-amber-600 dark:text-amber-400" : ""
+          }`}
+          style={entry.style}
+        >
+          {entry.value}
+        </span>
+      </LedgerRow>
+    ));
+  const metadataRows = renderMetadataRows(metadataItems);
+
+  const groups = credential.groups ?? [];
   const groupingBlock =
-    groups.length > 0 || credential.sourceChannel ? (
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5 text-[12px]">
-        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-          <span className="shrink-0 text-muted-foreground">分组</span>
-          {groups.length > 0 ? (
-            groups.map((g) => (
-              <span
-                key={g}
-                className="inline-flex max-w-full items-center truncate rounded-md bg-secondary px-1.5 py-0.5 font-medium text-secondary-foreground"
-              >
-                {g}
-              </span>
-            ))
-          ) : (
-            <span className="text-muted-foreground/60">未分组</span>
-          )}
-        </div>
-        {credential.sourceChannel && (
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="shrink-0 text-muted-foreground">来源</span>
-            <span className="min-w-0 truncate">{credential.sourceChannel}</span>
-          </div>
-        )}
+    groups.length > 0 ? (
+      <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+        <span className="mr-0.5 text-[11px] text-muted-foreground/80">分组</span>
+        {groups.map((g) => (
+          <span
+            key={g}
+            title="账号分组"
+            className="inline-flex max-w-full items-center break-all rounded-md bg-secondary/80 px-2 py-0.5 text-[11px] font-medium text-secondary-foreground"
+          >
+            {g}
+          </span>
+        ))}
       </div>
     ) : null;
 
-  // “更多操作”下拉 —— 卡片与列表行共用
   const moreMenu = (
-    // modal={false}：菜单非模态，避免 Radix 在 <html> 上施加 overflow:hidden 滚动锁。
-    // 该锁在移动端（尤其 iOS Safari）会与背景层 backdrop-blur / 固定定位叠加，
-    // 导致整页渲染错乱或横向位移——这正是移动端点击"更多操作"后页面异常的根因。
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <Button size="icon" variant="ghost" title="更多操作">
+        <Button size="icon" variant="ghost" className="h-8 w-8 hover:bg-accent" title="更多操作">
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="w-48">
         <DropdownMenuItem
           onSelect={(e) => {
             e.preventDefault();
@@ -720,7 +722,7 @@ export function CredentialCard({
               credential.refreshFailureCount === 0)
           }
         >
-          <RotateCcw />
+          <RotateCcw className="mr-2 h-4 w-4" />
           重置失败计数
         </DropdownMenuItem>
         <DropdownMenuItem
@@ -728,7 +730,7 @@ export function CredentialCard({
           disabled={credential.disabled}
           title={credential.disabled ? "已禁用凭据无法查询" : undefined}
         >
-          <Boxes />
+          <Boxes className="mr-2 h-4 w-4" />
           查看可用模型
         </DropdownMenuItem>
         {throttleRemaining > 0 && (
@@ -739,7 +741,7 @@ export function CredentialCard({
             }}
             disabled={clearThrottle.isPending}
           >
-            <Clock />
+            <Clock className="mr-2 h-4 w-4" />
             解除风控冷却（{formatThrottleCountdown(throttleRemaining)}）
           </DropdownMenuItem>
         )}
@@ -752,7 +754,7 @@ export function CredentialCard({
               }}
               disabled={overageBusy}
             >
-              <ZapOff />
+              <ZapOff className="mr-2 h-4 w-4 text-amber-500" />
               关闭超额
             </DropdownMenuItem>
           ) : (
@@ -763,20 +765,20 @@ export function CredentialCard({
               }}
               disabled={overageBusy}
             >
-              <Zap className="text-emerald-500" />
+              <Zap className="mr-2 h-4 w-4 text-emerald-500" />
               开启超额
             </DropdownMenuItem>
           ))}
         {credential.authMethod !== "api_key" && <DropdownMenuSeparator />}
         {credential.authMethod !== "api_key" && (
           <DropdownMenuItem onSelect={() => setShowReloginDialog(true)}>
-            <LogIn />
+            <LogIn className="mr-2 h-4 w-4" />
             重新登录
           </DropdownMenuItem>
         )}
         {credential.authMethod !== "api_key" && (
           <DropdownMenuItem onSelect={() => setShowUpdateTokenDialog(true)}>
-            <RefreshCw />
+            <RefreshCw className="mr-2 h-4 w-4" />
             重新导入 Token
           </DropdownMenuItem>
         )}
@@ -788,27 +790,25 @@ export function CredentialCard({
             setShowDeleteDialog(true);
           }}
         >
-          <Trash2 />
+          <Trash2 className="mr-2 h-4 w-4" />
           删除凭据
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
 
-  // 紧凑列表行：继承卡片的全部操作（启用/禁用 · 优先级 · 失败/成功 · 刷新 · 编辑 · 更多 · 拖拽 · 选择）
+  // 紧凑列表行 View
   const listView = (
     <div
       ref={setNodeRef}
       style={dragStyle}
       data-credential-id={credential.id}
-      // 这里刻意不加 overflow-hidden：优先级编辑框与它下方的队列位置预览是绝对定位
-      // 浮起的，会有意超出 56px 的优先级列，裁剪会把它们切掉。
-      className={`group flex min-w-0 items-center gap-2 rounded-2xl border bg-card px-2 py-2 transition-all sm:gap-3 sm:px-3 ${railBorderClass(
+      className={`group flex min-w-0 items-center gap-2 rounded-2xl border bg-card/90 px-3 py-2.5 transition-all sm:gap-3.5 sm:px-4 ${railBorderClass(
         disposition.tone,
       )} ${
         isDragging
           ? "shadow-apple-lg opacity-80"
-          : "hover:bg-accent/40 hover:shadow-apple-sm"
+          : "hover:bg-accent/30 hover:shadow-apple-sm"
       } ${stateClasses}`}
     >
       {/* 拖拽手柄（字段排序开启时隐藏，此时拖拽无意义） */}
@@ -818,42 +818,38 @@ export function CredentialCard({
           size="icon"
           variant="ghost"
           data-no-rect-select
-          className="h-8 w-8 shrink-0 cursor-grab touch-none active:cursor-grabbing"
+          className="h-8 w-8 shrink-0 cursor-grab touch-none active:cursor-grabbing hover:bg-accent/60"
           title="拖拽排序 · 越靠上越先被使用"
           {...attributes}
           {...listeners}
         >
-          <GripVertical className="h-4 w-4 text-muted-foreground" />
+          <GripVertical className="h-4 w-4 text-muted-foreground/70" />
         </Button>
       )}
 
-      {/* 选择框 */}
       <label
         data-no-rect-select
         className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-accent"
         onClick={(e) => e.stopPropagation()}
       >
         <Checkbox
-          className="h-5 w-5 [&_svg]:h-4 [&_svg]:w-4"
+          className="h-4 w-4 [&_svg]:h-3 [&_svg]:w-3"
           checked={selected}
           onCheckedChange={onToggleSelect}
         />
       </label>
 
-      {/* 身份 + 徽章 */}
       <div className="min-w-0 flex-1">
-        <div className="text-sm font-medium leading-5">
+        <div className="flex items-center gap-2 text-sm font-medium leading-5">
           <CredentialLabel id={credential.id} email={credential.email} />
         </div>
-        <div className="mt-1 flex min-w-0 items-center gap-1 overflow-hidden [&>*]:shrink-0">
-          {badges}
-          {/* 列表行放不下字段名，用一个前导斜杠把归属信息与状态徽章隔开，
-              形状（方角、实底）也与状态胶囊（圆角、描边）不同，扫读时可分辨 */}
+        <div className="mt-1 flex min-w-0 items-center gap-1.5 overflow-hidden [&>*]:shrink-0">
+          {statusBadges}
           {groups.map((g) => (
             <span
               key={g}
               title="账号分组"
-              className="inline-flex items-center rounded-md bg-secondary px-1.5 py-0.5 text-[11px] font-medium text-secondary-foreground"
+              className="inline-flex items-center rounded-md bg-secondary/80 px-1.5 py-0.5 text-[11px] font-medium text-secondary-foreground"
             >
               {g}
             </span>
@@ -861,77 +857,65 @@ export function CredentialCard({
           {credential.sourceChannel && (
             <span
               title="账号来源渠道"
-              className="text-[11px] text-muted-foreground"
+              className="text-[11px] text-muted-foreground/80"
             >
               {credential.sourceChannel}
             </span>
           )}
         </div>
-        <MetadataSummary
-          credential={credential}
-          schema={metadataSchema}
-          compact
-        />
+        <MetadataSummary credential={credential} schema={metadataSchema} />
       </div>
 
-      {/* 关键指标（中大屏） */}
-      <div className="hidden shrink-0 items-center gap-5 lg:flex">
-        <div className="relative w-14 shrink-0 text-center">
-          {/* 列宽只有 56px，塞不下「小=先用」。用一个升序楔形符号带住方向，
-              完整说明挂 title；点开编辑后由队列位置预览把话说全。 */}
+      <div className="hidden shrink-0 items-center gap-6 lg:flex">
+        <div className="relative w-16 shrink-0 text-center">
           <div
-            className="text-[10px] uppercase tracking-wider text-muted-foreground"
+            className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80"
             title="优先级：数字越小越先被使用，0 最先"
           >
-            优先级
-            <span className="ml-0.5 text-muted-foreground/60">↑</span>
+            优先级 ↑
           </div>
-          {/* 固定高度占位，避免编辑态切换时整行高度抖动 */}
           <div className="mt-0.5 flex h-[26px] items-center justify-center">
             {editingPriority ? (
-              // 编辑栏（≈112px）比列宽（56px）更宽：绝对定位脱离流式布局浮起，
-              // 配合背景与 z-index，避免被相邻"失败"列在绘制顺序上覆盖
-              <div className="absolute left-1/2 top-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-md border border-border/60 bg-card p-1 shadow-apple-sm">
-                <div className="inline-flex items-center gap-0.5">
-                <Input
-                  type="number"
-                  value={priorityValue}
-                  onChange={(e) => setPriorityValue(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handlePriorityChange();
-                    if (e.key === "Escape") {
+              <div className="absolute left-1/2 top-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border/70 bg-popover/95 p-2 shadow-apple-lg backdrop-blur-md">
+                <div className="inline-flex items-center gap-1">
+                  <Input
+                    type="number"
+                    value={priorityValue}
+                    onChange={(e) => setPriorityValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handlePriorityChange();
+                      if (e.key === "Escape") {
+                        setEditingPriority(false);
+                        setPriorityValue(String(credential.priority));
+                      }
+                    }}
+                    className="h-7 w-16 rounded-md text-sm font-mono"
+                    min="0"
+                    autoFocus
+                  />
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 text-emerald-600"
+                    onClick={handlePriorityChange}
+                    disabled={setPriority.isPending}
+                    title="确认"
+                  >
+                    ✓
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7 text-muted-foreground"
+                    onClick={() => {
                       setEditingPriority(false);
                       setPriorityValue(String(credential.priority));
-                    }
-                  }}
-                  className="h-7 w-16 rounded-md text-sm"
-                  min="0"
-                  autoFocus
-                />
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-7 w-7"
-                  onClick={handlePriorityChange}
-                  disabled={setPriority.isPending}
-                  title="确认"
-                >
-                  ✓
-                </Button>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-7 w-7"
-                  onClick={() => {
-                    setEditingPriority(false);
-                    setPriorityValue(String(credential.priority));
-                  }}
-                  title="取消"
-                >
-                  ✕
-                </Button>
+                    }}
+                    title="取消"
+                  >
+                    ✕
+                  </Button>
                 </div>
-                {/* 改这个数字会发生什么，当场说清楚 */}
                 <div className="mt-1 whitespace-nowrap px-1 text-center">
                   <PriorityPreview
                     credentialId={credential.id}
@@ -943,80 +927,78 @@ export function CredentialCard({
             ) : (
               <button
                 type="button"
-                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-sm font-medium tabular-nums transition-colors hover:bg-accent hover:text-primary"
+                className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 font-mono text-xs font-semibold tabular-nums transition-colors hover:bg-accent hover:text-primary"
                 onClick={() => setEditingPriority(true)}
-                title="点击编辑 · 数字越小越先被使用"
+                title={credential.isCurrent ? "当前调度优先凭据 · 点击编辑" : "点击编辑优先级"}
               >
-                {credential.priority}
-                <Pencil className="h-3 w-3 opacity-70" />
+                {credential.isCurrent && (
+                  <Flag className="h-3 w-3 fill-emerald-500 text-emerald-500 shrink-0" />
+                )}
+                #{credential.priority}
+                <Pencil className="h-3 w-3 opacity-60" />
               </button>
             )}
           </div>
         </div>
 
         <div className="w-20 text-center">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80">
             失败
           </div>
           <button
             type="button"
             onClick={() => setShowFailuresDialog(true)}
-            className="mt-0.5 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-sm font-medium tabular-nums transition-colors hover:bg-accent"
-            title="鉴权失败 / 账号风控 / 其他（额度·瞬态·网络等）。点击查看失败日志详情"
+            className="mt-0.5 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-semibold tabular-nums transition-colors hover:bg-accent"
+            title="鉴权失败 / 风控 / 其他。点击查看日志"
           >
             {failureStats ? (
-              <span className="tabular-nums">
-                <span className="text-destructive">{failureStats.auth}</span>
-                <span className="text-muted-foreground/50">/</span>
-                <span className="text-amber-600 dark:text-amber-400">
-                  {failureStats.throttle}
-                </span>
-                <span className="text-muted-foreground/50">/</span>
-                <span className="text-muted-foreground">
-                  {failureStats.other}
-                </span>
+              <span className="tabular-nums font-mono">
+                <span className="text-destructive font-bold">{failureStats.auth}</span>
+                <span className="text-muted-foreground/40">/</span>
+                <span className="text-amber-600 dark:text-amber-400">{failureStats.throttle}</span>
+                <span className="text-muted-foreground/40">/</span>
+                <span className="text-muted-foreground">{failureStats.other}</span>
               </span>
             ) : (
               <span
                 className={
                   credential.totalFailureCount > 0
-                    ? "text-destructive"
-                    : "text-muted-foreground"
+                    ? "font-mono font-bold text-destructive"
+                    : "font-mono text-muted-foreground"
                 }
               >
                 {credential.totalFailureCount}
               </span>
             )}
-            <ScrollText className="h-3.5 w-3.5 opacity-70" />
+            <ScrollText className="h-3 w-3 opacity-60" />
           </button>
         </div>
 
         <div className="w-16 text-center">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80">
             成功
           </div>
           <button
             type="button"
             onClick={handleResetSuccess}
-            className="mt-0.5 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-sm font-medium tabular-nums transition-colors hover:bg-accent hover:text-primary"
+            className="mt-0.5 inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-xs font-semibold tabular-nums transition-colors hover:bg-accent hover:text-primary"
             title="点击重置成功次数"
           >
             {credential.successCount}
-            <RotateCcw className="h-3 w-3 opacity-70" />
+            <RotateCcw className="h-3 w-3 opacity-50" />
           </button>
         </div>
       </div>
 
-      {/* 余额（大屏） */}
       <div className="hidden w-44 shrink-0 xl:block">
         {loadingBalance ? (
           <div className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            查询中…
+            查询余额…
           </div>
         ) : balance ? (
           <div>
-            <div className="flex items-baseline justify-between gap-2 text-xs tabular-nums">
+            <div className="flex items-baseline justify-between gap-2 text-xs tabular-nums font-mono">
               <span
                 className={`font-semibold ${
                   balance.remaining < 0
@@ -1030,45 +1012,37 @@ export function CredentialCard({
                   ? `-$${formatNumber(Math.abs(balance.remaining))}`
                   : `$${formatNumber(balance.remaining)}`}
               </span>
-              <span className="text-muted-foreground">
+              <span className="text-muted-foreground text-[11px]">
                 {balance.usagePercentage.toFixed(0)}%
               </span>
             </div>
             <Progress value={balance.usagePercentage} className="mt-1 h-1.5" />
           </div>
         ) : (
-          <div className="text-center text-[11px] text-muted-foreground">
+          <div className="text-center text-[11px] text-muted-foreground/70">
             余额未查询
           </div>
         )}
       </div>
 
-      {/* 最后调用 + 添加时间（中大屏） */}
-      <div className="hidden w-24 shrink-0 truncate text-right text-xs md:block">
-        <div className="truncate text-muted-foreground">
+      <div className="hidden w-28 shrink-0 truncate text-right text-xs md:block">
+        <div className="truncate font-medium text-foreground/90">
           {formatLastUsed(credential.lastUsedAt)}
         </div>
         <div
-          className="truncate text-[11px] tabular-nums text-muted-foreground/60"
+          className="truncate text-[10px] tabular-nums font-mono text-muted-foreground/60"
           title={formatCreatedAtFull(credential.createdAt)}
         >
-          添加 {formatCreatedAt(credential.createdAt)}
+          {formatCreatedAt(credential.createdAt)}
         </div>
       </div>
 
-      {/*
-        操作区：处置意图按钮在最前 —— 这一行现在唯一该做的事。
-        禁用态下会多出一个「启用」按钮，加上右侧几个固定宽度的指标列，总宽会超出
-        行容器把「更多操作」顶出右边界。所以有处置按钮时就收掉那两个图标按钮
-        （刷新 Token / 刷新余额）—— 它们在「更多操作」里本来就有一份，而处置按钮
-        才是这一行真正该点的东西。
-      */}
-      <div className="flex shrink-0 items-center gap-0.5 sm:gap-1">
+      <div className="flex shrink-0 items-center gap-1">
         {dispositionButton}
         <Button
           size="icon"
           variant="ghost"
-          className={`h-9 w-9 ${dispositionButton ? "hidden" : "hidden sm:inline-flex"}`}
+          className={`h-8 w-8 ${dispositionButton ? "hidden" : "hidden sm:inline-flex"}`}
           onClick={handleForceRefresh}
           disabled={
             forceRefresh.isPending ||
@@ -1084,21 +1058,21 @@ export function CredentialCard({
           }
         >
           <RefreshCw
-            className={`h-4 w-4 ${forceRefresh.isPending ? "animate-spin" : ""}`}
+            className={`h-3.5 w-3.5 ${forceRefresh.isPending ? "animate-spin" : ""}`}
           />
         </Button>
         <Button
           size="icon"
           variant="ghost"
-          className={`h-9 w-9 ${dispositionButton ? "hidden" : "hidden sm:inline-flex"}`}
+          className={`h-8 w-8 ${dispositionButton ? "hidden" : "hidden sm:inline-flex"}`}
           onClick={onRefreshBalance}
           disabled={loadingBalance || credential.disabled}
           title={credential.disabled ? "已禁用" : "刷新余额"}
         >
           {loadingBalance ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
           ) : (
-            <Wallet className="h-4 w-4" />
+            <Wallet className="h-3.5 w-3.5" />
           )}
         </Button>
         <Switch
@@ -1106,167 +1080,167 @@ export function CredentialCard({
           onCheckedChange={handleToggleDisabled}
           disabled={setDisabled.isPending}
           title={credential.disabled ? "启用" : "禁用"}
+          className="scale-90"
         />
         <Button
           size="icon"
           variant="ghost"
-          className="h-9 w-9"
+          className="h-8 w-8"
           onClick={() => setShowEditDialog(true)}
           title="编辑"
         >
-          <Pencil className="h-4 w-4" />
+          <Pencil className="h-3.5 w-3.5" />
         </Button>
         {moreMenu}
       </div>
     </div>
   );
 
+  // 标准卡片 View (Default)
   return (
     <>
       {view === "list" ? (
         listView
       ) : (
-      <Card
-        ref={setNodeRef}
-        style={dragStyle}
-        data-credential-id={credential.id}
-        className={`group flex h-full min-w-0 flex-col overflow-hidden ${
-          isDragging
-            ? "shadow-apple-lg opacity-80"
-            : "hover:-translate-y-0.5 hover:shadow-apple-lg"
-        } ${stateClasses}`}
-      >
-        <CardHeader className="p-4 pb-3 sm:p-5 sm:pb-3">
-          <div className="flex min-w-0 items-start gap-2.5 sm:gap-3">
-            <label
-              data-no-rect-select
-              className="mt-0.5 flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-accent sm:h-7 sm:w-7"
-              onClick={(e) => {
-                // label + Checkbox 双击事件去重，避免触发两次 onCheckedChange
-                e.stopPropagation();
-              }}
-            >
-              <Checkbox
-                className="h-5 w-5 [&_svg]:h-4 [&_svg]:w-4"
-                checked={selected}
-                onCheckedChange={onToggleSelect}
-              />
-            </label>
-            <div className="min-w-0 flex-1">
-              <CardTitle className="text-[15px] leading-5">
-                <CredentialLabel id={credential.id} email={credential.email} />
-              </CardTitle>
-              <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1 overflow-hidden">
-                {badges}
+        <Card
+          ref={setNodeRef}
+          style={dragStyle}
+          data-credential-id={credential.id}
+          className={`group flex h-full min-w-0 flex-col overflow-hidden rounded-2xl border-border/70 bg-gradient-to-b from-card via-card/95 to-card/90 shadow-apple transition-all duration-200 backdrop-blur-md ${
+            isDragging ? "shadow-apple-lg opacity-80 scale-[1.01]" : "hover:shadow-apple-lg hover:-translate-y-0.5"
+          } ${stateClasses}`}
+        >
+          {/* Card Header: 选择框 + Title + 呼吸指示 + 禁用开关 */}
+          <CardHeader className="p-4 pb-3 sm:p-4 sm:pb-3 border-b border-border/40 bg-muted/20">
+            <div className="flex min-w-0 items-center justify-between gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                <label
+                  data-no-rect-select
+                  className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-accent"
+                  title={selected ? "取消选择" : "选择凭据"}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <Checkbox
+                    className="h-4 w-4 [&_svg]:h-3 [&_svg]:w-3"
+                    checked={selected}
+                    onCheckedChange={onToggleSelect}
+                    disabled={preview}
+                  />
+                </label>
+                <CardTitle className="min-w-0 flex-1 text-sm font-semibold leading-snug">
+                  <CredentialLabel
+                    id={credential.id}
+                    email={credential.email}
+                    showId={false}
+                    className="flex w-full min-w-0 items-baseline gap-1.5 [&>span:last-child]:min-w-0 [&>span:last-child]:truncate font-mono"
+                  />
+                </CardTitle>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                <Switch
+                  checked={!credential.disabled}
+                  onCheckedChange={handleToggleDisabled}
+                  disabled={preview || setDisabled.isPending}
+                  title={credential.disabled ? "点击启用" : "点击禁用"}
+                  className="scale-90"
+                />
               </div>
             </div>
-            <Switch
-              className="mt-0.5"
-              checked={!credential.disabled}
-              onCheckedChange={handleToggleDisabled}
-              disabled={setDisabled.isPending}
-              title={credential.disabled ? "启用" : "禁用"}
-            />
+
+        {hasStatusBadges && (
+          <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1.5">
+            {statusBadges}
           </div>
-        </CardHeader>
+        )}
+      </CardHeader>
 
-        <CardContent className="flex flex-1 flex-col space-y-3 px-4 pb-4 sm:space-y-4 sm:px-5 sm:pb-5">
-          {/* 归属：分组 / 来源 —— 独立成块，与状态徽章分开 */}
-          {groupingBlock}
-
-          {/* 账号属性：按设置中的 Schema 显示名称和枚举文案，扩展 key 同样可见 */}
-          <MetadataSummary credential={credential} schema={metadataSchema} />
-
-          {/* 信息行 */}
-          <dl className="grid grid-cols-1 gap-2 text-[13px] min-[420px]:grid-cols-2 min-[420px]:gap-x-4">
-            <div className="flex min-w-0 items-center justify-between gap-2">
-              {/* 方向写在字段名里：标签本来就该说清这个数字是什么意思 */}
-              <dt className="shrink-0 text-muted-foreground">
-                优先级
-                <span className="ml-1 text-[11px] text-muted-foreground/70">
-                  小=先用
+          <CardContent className="flex flex-1 flex-col p-4 space-y-3.5">
+            {/* 核心指标 (Metrics Grid) */}
+            <div className="grid grid-cols-3 divide-x divide-border/30 text-center py-1">
+              {/* Priority */}
+              <div className="flex flex-col items-center justify-center px-1">
+                <span className="text-[10px] font-semibold text-muted-foreground/80 uppercase tracking-wider">
+                  优先级
                 </span>
-              </dt>
-              <dd className="min-w-0">
                 {editingPriority ? (
-                  <div className="max-w-full text-right">
-                    <div className="inline-flex max-w-full items-center gap-1">
-                      <Input
-                        type="number"
-                        value={priorityValue}
-                        onChange={(e) => setPriorityValue(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") handlePriorityChange();
-                          if (e.key === "Escape") {
-                            setEditingPriority(false);
-                            setPriorityValue(String(credential.priority));
-                          }
-                        }}
-                        className="w-16 h-7 rounded-md text-base sm:text-sm"
-                        min="0"
-                        autoFocus
-                      />
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7"
-                        onClick={handlePriorityChange}
-                        disabled={setPriority.isPending}
-                        title="保存"
-                      >
-                        ✓
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-7 w-7"
-                        onClick={() => {
+                  <div className="mt-1 flex items-center justify-center gap-0.5">
+                    <Input
+                      type="number"
+                      value={priorityValue}
+                      onChange={(e) => setPriorityValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handlePriorityChange();
+                        if (e.key === "Escape") {
                           setEditingPriority(false);
                           setPriorityValue(String(credential.priority));
-                        }}
-                        title="取消"
-                      >
-                        ✕
-                      </Button>
-                    </div>
-                    <div className="mt-0.5">
-                      <PriorityPreview
-                        credentialId={credential.id}
-                        draft={priorityValue}
-                        disabled={credential.disabled}
-                      />
-                    </div>
+                        }
+                      }}
+                      className="h-6 w-12 text-center text-xs font-mono p-0"
+                      min="0"
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={handlePriorityChange}
+                      className="text-xs text-emerald-600 font-bold px-1"
+                    >
+                      ✓
+                    </button>
                   </div>
                 ) : (
                   <button
                     type="button"
-                    className="inline-flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 font-medium tabular-nums transition-colors hover:bg-accent hover:text-primary"
-                    onClick={() => setEditingPriority(true)}
-                    title="点击编辑优先级"
+                    onClick={() => {
+                      if (!preview) setEditingPriority(true);
+                    }}
+                    className={`mt-0.5 inline-flex items-center gap-1 rounded-md px-2 py-0.5 font-mono text-xs font-bold border transition-colors hover:brightness-105 ${railChipClass(disposition.tone)}`}
+                    title={credential.isCurrent ? "当前调度优先凭据 · 点击编辑优先级" : "点击编辑优先级（数字越小越先被使用）"}
                   >
-                    {credential.priority}
-                    <Pencil className="h-3 w-3 opacity-70" />
+                    {credential.isCurrent && (
+                      <Flag className="h-3 w-3 fill-emerald-500 text-emerald-500 shrink-0" />
+                    )}
+                    #{credential.priority}
+                    <Pencil className="h-2.5 w-2.5 opacity-60" />
                   </button>
                 )}
-              </dd>
-            </div>
-            <div className="flex min-w-0 items-center justify-between gap-2">
-              <dt className="shrink-0 text-muted-foreground">失败次数</dt>
-              <dd className="min-w-0">
+              </div>
+
+              {/* Success */}
+              <div className="flex flex-col items-center justify-center px-1">
+                <span className="text-[10px] font-semibold text-muted-foreground/80 uppercase tracking-wider">
+                  成功数
+                </span>
                 <button
                   type="button"
-                  onClick={() => setShowFailuresDialog(true)}
-                  className="inline-flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 font-medium tabular-nums transition-colors hover:bg-accent"
-                  title="鉴权失败 / 账号风控 / 其他（额度·瞬态·网络等）。点击查看失败日志详情"
+                  onClick={preview ? undefined : handleResetSuccess}
+                  disabled={preview}
+                  className="mt-0.5 inline-flex items-center gap-1 font-mono text-xs font-bold text-emerald-600 dark:text-emerald-400 hover:text-emerald-500 transition-colors"
+                  title="点击重置成功次数"
+                >
+                  {credential.successCount}
+                  <RotateCcw className="h-2.5 w-2.5 opacity-50" />
+                </button>
+              </div>
+
+              {/* Failures */}
+              <div className="flex flex-col items-center justify-center px-1">
+                <span className="text-[10px] font-semibold text-muted-foreground/80 uppercase tracking-wider">
+                  失败数
+                </span>
+                <button
+                  type="button"
+                  onClick={preview ? undefined : () => setShowFailuresDialog(true)}
+                  disabled={preview}
+                  className="mt-0.5 inline-flex items-center gap-1 font-mono text-xs font-bold hover:text-primary transition-colors"
+                  title="查看失败日志"
                 >
                   {failureStats ? (
-                    <span className="tabular-nums">
+                    <span className="text-[11px]">
                       <span className="text-destructive">{failureStats.auth}</span>
-                      <span className="text-muted-foreground/50">/</span>
-                      <span className="text-amber-600 dark:text-amber-400">
-                        {failureStats.throttle}
-                      </span>
-                      <span className="text-muted-foreground/50">/</span>
+                      <span className="text-muted-foreground/40">/</span>
+                      <span className="text-amber-600 dark:text-amber-400">{failureStats.throttle}</span>
+                      <span className="text-muted-foreground/40">/</span>
                       <span className="text-muted-foreground">{failureStats.other}</span>
                     </span>
                   ) : (
@@ -1280,219 +1254,266 @@ export function CredentialCard({
                       {credential.totalFailureCount}
                     </span>
                   )}
-                  <ScrollText className="h-3.5 w-3.5 opacity-70" />
+                  <ScrollText className="h-2.5 w-2.5 opacity-50" />
                 </button>
-              </dd>
-            </div>
-            <div className="flex min-w-0 items-center justify-between gap-2">
-              <dt className="shrink-0 text-muted-foreground">刷新失败</dt>
-              <dd
-                className={`tabular-nums font-medium ${credential.refreshFailureCount > 0 ? "text-destructive" : ""}`}
-              >
-                {credential.refreshFailureCount}
-              </dd>
-            </div>
-            <div className="flex min-w-0 items-center justify-between gap-2">
-              <dt className="shrink-0 text-muted-foreground">成功次数</dt>
-              <dd className="min-w-0">
-                <button
-                  type="button"
-                  onClick={handleResetSuccess}
-                  className="inline-flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 font-medium tabular-nums transition-colors hover:bg-accent hover:text-primary"
-                  title="点击重置成功次数"
-                >
-                  {credential.successCount}
-                  <RotateCcw className="h-3 w-3 opacity-70" />
-                </button>
-              </dd>
-            </div>
-            <div className="flex min-w-0 items-center justify-between gap-2 border-t border-border/50 pt-2 min-[420px]:col-span-2">
-              <dt className="shrink-0 text-muted-foreground">最后调用</dt>
-              <dd className="min-w-0 truncate text-right font-medium">
-                {formatLastUsed(credential.lastUsedAt)}
-              </dd>
-            </div>
-            <div className="flex min-w-0 items-center justify-between gap-2 min-[420px]:col-span-2">
-              <dt className="shrink-0 text-muted-foreground">添加时间</dt>
-              <dd
-                className="min-w-0 truncate text-right font-medium tabular-nums"
-                title={formatCreatedAtFull(credential.createdAt)}
-              >
-                {formatCreatedAt(credential.createdAt)}
-              </dd>
-            </div>
-            {credential.maskedApiKey && (
-              <div className="flex min-w-0 items-center justify-between gap-2 min-[420px]:col-span-2">
-                <dt className="shrink-0 text-muted-foreground">API Key</dt>
-                <dd className="min-w-0 truncate text-right font-mono text-xs">
-                  {credential.maskedApiKey}
-                </dd>
               </div>
-            )}
-            {credential.hasProxy && (
-              <div className="flex min-w-0 items-center justify-between gap-2 min-[420px]:col-span-2">
-                <dt className="shrink-0 text-muted-foreground">代理</dt>
-                <dd className="min-w-0 truncate text-right font-mono text-xs">
-                  {maskProxyUrl(credential.proxyUrl ?? "")}
-                </dd>
-              </div>
-            )}
-          </dl>
+            </div>
 
-          {/* 余额面板 */}
-          <div
-            className={`flex min-h-[138px] flex-col rounded-xl border p-3 transition-colors sm:min-h-[150px] sm:p-4 ${
-              isQuotaExceeded || disabledByQuota
-                ? "border-amber-500/40 bg-amber-50/60 dark:bg-amber-500/[0.06]"
-                : "border-border/60 bg-secondary/40"
-            }`}
-          >
-            {loadingBalance ? (
-              <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                正在查询余额…
+            {/* Status & Ledger Section */}
+            <div className="space-y-1 border-t border-border/40 pt-3 px-3 text-[12px]">
+              <CardSectionTitle icon={Activity}>运行与账号信息</CardSectionTitle>
+              {groupingBlock && <div className="py-1">{groupingBlock}</div>}
+              <LedgerRow label="调配状态">
+                <span
+                  className={`inline-flex items-center gap-1 font-medium ${
+                    isIdle
+                      ? "text-emerald-700 dark:text-emerald-400"
+                      : railTextClass(disposition.tone)
+                  }`}
+                >
+                  {isIdle && <CheckCircle2 className="h-3 w-3" />}
+                  {dispatchStatus}
+                </span>
+              </LedgerRow>
+              <LedgerRow label="凭据类型">
+                <span className="font-semibold">{authLabel}</span>
+              </LedgerRow>
+              <LedgerRow label="最近调用">
+                <span className="font-mono text-muted-foreground">
+                  {formatLastUsed(credential.lastUsedAt)}
+                </span>
+              </LedgerRow>
+              <LedgerRow label="添加时间">
+                <span
+                  className="font-mono text-muted-foreground/80"
+                  title={formatCreatedAtFull(credential.createdAt)}
+                >
+                  {formatCreatedAt(credential.createdAt)}
+                </span>
+              </LedgerRow>
+              {metadataRows}
+            </div>
+
+            {/* Usage & Quota Card (余额与额度) */}
+            <div
+              className={`rounded-xl border p-3 transition-all space-y-2 ${
+                isQuotaExceeded || disabledByQuota
+                  ? "border-amber-500/50 bg-amber-500/[0.04]"
+                  : "border-border/60 bg-secondary/20"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <CardSectionTitle icon={Wallet}>额度与用量</CardSectionTitle>
+                <div className="flex items-center gap-1.5">
+                  {subscriptionBadge}
+                  {balance && <OverageStatusPill balance={balance} />}
+                </div>
               </div>
-            ) : balance ? (
-              <div className="space-y-3">
-                <div className="flex min-w-0 items-end justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
-                      {balance.remaining < 0 ? "超额" : "余额"}
+
+              {loadingBalance ? (
+                <div className="flex items-center justify-center gap-2 py-3 text-xs text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  正在查询最新余额…
+                </div>
+              ) : balance ? (
+                <div className="space-y-2">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <div>
+                      <div className="text-[10px] font-semibold text-muted-foreground uppercase">
+                        剩余可用
+                      </div>
+                      <div
+                        className={`console-num font-mono text-xl font-bold tracking-tight ${
+                          balance.remaining < 0
+                            ? "text-red-600 dark:text-red-400"
+                            : balance.remaining === 0
+                              ? "text-amber-600 dark:text-amber-400"
+                              : "text-emerald-600 dark:text-emerald-400"
+                        }`}
+                      >
+                        {balance.remaining < 0
+                          ? `-$${formatNumber(Math.abs(balance.remaining))}`
+                          : `$${formatNumber(balance.remaining)}`}
+                      </div>
                     </div>
-                    <div
-                      className={`mt-0.5 text-xl font-semibold tabular-nums ${
-                        balance.remaining < 0
-                          ? "text-red-600 dark:text-red-400"
-                          : balance.remaining === 0
-                            ? "text-amber-600 dark:text-amber-400"
-                            : "text-emerald-600 dark:text-emerald-400"
-                      }`}
-                    >
-                      {balance.remaining < 0
-                        ? `-$${formatNumber(Math.abs(balance.remaining))}`
-                        : `$${formatNumber(balance.remaining)}`}
+                    <div className="text-right font-mono">
+                      <div className="text-[10px] font-semibold text-muted-foreground uppercase">
+                        已用比例
+                      </div>
+                      <div className="text-sm font-semibold text-foreground">
+                        {balance.usagePercentage.toFixed(1)}%
+                      </div>
                     </div>
                   </div>
-                  <div className="min-w-0 shrink-0 text-right">
-                    <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
-                      超额
-                    </div>
-                    <div className="mt-1 flex items-center justify-end">
-                      <OverageStatusPill balance={balance} />
-                    </div>
+
+                  <Progress value={balance.usagePercentage} className="h-1.5 bg-muted" />
+
+                  <div className="grid grid-cols-2 gap-1 text-[11px] font-mono text-muted-foreground pt-1 border-t border-border/30">
+                    <div>已用: ${formatNumber(balance.currentUsage)}</div>
+                    <div className="text-right">上限: ${formatNumber(balance.usageLimit)}</div>
                   </div>
+
+                  {balance.nextResetAt && (
+                    <div className="flex items-center justify-between text-[11px] font-mono text-muted-foreground/80 pt-0.5">
+                      <span>下次重置</span>
+                      <span>{formatResetDate(balance.nextResetAt)}</span>
+                    </div>
+                  )}
                 </div>
-                <div className="space-y-1.5">
-                  <Progress value={balance.usagePercentage} />
-                  <div className="grid grid-cols-3 gap-1 text-[11px] tabular-nums text-muted-foreground">
-                    <span className="min-w-0 truncate">
-                      已用 ${formatNumber(balance.currentUsage)}
-                    </span>
-                    <span className="text-center">
-                      {balance.usagePercentage.toFixed(1)}%
-                    </span>
-                    <span className="min-w-0 truncate text-right">
-                      额度 ${formatNumber(balance.usageLimit)}
-                    </span>
-                  </div>
+              ) : (
+                <div className="flex items-center justify-between py-1 text-xs">
+                  <span className="text-muted-foreground">尚未获取余额数据</span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 px-2.5 text-xs font-medium"
+                    onClick={onRefreshBalance}
+                  >
+                    <Wallet className="mr-1.5 h-3.5 w-3.5" />
+                    查询余额
+                  </Button>
                 </div>
-                <div className="break-words border-t border-border/50 pt-2 text-[11px] text-muted-foreground">
-                  下次重置：
-                  <span className="font-medium text-foreground">
-                    {formatResetDate(balance.nextResetAt)}
-                  </span>
+              )}
+            </div>
+
+            {/* Connection Details 手风琴展开面板 */}
+            <div className="rounded-xl border border-border/40 bg-card/40 overflow-hidden">
+              <button
+                type="button"
+                className="flex w-full items-center justify-between px-3 py-2 text-left hover:bg-accent/40 transition-colors"
+                onClick={() => setConnectionExpanded((expanded) => !expanded)}
+                aria-expanded={connectionExpanded}
+              >
+                <CardSectionTitle icon={Server}>连接与代理详情</CardSectionTitle>
+                <ChevronRight
+                  className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${
+                    connectionExpanded ? "rotate-90" : ""
+                  }`}
+                />
+              </button>
+              {connectionExpanded && (
+                <div className="px-3 pb-2.5 pt-1 space-y-1 border-t border-border/30 text-[12px]">
+                  {credential.endpoint && (
+                    <LedgerRow label="端点" icon={Server}>
+                      <span>{endpointDisplayLabel(credential.endpoint)}</span>
+                    </LedgerRow>
+                  )}
+                  {credential.hasProfileArn && (
+                    <LedgerRow label="Profile ARN" icon={Layers}>
+                      <span className="text-emerald-600 dark:text-emerald-400">已配置</span>
+                    </LedgerRow>
+                  )}
+                  {credential.sourceChannel && (
+                    <LedgerRow label="来源" icon={Globe}>
+                      <span>{credential.sourceChannel}</span>
+                    </LedgerRow>
+                  )}
+                  {credential.maskedApiKey && (
+                    <LedgerRow label="API Key" icon={Key}>
+                      <span className="font-mono text-xs text-muted-foreground">{credential.maskedApiKey}</span>
+                    </LedgerRow>
+                  )}
+                  {credential.hasProxy && (
+                    <LedgerRow label="代理地址" icon={Globe}>
+                      <span
+                        className="font-mono text-xs"
+                        title={maskProxyUrl(credential.proxyUrl ?? "")}
+                      >
+                        {proxyDisplayLabel(credential.proxyUrl ?? "")}
+                      </span>
+                    </LedgerRow>
+                  )}
                 </div>
+              )}
+            </div>
+
+            {/* 底栏 ToolBar */}
+            {preview ? (
+              <div className="mt-auto flex items-center justify-end gap-1 pt-2 border-t border-border/40">
+                <Button size="icon" variant="ghost" className="h-8 w-8" disabled title="预览">
+                  <RefreshCw className="h-4 w-4" />
+                </Button>
+                <Button size="icon" variant="ghost" className="h-8 w-8" disabled title="预览">
+                  <Wallet className="h-4 w-4" />
+                </Button>
+                <Button size="icon" variant="ghost" className="h-8 w-8" disabled title="预览">
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button size="icon" variant="ghost" className="h-8 w-8" disabled title="预览">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
               </div>
             ) : (
-              <div className="flex flex-1 items-center justify-center text-center text-[13px] text-muted-foreground">
-                余额未查询，点击顶部"刷新当前页余额"即可加载。
-              </div>
-            )}
-          </div>
-
-          {/* 操作区 */}
-          {/* min-w-0 + flex-wrap：两组按钮宽度不够时折行，不把内容顶出卡片 */}
-          <div className="mt-auto flex flex-col gap-2 border-t border-border/50 pt-3 min-[420px]:flex-row min-[420px]:flex-wrap min-[420px]:items-center min-[420px]:justify-between">
-            <div className="grid min-w-0 grid-cols-3 gap-1 min-[420px]:flex min-[420px]:items-center">
-              {!dragDisabled && (
-                <>
+              <div className="mt-auto flex min-w-0 items-center gap-1 pt-2 border-t border-border/40">
+                {!dragDisabled && (
                   <Button
                     ref={setActivatorNodeRef}
                     size="icon"
                     variant="ghost"
                     data-no-rect-select
-                    className="w-full cursor-grab touch-none active:cursor-grabbing min-[420px]:w-9"
-                    title="拖拽排序 · 越靠上越先被使用"
+                    className="h-8 w-8 shrink-0 cursor-grab touch-none active:cursor-grabbing hover:bg-accent"
+                    title="拖拽排序"
                     {...attributes}
                     {...listeners}
                   >
-                    <GripVertical className="h-4 w-4 text-muted-foreground" />
+                    <GripVertical className="h-4 w-4 text-muted-foreground/70" />
                   </Button>
-                  <span className="mx-1 hidden h-5 w-px bg-border/70 min-[420px]:inline-block" />
-                </>
-              )}
-              <Button
-                size="sm"
-                variant="ghost"
-                className="w-full px-2 min-[420px]:w-auto min-[420px]:px-3"
-                onClick={handleForceRefresh}
-                disabled={
-                  forceRefresh.isPending ||
-                  credential.disabled ||
-                  credential.authMethod === "api_key"
-                }
-                title={
-                  credential.authMethod === "api_key"
-                    ? "API Key 无需刷新"
-                    : credential.disabled
-                      ? "已禁用"
-                      : "强制刷新 Token"
-                }
-              >
-                <RefreshCw
-                  className={`h-3.5 w-3.5 ${forceRefresh.isPending ? "animate-spin" : ""}`}
-                />
-                <span className="hidden sm:inline">刷新 Token</span>
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="w-full px-2 min-[420px]:w-auto min-[420px]:px-3"
-                onClick={onRefreshBalance}
-                disabled={loadingBalance || credential.disabled}
-                title={credential.disabled ? "已禁用" : "刷新余额"}
-              >
-                <RefreshCw
-                  className={`h-3.5 w-3.5 ${loadingBalance ? "animate-spin" : ""}`}
-                />
-                <span className="hidden sm:inline">刷新余额</span>
-              </Button>
-            </div>
-
-            {/*
-              原先是 grid-cols-[1fr_auto]（两列）。禁用态会多出「启用」处置按钮，
-              三个孩子塞两列，加上这条链路上没有任何 min-w-0 / flex-wrap 约束、
-              Card 也没裁剪，于是「更多操作」被按固有宽度推出卡片右边界。
-              改成可换行的 flex：宽度不够就折行，而不是往外顶。
-            */}
-            <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
-              {dispositionButton}
-              <Button
-                size="sm"
-                variant="outline"
-                className="flex-1 min-[420px]:flex-none"
-                onClick={() => setShowEditDialog(true)}
-              >
-                <Pencil className="h-3.5 w-3.5" />
-                编辑
-              </Button>
-              {moreMenu}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+                )}
+                {dispositionButton}
+                <span className="min-w-0 flex-1" />
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 shrink-0 hover:bg-accent"
+                  onClick={handleForceRefresh}
+                  disabled={
+                    forceRefresh.isPending ||
+                    credential.disabled ||
+                    credential.authMethod === "api_key"
+                  }
+                  title={
+                    credential.authMethod === "api_key"
+                      ? "API Key 无需刷新"
+                      : credential.disabled
+                        ? "已禁用"
+                        : "强制刷新 Token"
+                  }
+                >
+                  <RefreshCw
+                    className={`h-4 w-4 ${forceRefresh.isPending ? "animate-spin" : ""}`}
+                  />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 shrink-0 hover:bg-accent"
+                  onClick={onRefreshBalance}
+                  disabled={loadingBalance || credential.disabled}
+                  title={credential.disabled ? "已禁用" : "刷新余额"}
+                >
+                  {loadingBalance ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Wallet className="h-4 w-4" />
+                  )}
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 shrink-0 hover:bg-accent"
+                  onClick={() => setShowEditDialog(true)}
+                  title="编辑"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                {moreMenu}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       )}
 
+      {/* 弹窗 Dialog 组件保持完全相同的功能 */}
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
@@ -1547,7 +1568,6 @@ export function CredentialCard({
         onOpenChange={setShowModelsDialog}
         credentialId={credential.id}
       />
-      {/* 「查看余额」处置动作：拉一次最新余额，看清用量与下次重置时间 */}
       <BalanceDialog
         open={showBalanceDialog}
         onOpenChange={setShowBalanceDialog}

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -1427,7 +1427,7 @@ export function CredentialCard({
 
             {/* 底栏 ToolBar */}
             {preview ? (
-              <div className="mt-auto flex items-center justify-end gap-1 pt-2 border-t border-border/40">
+              <div className="mt-auto flex items-center justify-end gap-2 pt-2.5 border-t border-border/40">
                 <Button size="icon" variant="ghost" className="h-8 w-8" disabled title="预览">
                   <RefreshCw className="h-4 w-4" />
                 </Button>
@@ -1442,7 +1442,7 @@ export function CredentialCard({
                 </Button>
               </div>
             ) : (
-              <div className="mt-auto flex min-w-0 items-center gap-1 pt-2 border-t border-border/40">
+              <div className="mt-auto flex min-w-0 items-center gap-2 pt-2.5 border-t border-border/40">
                 {!dragDisabled && (
                   <Button
                     ref={setActivatorNodeRef}

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -922,7 +922,7 @@ export function CredentialCard({
           >
             {failureStats ? (
               <span className="tabular-nums font-mono">
-                <span className="text-destructive font-bold">{failureStats.auth}</span>
+                <span className="text-destructive font-semibold">{failureStats.auth}</span>
                 <span className="text-muted-foreground/40">/</span>
                 <span className="text-amber-600 dark:text-amber-400">{failureStats.throttle}</span>
                 <span className="text-muted-foreground/40">/</span>
@@ -932,7 +932,7 @@ export function CredentialCard({
               <span
                 className={
                   credential.totalFailureCount > 0
-                    ? "font-mono font-bold text-destructive"
+                    ? "font-mono font-semibold text-destructive"
                     : "font-mono text-muted-foreground"
                 }
               >
@@ -1163,7 +1163,7 @@ export function CredentialCard({
                     onClick={() => {
                       if (!preview) setEditingPriority(true);
                     }}
-                    className={`mt-0.5 inline-flex items-center gap-1 rounded-md px-2 py-0.5 font-mono text-xs font-bold border transition-colors hover:brightness-105 ${railChipClass(disposition.tone)}`}
+                    className={`mt-0.5 inline-flex items-center gap-1 rounded-md px-2 py-0.5 font-mono text-xs font-semibold border transition-colors hover:brightness-105 ${railChipClass(disposition.tone)}`}
                     title={credential.isCurrent ? "当前调度优先凭据 · 点击编辑优先级" : "点击编辑优先级（数字越小越先被使用）"}
                   >
                     {credential.isCurrent && (
@@ -1184,7 +1184,7 @@ export function CredentialCard({
                   type="button"
                   onClick={preview ? undefined : handleResetSuccess}
                   disabled={preview}
-                  className="mt-0.5 inline-flex items-center gap-1 font-mono text-xs font-bold text-emerald-600 dark:text-emerald-400 hover:text-emerald-500 transition-colors"
+                  className="mt-0.5 inline-flex items-center gap-1 font-mono text-xs font-semibold text-emerald-600 dark:text-emerald-400 hover:text-emerald-500 transition-colors"
                   title="点击重置成功次数"
                 >
                   {credential.successCount}
@@ -1201,7 +1201,7 @@ export function CredentialCard({
                   type="button"
                   onClick={preview ? undefined : () => setShowFailuresDialog(true)}
                   disabled={preview}
-                  className="mt-0.5 inline-flex items-center gap-1 font-mono text-xs font-bold hover:text-primary transition-colors"
+                  className="mt-0.5 inline-flex items-center gap-1 font-mono text-xs font-semibold hover:text-primary transition-colors"
                   title="查看失败日志"
                 >
                   {failureStats ? (
@@ -1280,7 +1280,7 @@ export function CredentialCard({
                         剩余可用
                       </div>
                       <div
-                        className={`console-num font-mono text-xl font-bold tracking-tight ${
+                        className={`console-num font-mono text-xl font-semibold tracking-tight ${
                           balance.remaining < 0
                             ? "text-red-600 dark:text-red-400"
                             : balance.remaining === 0

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -39,7 +39,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type { CredentialMetadataSchema, CredentialStatusItem, BalanceResponse } from "@/types/api";
+import type {
+  CredentialMetadataFieldSchema,
+  CredentialMetadataSchema,
+  CredentialStatusItem,
+  BalanceResponse,
+} from "@/types/api";
 import { maskProxyUrl, extractErrorMessage, overageFailureMessage } from "@/lib/utils";
 import {
   useSetDisabled,
@@ -64,6 +69,7 @@ import { getDisposition } from "@/components/console/credential-state";
 import { railBorderClass } from "@/components/console/rail";
 import { PriorityPreview } from "@/components/console/priority-preview";
 import { CredentialLabel } from "@/components/console/credential-label";
+import { metadataCssToStyle } from "@/lib/credential-metadata-style";
 
 interface CredentialCardProps {
   credential: CredentialStatusItem;
@@ -135,6 +141,140 @@ function formatThrottleCountdown(secs: number): string {
   const s = total % 60;
   const pad = (n: number) => String(n).padStart(2, "0");
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}
+
+function metadataValueLabel(
+  value: unknown,
+  field?: CredentialMetadataFieldSchema,
+): string {
+  const option = field?.oneOf?.find(
+    (item) => JSON.stringify(item.const) === JSON.stringify(value),
+  );
+  if (option) return option.title;
+  if (typeof value === "boolean") return value ? "是" : "否";
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Schema 字段优先按配置顺序展示，未登记的扩展字段随后按 key 排序。
+ * 空值不占卡片空间，但 false 和 0 都是有效 metadata，必须保留。
+ */
+function metadataEntries(
+  credential: CredentialStatusItem,
+  schema?: CredentialMetadataSchema,
+) {
+  const metadata = credential.metadata ?? { type: "normal" as const };
+  const schemaKeys = Object.keys(schema?.properties ?? {});
+  const extraKeys = Object.keys(metadata)
+    .filter((key) => !schemaKeys.includes(key))
+    .sort((a, b) => a.localeCompare(b));
+
+  return [...schemaKeys, ...extraKeys]
+    .filter((key, index, keys) => keys.indexOf(key) === index)
+    .flatMap((key) => {
+      const value = metadata[key];
+      if (value == null || value === "") return [];
+      const field = schema?.properties[key];
+      return [{
+        key,
+        label: field?.title?.trim() || key,
+        value: key === "salePrice" && typeof value === "number"
+          ? `¥${value.toLocaleString("zh-CN", {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}`
+          : metadataValueLabel(value, field),
+        emphasized: key === "type" && value === "boom",
+        style: metadataCssToStyle(field?.["x-css"]),
+      }];
+    });
+}
+
+function MetadataSummary({
+  credential,
+  schema,
+  compact = false,
+}: {
+  credential: CredentialStatusItem;
+  schema?: CredentialMetadataSchema;
+  compact?: boolean;
+}) {
+  const entries = metadataEntries(credential, schema);
+  if (entries.length === 0) return null;
+
+  if (compact) {
+    return (
+      <div
+        className="mt-1 flex min-w-0 items-center gap-1 overflow-hidden"
+        aria-label="凭据 Metadata"
+      >
+        {entries.map((entry) => (
+          <span
+            key={entry.key}
+            className={`inline-flex min-w-0 max-w-full shrink-0 items-center overflow-hidden rounded-md border px-1.5 py-0.5 text-[11px] ${
+              entry.emphasized
+                ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                : "border-border/60 bg-muted/45 text-foreground"
+            }`}
+            title={`${entry.label}: ${entry.value}`}
+            style={entry.style}
+          >
+            <span className="shrink-0 text-muted-foreground">{entry.label}</span>
+            <span className="mx-1 text-border">·</span>
+            <span className="max-w-40 truncate font-medium">{entry.value}</span>
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="min-w-0 overflow-hidden rounded-xl border border-border/60"
+      aria-label="凭据 Metadata"
+    >
+      <div className="bg-muted/50 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        Metadata
+      </div>
+      <table className="w-full table-fixed text-[12px]">
+        <colgroup>
+          <col className="w-[38%]" />
+          <col />
+        </colgroup>
+        <tbody>
+          {entries.map((entry) => (
+            <tr key={entry.key} className="border-t border-border/50">
+              <th
+                scope="row"
+                className="bg-muted/20 px-3 py-1.5 text-left font-normal text-muted-foreground"
+                title={entry.key === entry.label ? undefined : `key: ${entry.key}`}
+              >
+                <span className="block truncate">{entry.label}</span>
+              </th>
+              <td
+                className={`px-3 py-1.5 font-medium ${
+                  entry.emphasized
+                    ? "bg-amber-500/[0.07] text-amber-700 dark:text-amber-300"
+                    : "text-foreground"
+                }`}
+                title={entry.value}
+                style={entry.style}
+              >
+                <span className="block truncate">{entry.value}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 /**
@@ -467,18 +607,10 @@ export function CredentialCard({
     .filter(Boolean)
     .join(" ");
 
-  // 订阅 / 状态 / 鉴权 / 分组等徽章 —— 卡片头部与列表行共用
+  // 订阅 / 状态 / 鉴权等徽章 —— 卡片头部与列表行共用。
+  // Metadata 独立展示，避免把账号属性和运行状态混为一谈。
   const badges = (
     <>
-      {credential.metadata?.type === "boom" && (
-        <Badge
-          variant="outline"
-          className="border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-          title="账号类型：炸弹号（仅标记，不参与调度）"
-        >
-          炸弹号
-        </Badge>
-      )}
       {balance?.subscriptionTitle && (
         <SubscriptionBadge
           title={balance.subscriptionTitle}
@@ -735,6 +867,11 @@ export function CredentialCard({
             </span>
           )}
         </div>
+        <MetadataSummary
+          credential={credential}
+          schema={metadataSchema}
+          compact
+        />
       </div>
 
       {/* 关键指标（中大屏） */}
@@ -1036,6 +1173,9 @@ export function CredentialCard({
         <CardContent className="flex flex-1 flex-col space-y-3 px-4 pb-4 sm:space-y-4 sm:px-5 sm:pb-5">
           {/* 归属：分组 / 来源 —— 独立成块，与状态徽章分开 */}
           {groupingBlock}
+
+          {/* 账号属性：按设置中的 Schema 显示名称和枚举文案，扩展 key 同样可见 */}
+          <MetadataSummary credential={credential} schema={metadataSchema} />
 
           {/* 信息行 */}
           <dl className="grid grid-cols-1 gap-2 text-[13px] min-[420px]:grid-cols-2 min-[420px]:gap-x-4">

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -51,8 +51,9 @@ import type {
   CredentialMetadataSchema,
   CredentialStatusItem,
   BalanceResponse,
+  ProxyPoolEntry,
 } from "@/types/api";
-import { maskProxyUrl, extractErrorMessage, overageFailureMessage } from "@/lib/utils";
+import { maskProxyUrl, extractErrorMessage, overageFailureMessage, cn } from "@/lib/utils";
 import {
   useSetDisabled,
   useSetPriority,
@@ -62,8 +63,8 @@ import {
   useResetSuccessCount,
   useClearThrottle,
 } from "@/hooks/use-credentials";
-import { setCredentialOverage } from "@/api/credentials";
-import { useQueryClient } from "@tanstack/react-query";
+import { setCredentialOverage, getProxyPool } from "@/api/credentials";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { EditCredentialDialog } from "@/components/edit-credential-dialog";
@@ -222,6 +223,7 @@ function LedgerRow({
   title,
   description,
   icon: Icon,
+  danger,
   children,
 }: {
   label: string;
@@ -229,10 +231,14 @@ function LedgerRow({
   title?: string;
   description?: string;
   icon?: React.ElementType;
+  danger?: boolean;
   children: React.ReactNode;
 }) {
   return (
-    <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2.5 gap-y-0.5 py-0.5">
+    <div className={cn(
+      "grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2.5 gap-y-0.5 py-0.5 -mx-2 px-2 rounded",
+      danger && "bg-destructive/10 border border-destructive/30",
+    )}>
       <dt className="flex shrink-0 flex-col" title={title}>
         <span className="flex items-center gap-1.5">
           {Icon && <Icon className="h-3.5 w-3.5 text-muted-foreground/70" />}
@@ -403,6 +409,21 @@ export function CredentialCard({
   const resetSuccess = useResetSuccessCount();
   const clearThrottle = useClearThrottle();
   const queryClient = useQueryClient();
+
+  // 代理池健康数据，用于标记凭据专属代理是否异常
+  const { data: proxyPool } = useQuery({
+    queryKey: ['proxy-pool'],
+    queryFn: getProxyPool,
+    staleTime: 30_000,
+  });
+
+  /** 凭据专属代理在代理池中的健康信息（仅当 proxyUrl 匹配到池内条目时有效） */
+  const proxyEntry: ProxyPoolEntry | undefined = (() => {
+    if (!credential.proxyUrl || !proxyPool?.proxies) return undefined;
+    return proxyPool.proxies.find((p) => p.url === credential.proxyUrl);
+  })();
+
+  const proxyUnhealthy = proxyEntry && (proxyEntry.health === 'unhealthy' || proxyEntry.autoDisabled);
 
   const {
     attributes,
@@ -1381,13 +1402,18 @@ export function CredentialCard({
                     </LedgerRow>
                   )}
                   {credential.hasProxy && (
-                    <LedgerRow label="代理地址" icon={Globe}>
+                    <LedgerRow label="代理地址" icon={Globe} danger={proxyUnhealthy}>
                       <span
                         className="font-mono text-xs"
                         title={maskProxyUrl(credential.proxyUrl ?? "")}
                       >
                         {proxyDisplayLabel(credential.proxyUrl ?? "")}
                       </span>
+                      {proxyEntry && proxyUnhealthy && (
+                        <span className="ml-1.5 text-[11px] font-medium text-destructive">
+                          {proxyEntry.autoDisabled ? '已自动禁用' : `异常 ×${proxyEntry.consecutiveFailures}`}
+                        </span>
+                      )}
                     </LedgerRow>
                   )}
                 </div>

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -59,6 +59,11 @@ import { UpdateTokenDialog } from "@/components/update-token-dialog";
 import { ReloginDialog } from "@/components/relogin-dialog";
 import { CredentialFailuresDialog } from "@/components/credential-failures-dialog";
 import { AvailableModelsDialog } from "@/components/available-models-dialog";
+import { BalanceDialog } from "@/components/balance-dialog";
+import { getDisposition } from "@/components/console/credential-state";
+import { railBorderClass } from "@/components/console/rail";
+import { PriorityPreview } from "@/components/console/priority-preview";
+import { CredentialLabel } from "@/components/console/credential-label";
 
 interface CredentialCardProps {
   credential: CredentialStatusItem;
@@ -232,6 +237,7 @@ export function CredentialCard({
   const [showReloginDialog, setShowReloginDialog] = useState(false);
   const [showFailuresDialog, setShowFailuresDialog] = useState(false);
   const [showModelsDialog, setShowModelsDialog] = useState(false);
+  const [showBalanceDialog, setShowBalanceDialog] = useState(false);
 
   const setDisabled = useSetDisabled();
   const setPriority = useSetPriority();
@@ -319,7 +325,7 @@ export function CredentialCard({
   const handlePriorityChange = () => {
     const np = parseInt(priorityValue, 10);
     if (isNaN(np) || np < 0) {
-      toast.error("优先级必须是非负整数");
+      toast.error("优先级要填 0 或更大的整数，0 最先被使用");
       return;
     }
     setPriority.mutate(
@@ -392,6 +398,58 @@ export function CredentialCard({
   const reasonStyle = getDisabledReasonStyle(credential.disabledReason);
   const isThrottled = !credential.disabled && throttleRemaining > 0;
 
+  // 状态判定与处置意图 —— 与日志页共用同一套四档色轨语义，
+  // 判定逻辑集中在 console/credential-state.ts，卡片与列表行只负责渲染。
+  const disposition = getDisposition(credential, balance, throttleRemaining);
+
+  /** 处置意图 → 具体 handler。语义类型在 credential-state 里定义，落地在这里。 */
+  const runDisposition = () => {
+    switch (disposition.action) {
+      case "clearThrottle":
+        handleClearThrottle();
+        break;
+      case "viewBalance":
+        setShowBalanceDialog(true);
+        break;
+      case "relogin":
+        setShowReloginDialog(true);
+        break;
+      case "enable":
+        handleToggleDisabled();
+        break;
+      case "refreshToken":
+        handleForceRefresh();
+        break;
+      case "viewFailures":
+        setShowFailuresDialog(true);
+        break;
+      case "none":
+        break;
+    }
+  };
+
+  /**
+   * 处置按钮：这一行当前唯一该做的事。
+   *
+   * 只在需要处置时出现，健康行不显示 —— 空着本身就是信息："这行不用管"。
+   */
+  const dispositionButton = disposition.actionLabel ? (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={runDisposition}
+      disabled={
+        (disposition.action === "clearThrottle" && clearThrottle.isPending) ||
+        (disposition.action === "enable" && setDisabled.isPending) ||
+        (disposition.action === "refreshToken" && forceRefresh.isPending)
+      }
+      title={`${disposition.stateLabel} → ${disposition.actionLabel}`}
+      className="h-7 whitespace-nowrap px-2.5 text-xs"
+    >
+      {disposition.actionLabel}
+    </Button>
+  ) : null;
+
   // 卡片与列表行共用的状态描边 / 灰化（当前优先 · 超额 · 冷却 · 禁用）
   const stateClasses = [
     credential.isCurrent ? "ring-2 ring-primary/60 shadow-apple-lg" : "",
@@ -453,20 +511,48 @@ export function CredentialCard({
             .join(" · ")}
         </Badge>
       )}
-      {/* 账号所属分组 */}
-      {(credential.groups ?? []).map((g) => (
-        <Badge key={g} variant="outline" title="账号分组">
-          {g}
-        </Badge>
-      ))}
-      {/* 账号来源渠道 */}
-      {credential.sourceChannel && (
-        <Badge variant="outline" title="账号来源渠道">
-          来源: {credential.sourceChannel}
-        </Badge>
-      )}
+      {/* 分组与来源不在这里：它们不是状态，见下方 groupingBlock */}
     </>
   );
+
+  const groups = credential.groups ?? [];
+
+  /**
+   * 归属模块：分组 + 来源渠道。
+   *
+   * 原先这两样和「已禁用」「冷却」「Builder ID」挤在同一串徽章里，但它们回答的是
+   * 完全不同的问题 —— 那些说的是"这个号现在怎么了"（会变，要处置），分组说的是
+   * "这个号归谁用"（人为归档，稳定）。混在一起的后果是：想按分组扫一眼时，眼睛
+   * 得在一排形状相同的胶囊里挑出哪几个是分组，因为它们长得一模一样。
+   *
+   * 拆成独立一块并加上字段名，分组就有了固定位置：不用读内容也知道去哪儿看。
+   */
+  const groupingBlock =
+    groups.length > 0 || credential.sourceChannel ? (
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5 text-[12px]">
+        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+          <span className="shrink-0 text-muted-foreground">分组</span>
+          {groups.length > 0 ? (
+            groups.map((g) => (
+              <span
+                key={g}
+                className="inline-flex max-w-full items-center truncate rounded-md bg-secondary px-1.5 py-0.5 font-medium text-secondary-foreground"
+              >
+                {g}
+              </span>
+            ))
+          ) : (
+            <span className="text-muted-foreground/60">未分组</span>
+          )}
+        </div>
+        {credential.sourceChannel && (
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="shrink-0 text-muted-foreground">来源</span>
+            <span className="min-w-0 truncate">{credential.sourceChannel}</span>
+          </div>
+        )}
+      </div>
+    ) : null;
 
   // “更多操作”下拉 —— 卡片与列表行共用
   const moreMenu = (
@@ -572,7 +658,11 @@ export function CredentialCard({
       ref={setNodeRef}
       style={dragStyle}
       data-credential-id={credential.id}
-      className={`group flex min-w-0 items-center gap-2 rounded-2xl border bg-card px-2 py-2 transition-all sm:gap-3 sm:px-3 ${
+      // 这里刻意不加 overflow-hidden：优先级编辑框与它下方的队列位置预览是绝对定位
+      // 浮起的，会有意超出 56px 的优先级列，裁剪会把它们切掉。
+      className={`group flex min-w-0 items-center gap-2 rounded-2xl border bg-card px-2 py-2 transition-all sm:gap-3 sm:px-3 ${railBorderClass(
+        disposition.tone,
+      )} ${
         isDragging
           ? "shadow-apple-lg opacity-80"
           : "hover:bg-accent/40 hover:shadow-apple-sm"
@@ -586,7 +676,7 @@ export function CredentialCard({
           variant="ghost"
           data-no-rect-select
           className="h-8 w-8 shrink-0 cursor-grab touch-none active:cursor-grabbing"
-          title="拖拽调整优先级"
+          title="拖拽排序 · 越靠上越先被使用"
           {...attributes}
           {...listeners}
         >
@@ -609,26 +699,52 @@ export function CredentialCard({
 
       {/* 身份 + 徽章 */}
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium leading-5">
-          {credential.email || `凭据 #${credential.id}`}
+        <div className="text-sm font-medium leading-5">
+          <CredentialLabel id={credential.id} email={credential.email} />
         </div>
         <div className="mt-1 flex min-w-0 items-center gap-1 overflow-hidden [&>*]:shrink-0">
           {badges}
+          {/* 列表行放不下字段名，用一个前导斜杠把归属信息与状态徽章隔开，
+              形状（方角、实底）也与状态胶囊（圆角、描边）不同，扫读时可分辨 */}
+          {groups.map((g) => (
+            <span
+              key={g}
+              title="账号分组"
+              className="inline-flex items-center rounded-md bg-secondary px-1.5 py-0.5 text-[11px] font-medium text-secondary-foreground"
+            >
+              {g}
+            </span>
+          ))}
+          {credential.sourceChannel && (
+            <span
+              title="账号来源渠道"
+              className="text-[11px] text-muted-foreground"
+            >
+              {credential.sourceChannel}
+            </span>
+          )}
         </div>
       </div>
 
       {/* 关键指标（中大屏） */}
       <div className="hidden shrink-0 items-center gap-5 lg:flex">
         <div className="relative w-14 shrink-0 text-center">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          {/* 列宽只有 56px，塞不下「小=先用」。用一个升序楔形符号带住方向，
+              完整说明挂 title；点开编辑后由队列位置预览把话说全。 */}
+          <div
+            className="text-[10px] uppercase tracking-wider text-muted-foreground"
+            title="优先级：数字越小越先被使用，0 最先"
+          >
             优先级
+            <span className="ml-0.5 text-muted-foreground/60">↑</span>
           </div>
           {/* 固定高度占位，避免编辑态切换时整行高度抖动 */}
           <div className="mt-0.5 flex h-[26px] items-center justify-center">
             {editingPriority ? (
               // 编辑栏（≈112px）比列宽（56px）更宽：绝对定位脱离流式布局浮起，
               // 配合背景与 z-index，避免被相邻"失败"列在绘制顺序上覆盖
-              <div className="absolute left-1/2 top-1/2 z-30 inline-flex -translate-x-1/2 -translate-y-1/2 items-center gap-0.5 rounded-md border border-border/60 bg-card p-1 shadow-apple-sm">
+              <div className="absolute left-1/2 top-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-md border border-border/60 bg-card p-1 shadow-apple-sm">
+                <div className="inline-flex items-center gap-0.5">
                 <Input
                   type="number"
                   value={priorityValue}
@@ -666,13 +782,22 @@ export function CredentialCard({
                 >
                   ✕
                 </Button>
+                </div>
+                {/* 改这个数字会发生什么，当场说清楚 */}
+                <div className="mt-1 whitespace-nowrap px-1 text-center">
+                  <PriorityPreview
+                    credentialId={credential.id}
+                    draft={priorityValue}
+                    disabled={credential.disabled}
+                  />
+                </div>
               </div>
             ) : (
               <button
                 type="button"
                 className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-sm font-medium tabular-nums transition-colors hover:bg-accent hover:text-primary"
                 onClick={() => setEditingPriority(true)}
-                title="点击编辑优先级"
+                title="点击编辑 · 数字越小越先被使用"
               >
                 {credential.priority}
                 <Pencil className="h-3 w-3 opacity-70" />
@@ -783,12 +908,19 @@ export function CredentialCard({
         </div>
       </div>
 
-      {/* 操作区 */}
+      {/*
+        操作区：处置意图按钮在最前 —— 这一行现在唯一该做的事。
+        禁用态下会多出一个「启用」按钮，加上右侧几个固定宽度的指标列，总宽会超出
+        行容器把「更多操作」顶出右边界。所以有处置按钮时就收掉那两个图标按钮
+        （刷新 Token / 刷新余额）—— 它们在「更多操作」里本来就有一份，而处置按钮
+        才是这一行真正该点的东西。
+      */}
       <div className="flex shrink-0 items-center gap-0.5 sm:gap-1">
+        {dispositionButton}
         <Button
           size="icon"
           variant="ghost"
-          className="hidden h-9 w-9 sm:inline-flex"
+          className={`h-9 w-9 ${dispositionButton ? "hidden" : "hidden sm:inline-flex"}`}
           onClick={handleForceRefresh}
           disabled={
             forceRefresh.isPending ||
@@ -810,7 +942,7 @@ export function CredentialCard({
         <Button
           size="icon"
           variant="ghost"
-          className="hidden h-9 w-9 sm:inline-flex"
+          className={`h-9 w-9 ${dispositionButton ? "hidden" : "hidden sm:inline-flex"}`}
           onClick={onRefreshBalance}
           disabled={loadingBalance || credential.disabled}
           title={credential.disabled ? "已禁用" : "刷新余额"}
@@ -850,7 +982,7 @@ export function CredentialCard({
         ref={setNodeRef}
         style={dragStyle}
         data-credential-id={credential.id}
-        className={`group flex h-full min-w-0 flex-col ${
+        className={`group flex h-full min-w-0 flex-col overflow-hidden ${
           isDragging
             ? "shadow-apple-lg opacity-80"
             : "hover:-translate-y-0.5 hover:shadow-apple-lg"
@@ -873,8 +1005,8 @@ export function CredentialCard({
               />
             </label>
             <div className="min-w-0 flex-1">
-              <CardTitle className="truncate text-[15px] leading-5">
-                {credential.email || `凭据 #${credential.id}`}
+              <CardTitle className="text-[15px] leading-5">
+                <CredentialLabel id={credential.id} email={credential.email} />
               </CardTitle>
               <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1 overflow-hidden">
                 {badges}
@@ -891,40 +1023,68 @@ export function CredentialCard({
         </CardHeader>
 
         <CardContent className="flex flex-1 flex-col space-y-3 px-4 pb-4 sm:space-y-4 sm:px-5 sm:pb-5">
+          {/* 归属：分组 / 来源 —— 独立成块，与状态徽章分开 */}
+          {groupingBlock}
+
           {/* 信息行 */}
           <dl className="grid grid-cols-1 gap-2 text-[13px] min-[420px]:grid-cols-2 min-[420px]:gap-x-4">
             <div className="flex min-w-0 items-center justify-between gap-2">
-              <dt className="shrink-0 text-muted-foreground">优先级</dt>
+              {/* 方向写在字段名里：标签本来就该说清这个数字是什么意思 */}
+              <dt className="shrink-0 text-muted-foreground">
+                优先级
+                <span className="ml-1 text-[11px] text-muted-foreground/70">
+                  小=先用
+                </span>
+              </dt>
               <dd className="min-w-0">
                 {editingPriority ? (
-                  <div className="inline-flex max-w-full items-center gap-1">
-                    <Input
-                      type="number"
-                      value={priorityValue}
-                      onChange={(e) => setPriorityValue(e.target.value)}
-                      className="w-16 h-7 rounded-md text-base sm:text-sm"
-                      min="0"
-                    />
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="h-7 w-7"
-                      onClick={handlePriorityChange}
-                      disabled={setPriority.isPending}
-                    >
-                      ✓
-                    </Button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="h-7 w-7"
-                      onClick={() => {
-                        setEditingPriority(false);
-                        setPriorityValue(String(credential.priority));
-                      }}
-                    >
-                      ✕
-                    </Button>
+                  <div className="max-w-full text-right">
+                    <div className="inline-flex max-w-full items-center gap-1">
+                      <Input
+                        type="number"
+                        value={priorityValue}
+                        onChange={(e) => setPriorityValue(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handlePriorityChange();
+                          if (e.key === "Escape") {
+                            setEditingPriority(false);
+                            setPriorityValue(String(credential.priority));
+                          }
+                        }}
+                        className="w-16 h-7 rounded-md text-base sm:text-sm"
+                        min="0"
+                        autoFocus
+                      />
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-7 w-7"
+                        onClick={handlePriorityChange}
+                        disabled={setPriority.isPending}
+                        title="保存"
+                      >
+                        ✓
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-7 w-7"
+                        onClick={() => {
+                          setEditingPriority(false);
+                          setPriorityValue(String(credential.priority));
+                        }}
+                        title="取消"
+                      >
+                        ✕
+                      </Button>
+                    </div>
+                    <div className="mt-0.5">
+                      <PriorityPreview
+                        credentialId={credential.id}
+                        draft={priorityValue}
+                        disabled={credential.disabled}
+                      />
+                    </div>
                   </div>
                 ) : (
                   <button
@@ -1100,8 +1260,9 @@ export function CredentialCard({
           </div>
 
           {/* 操作区 */}
-          <div className="mt-auto flex flex-col gap-2 border-t border-border/50 pt-3 min-[420px]:flex-row min-[420px]:items-center min-[420px]:justify-between">
-            <div className="grid grid-cols-3 gap-1 min-[420px]:flex min-[420px]:items-center">
+          {/* min-w-0 + flex-wrap：两组按钮宽度不够时折行，不把内容顶出卡片 */}
+          <div className="mt-auto flex flex-col gap-2 border-t border-border/50 pt-3 min-[420px]:flex-row min-[420px]:flex-wrap min-[420px]:items-center min-[420px]:justify-between">
+            <div className="grid min-w-0 grid-cols-3 gap-1 min-[420px]:flex min-[420px]:items-center">
               {!dragDisabled && (
                 <>
                   <Button
@@ -1110,7 +1271,7 @@ export function CredentialCard({
                     variant="ghost"
                     data-no-rect-select
                     className="w-full cursor-grab touch-none active:cursor-grabbing min-[420px]:w-9"
-                    title="拖拽调整优先级"
+                    title="拖拽排序 · 越靠上越先被使用"
                     {...attributes}
                     {...listeners}
                   >
@@ -1157,11 +1318,18 @@ export function CredentialCard({
               </Button>
             </div>
 
-            <div className="grid grid-cols-[1fr_auto] gap-1 min-[420px]:flex min-[420px]:items-center">
+            {/*
+              原先是 grid-cols-[1fr_auto]（两列）。禁用态会多出「启用」处置按钮，
+              三个孩子塞两列，加上这条链路上没有任何 min-w-0 / flex-wrap 约束、
+              Card 也没裁剪，于是「更多操作」被按固有宽度推出卡片右边界。
+              改成可换行的 flex：宽度不够就折行，而不是往外顶。
+            */}
+            <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
+              {dispositionButton}
               <Button
                 size="sm"
                 variant="outline"
-                className="w-full min-[420px]:w-auto"
+                className="flex-1 min-[420px]:flex-none"
                 onClick={() => setShowEditDialog(true)}
               >
                 <Pencil className="h-3.5 w-3.5" />
@@ -1226,6 +1394,12 @@ export function CredentialCard({
         open={showModelsDialog}
         onOpenChange={setShowModelsDialog}
         credentialId={credential.id}
+      />
+      {/* 「查看余额」处置动作：拉一次最新余额，看清用量与下次重置时间 */}
+      <BalanceDialog
+        open={showBalanceDialog}
+        onOpenChange={setShowBalanceDialog}
+        credentialId={showBalanceDialog ? credential.id : null}
       />
     </>
   );

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -15,7 +15,6 @@ import {
   ScrollText,
   Boxes,
   Wallet,
-  CheckCircle2,
   ChevronRight,
   Activity,
   Key,
@@ -1265,13 +1264,12 @@ export function CredentialCard({
               {groupingBlock && <div className="py-1">{groupingBlock}</div>}
               <LedgerRow label="调配状态">
                 <span
-                  className={`inline-flex items-center gap-1 font-medium ${
+                  className={`font-medium ${
                     isIdle
                       ? "text-emerald-700 dark:text-emerald-400"
                       : railTextClass(disposition.tone)
                   }`}
                 >
-                  {isIdle && <CheckCircle2 className="h-3 w-3" />}
                   {dispatchStatus}
                 </span>
               </LedgerRow>

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -188,26 +188,40 @@ function metadataValueLabel(value: unknown): string {
   }
 }
 
+/** schema oneOf 中匹配 value 的 title。如 "normal" → "正常号"。 */
+function resolveOneOfLabel(
+  schema: CredentialMetadataSchema | undefined,
+  key: string,
+  value: unknown,
+): string | undefined {
+  const field = schema?.properties?.[key];
+  if (!field?.oneOf) return undefined;
+  const match = field.oneOf.find((opt) => opt.const === value);
+  return match?.title;
+}
+
 function metadataEntries(
   credential: CredentialStatusItem,
+  schema?: CredentialMetadataSchema,
 ) {
   const metadata = credential.metadata ?? {};
   return Object.entries(metadata).flatMap(([key, detail]) => {
-    const value = detail.value;
-    if (value == null || value === "") return [];
+    const rawValue = detail.value;
+    if (rawValue == null || rawValue === "") return [];
+    const oneOfLabel = resolveOneOfLabel(schema, key, rawValue);
     return [
       {
         key,
         label: detail.title?.trim() || key,
         description: detail.description,
         value:
-          key === "salePrice" && typeof value === "number"
-            ? `¥${value.toLocaleString("zh-CN", {
+          key === "salePrice" && typeof rawValue === "number"
+            ? `¥${(rawValue as number).toLocaleString("zh-CN", {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,
               })}`
-            : metadataValueLabel(value),
-        emphasized: key === "type" && value === "boom",
+            : oneOfLabel ?? metadataValueLabel(rawValue),
+        emphasized: key === "type" && rawValue === "boom",
       },
     ];
   });
@@ -215,29 +229,38 @@ function metadataEntries(
 
 
 
-/** 账目行 —— 标签在左，值贴右边缘 */
+/** 账目行 —— 标签 + 描述在左，值贴右边缘 */
 function LedgerRow({
   label,
   hint,
   title,
+  description,
   icon: Icon,
   children,
 }: {
   label: string;
   hint?: string;
   title?: string;
+  description?: string;
   icon?: React.ElementType;
   children: React.ReactNode;
 }) {
   return (
     <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2.5 gap-y-0.5 py-0.5">
-      <dt className="flex shrink-0 items-center gap-1.5" title={title}>
-        {Icon && <Icon className="h-3.5 w-3.5 text-muted-foreground/70" />}
-        <span className="text-[12px] font-normal tracking-normal text-muted-foreground">
-          {label}
+      <dt className="flex shrink-0 flex-col" title={title}>
+        <span className="flex items-center gap-1.5">
+          {Icon && <Icon className="h-3.5 w-3.5 text-muted-foreground/70" />}
+          <span className="text-[12px] font-normal tracking-normal text-muted-foreground">
+            {label}
+          </span>
+          {hint && (
+            <span className="text-[10px] text-muted-foreground/50">{hint}</span>
+          )}
         </span>
-        {hint && (
-          <span className="text-[10px] text-muted-foreground/50">{hint}</span>
+        {description && (
+          <span className="text-[10px] leading-tight text-muted-foreground/50 mt-0.5">
+            {description}
+          </span>
         )}
       </dt>
       <dd className="min-w-0 break-all text-right text-[12px] leading-4 text-foreground/90 font-medium">
@@ -330,10 +353,12 @@ function getDisabledReasonStyle(reason?: string | null): {
 
 function MetadataSummary({
   credential,
+  metadataSchema,
 }: {
   credential: CredentialStatusItem;
+  metadataSchema?: CredentialMetadataSchema;
 }) {
-  const entries = metadataEntries(credential);
+  const entries = metadataEntries(credential, metadataSchema);
   if (entries.length === 0) return null;
 
   return (
@@ -636,12 +661,13 @@ export function CredentialCard({
     <SubscriptionBadge title={subscriptionTitle} />
   ) : null;
 
-  const metadataItems = metadataEntries(credential);
+  const metadataItems = metadataEntries(credential, metadataSchema);
   const renderMetadataRows = (items: typeof metadataItems) =>
     items.map((entry) => (
       <LedgerRow
         key={entry.key}
         label={entry.label}
+        description={entry.description}
         title={entry.description || (entry.key === entry.label ? undefined : `key: ${entry.key}`)}
       >
         <span
@@ -832,7 +858,7 @@ export function CredentialCard({
             </span>
           )}
         </div>
-        <MetadataSummary credential={credential} />
+        <MetadataSummary credential={credential} metadataSchema={metadataSchema} />
       </div>
 
       <div className="hidden shrink-0 items-center gap-6 lg:flex">

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -39,7 +39,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import type { CredentialStatusItem, BalanceResponse } from "@/types/api";
+import type { CredentialMetadataSchema, CredentialStatusItem, BalanceResponse } from "@/types/api";
 import { maskProxyUrl, extractErrorMessage, overageFailureMessage } from "@/lib/utils";
 import {
   useSetDisabled,
@@ -78,6 +78,7 @@ interface CredentialCardProps {
   view?: "card" | "list";
   /** 字段排序开启时禁用拖拽调优先级（隐藏拖拽手柄） */
   dragDisabled?: boolean;
+  metadataSchema?: CredentialMetadataSchema;
 }
 
 function formatLastUsed(lastUsedAt: string | null): string {
@@ -226,6 +227,7 @@ export function CredentialCard({
   failureStats,
   view = "card",
   dragDisabled = false,
+  metadataSchema,
 }: CredentialCardProps) {
   const [editingPriority, setEditingPriority] = useState(false);
   const [priorityValue, setPriorityValue] = useState(
@@ -468,6 +470,15 @@ export function CredentialCard({
   // 订阅 / 状态 / 鉴权 / 分组等徽章 —— 卡片头部与列表行共用
   const badges = (
     <>
+      {credential.metadata?.type === "boom" && (
+        <Badge
+          variant="outline"
+          className="border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+          title="账号类型：炸弹号（仅标记，不参与调度）"
+        >
+          炸弹号
+        </Badge>
+      )}
       {balance?.subscriptionTitle && (
         <SubscriptionBadge
           title={balance.subscriptionTitle}
@@ -1373,6 +1384,7 @@ export function CredentialCard({
         open={showEditDialog}
         onOpenChange={setShowEditDialog}
         credential={credential}
+        metadataSchema={metadataSchema}
       />
       <UpdateTokenDialog
         open={showUpdateTokenDialog}

--- a/admin-ui/src/components/credential-card.tsx
+++ b/admin-ui/src/components/credential-card.tsx
@@ -48,7 +48,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type {
-  CredentialMetadataFieldSchema,
   CredentialMetadataSchema,
   CredentialStatusItem,
   BalanceResponse,
@@ -80,7 +79,6 @@ import {
 } from "@/components/console/rail";
 import { PriorityPreview } from "@/components/console/priority-preview";
 import { CredentialLabel } from "@/components/console/credential-label";
-import { metadataCssToStyle } from "@/lib/credential-metadata-style";
 
 interface CredentialCardProps {
   credential: CredentialStatusItem;
@@ -178,14 +176,7 @@ function endpointDisplayLabel(endpoint: string): string {
   return endpoint;
 }
 
-function metadataValueLabel(
-  value: unknown,
-  field?: CredentialMetadataFieldSchema,
-): string {
-  const option = field?.oneOf?.find(
-    (item) => JSON.stringify(item.const) === JSON.stringify(value),
-  );
-  if (option) return option.title;
+function metadataValueLabel(value: unknown): string {
   if (typeof value === "boolean") return value ? "是" : "否";
   if (typeof value === "string" || typeof value === "number") {
     return String(value);
@@ -199,36 +190,27 @@ function metadataValueLabel(
 
 function metadataEntries(
   credential: CredentialStatusItem,
-  schema?: CredentialMetadataSchema,
 ) {
   const metadata = credential.metadata ?? {};
-  const schemaKeys = Object.keys(schema?.properties ?? {});
-  const extraKeys = Object.keys(metadata)
-    .filter((key) => !schemaKeys.includes(key))
-    .sort((a, b) => a.localeCompare(b));
-
-  return [...schemaKeys, ...extraKeys]
-    .filter((key, index, keys) => keys.indexOf(key) === index)
-    .flatMap((key) => {
-      const field = schema?.properties[key];
-      const value = metadata[key] ?? field?.default;
-      if (value == null || value === "") return [];
-      return [
-        {
-          key,
-          label: field?.title?.trim() || key,
-          value:
-            key === "salePrice" && typeof value === "number"
-              ? `¥${value.toLocaleString("zh-CN", {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                })}`
-              : metadataValueLabel(value, field),
-          emphasized: key === "type" && value === "boom",
-          style: metadataCssToStyle(field?.["x-css"]),
-        },
-      ];
-    });
+  return Object.entries(metadata).flatMap(([key, detail]) => {
+    const value = detail.value;
+    if (value == null || value === "") return [];
+    return [
+      {
+        key,
+        label: detail.title?.trim() || key,
+        description: detail.description,
+        value:
+          key === "salePrice" && typeof value === "number"
+            ? `¥${value.toLocaleString("zh-CN", {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}`
+            : metadataValueLabel(value),
+        emphasized: key === "type" && value === "boom",
+      },
+    ];
+  });
 }
 
 
@@ -348,12 +330,10 @@ function getDisabledReasonStyle(reason?: string | null): {
 
 function MetadataSummary({
   credential,
-  schema,
 }: {
   credential: CredentialStatusItem;
-  schema?: CredentialMetadataSchema;
 }) {
-  const entries = metadataEntries(credential, schema);
+  const entries = metadataEntries(credential);
   if (entries.length === 0) return null;
 
   return (
@@ -369,8 +349,7 @@ function MetadataSummary({
               ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
               : "border-border/60 bg-muted/45 text-foreground"
           }`}
-          title={`${entry.label}: ${entry.value}`}
-          style={entry.style}
+          title={entry.description || `${entry.label}: ${entry.value}`}
         >
           <span className="shrink-0 text-muted-foreground">{entry.label}</span>
           <span className="mx-1 text-border">·</span>
@@ -657,19 +636,18 @@ export function CredentialCard({
     <SubscriptionBadge title={subscriptionTitle} />
   ) : null;
 
-  const metadataItems = metadataEntries(credential, metadataSchema);
+  const metadataItems = metadataEntries(credential);
   const renderMetadataRows = (items: typeof metadataItems) =>
     items.map((entry) => (
       <LedgerRow
         key={entry.key}
         label={entry.label}
-        title={entry.key === entry.label ? undefined : `key: ${entry.key}`}
+        title={entry.description || (entry.key === entry.label ? undefined : `key: ${entry.key}`)}
       >
         <span
           className={`font-medium ${
             entry.emphasized ? "text-amber-600 dark:text-amber-400" : ""
           }`}
-          style={entry.style}
         >
           {entry.value}
         </span>
@@ -854,7 +832,7 @@ export function CredentialCard({
             </span>
           )}
         </div>
-        <MetadataSummary credential={credential} schema={metadataSchema} />
+        <MetadataSummary credential={credential} />
       </div>
 
       <div className="hidden shrink-0 items-center gap-6 lg:flex">

--- a/admin-ui/src/components/credential-metadata-field.tsx
+++ b/admin-ui/src/components/credential-metadata-field.tsx
@@ -81,7 +81,11 @@ export function metadataDefaults(
   for (const [key, field] of Object.entries(schema?.properties ?? {})) {
     if (field.default !== undefined) values[key] = field.default
   }
-  return { ...values, type: typeof values.type === 'string' ? values.type : 'normal' } as CredentialMetadata
+  return {
+    ...values,
+    type: typeof values.type === 'string' ? values.type : 'normal',
+    saleStatus: typeof values.saleStatus === 'string' ? values.saleStatus : 'not_for_sale',
+  } as CredentialMetadata
 }
 
 interface CredentialMetadataEditorProps {
@@ -149,6 +153,7 @@ export function CredentialMetadataEditor({
               id={`metadata-${key}`}
               type={field.type === 'string' ? 'text' : 'number'}
               step={field.type === 'integer' ? 1 : 'any'}
+              min={field.minimum}
               value={current == null ? '' : String(current)}
               onChange={(event) => {
                 const raw = event.target.value

--- a/admin-ui/src/components/credential-metadata-field.tsx
+++ b/admin-ui/src/components/credential-metadata-field.tsx
@@ -1,0 +1,171 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { CredentialMetadataSchema } from '@/types/api'
+import type { CredentialMetadata } from '@/types/api'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+
+interface CredentialMetadataFieldProps {
+  schema?: CredentialMetadataSchema
+  fieldKey: string
+  value: string
+  onValueChange: (value: string) => void
+  disabled?: boolean
+  className?: string
+}
+
+/** 按后端 JSON Schema 渲染 metadata 枚举字段，避免在各个表单重复硬编码 key/value。 */
+export function CredentialMetadataField({
+  schema,
+  fieldKey,
+  value,
+  onValueChange,
+  disabled,
+  className,
+}: CredentialMetadataFieldProps) {
+  const field = schema?.properties[fieldKey]
+  if (!field?.oneOf?.length) return null
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor={`metadata-${fieldKey}`} className="text-sm font-medium">
+        {field.title}
+      </label>
+      <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+        <SelectTrigger
+          id={`metadata-${fieldKey}`}
+          className={className ?? 'h-10 rounded-xl px-3.5'}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {field.oneOf.map((option) => (
+            <SelectItem key={String(option.const)} value={String(option.const)}>
+              {option.title}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {field.description && (
+        <p className="text-xs text-muted-foreground">{field.description}</p>
+      )}
+    </div>
+  )
+}
+
+export function metadataFieldDefault(
+  schema: CredentialMetadataSchema | undefined,
+  fieldKey: string,
+  fallback: string,
+): string {
+  const value = schema?.properties[fieldKey]?.default
+  return typeof value === 'string' ? value : fallback
+}
+
+export function metadataFieldValues(
+  schema: CredentialMetadataSchema | undefined,
+  fieldKey: string,
+): string[] {
+  return schema?.properties[fieldKey]?.oneOf?.map((option) => String(option.const)) ?? []
+}
+
+export function metadataDefaults(
+  schema: CredentialMetadataSchema | undefined,
+): CredentialMetadata {
+  const values: Record<string, unknown> = {}
+  for (const [key, field] of Object.entries(schema?.properties ?? {})) {
+    if (field.default !== undefined) values[key] = field.default
+  }
+  return { ...values, type: typeof values.type === 'string' ? values.type : 'normal' } as CredentialMetadata
+}
+
+interface CredentialMetadataEditorProps {
+  schema?: CredentialMetadataSchema
+  value: CredentialMetadata
+  onChange: (value: CredentialMetadata) => void
+  disabled?: boolean
+}
+
+/** 按 schema 渲染全部已登记字段；schema 外扩展键仍留在 value 中，不会被覆盖。 */
+export function CredentialMetadataEditor({
+  schema,
+  value,
+  onChange,
+  disabled,
+}: CredentialMetadataEditorProps) {
+  if (!schema) return null
+
+  const setField = (key: string, next: unknown) => {
+    const updated = { ...value }
+    if (next === undefined || next === '') delete updated[key]
+    else updated[key] = next
+    onChange(updated)
+  }
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(schema.properties).map(([key, field]) => {
+        const current = value[key] ?? field.default
+        if (field.oneOf?.length) {
+          return (
+            <CredentialMetadataField
+              key={key}
+              schema={schema}
+              fieldKey={key}
+              value={typeof current === 'string' ? current : ''}
+              onValueChange={(next) => {
+                if (field.type === 'boolean') setField(key, next === 'true')
+                else if (field.type === 'number' || field.type === 'integer') setField(key, Number(next))
+                else setField(key, next)
+              }}
+              disabled={disabled}
+            />
+          )
+        }
+        if (field.type === 'boolean') {
+          return (
+            <div key={key} className="space-y-1.5">
+              <label className="flex items-center justify-between gap-3 text-sm font-medium">
+                <span>{field.title}</span>
+                <Switch
+                  checked={Boolean(current)}
+                  onCheckedChange={(next) => setField(key, next)}
+                  disabled={disabled}
+                />
+              </label>
+              {field.description && <p className="text-xs text-muted-foreground">{field.description}</p>}
+            </div>
+          )
+        }
+        return (
+          <div key={key} className="space-y-2">
+            <label htmlFor={`metadata-${key}`} className="text-sm font-medium">{field.title}</label>
+            <Input
+              id={`metadata-${key}`}
+              type={field.type === 'string' ? 'text' : 'number'}
+              step={field.type === 'integer' ? 1 : 'any'}
+              value={current == null ? '' : String(current)}
+              onChange={(event) => {
+                const raw = event.target.value
+                const parsed = Number(raw)
+                setField(
+                  key,
+                  field.type === 'string' || raw === ''
+                    ? raw
+                    : Number.isFinite(parsed) ? parsed : undefined,
+                )
+              }}
+              disabled={disabled}
+            />
+            {field.description && <p className="text-xs text-muted-foreground">{field.description}</p>}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -135,6 +135,7 @@ import {
   updateAdminKey,
 } from "@/api/credentials";
 import {
+  cn,
   extractErrorMessage,
   parseError,
   generateApiKey,
@@ -335,7 +336,42 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const [tierFilter, setTierFilter] = useState<Set<Tier>>(new Set());
   // 模糊搜索：按来源渠道（备注）/ 邮箱做大小写不敏感的子串匹配；空串 = 不限
   const [searchQuery, setSearchQuery] = useState("");
-  // 字段排序：'manual' 保留服务端顺序与拖拽调优先级；其余字段按方向排序并禁用拖拽
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // 快捷键支持：按下 '/' 或 'Cmd/Ctrl+K' 聚焦搜索框；'Esc' 快速清空并失焦
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (searchQuery || document.activeElement === searchInputRef.current) {
+          setSearchQuery("");
+          searchInputRef.current?.blur();
+        }
+        return;
+      }
+
+      if (
+        e.key === "/" &&
+        !["INPUT", "TEXTAREA", "SELECT"].includes(
+          (e.target as HTMLElement)?.tagName,
+        ) &&
+        !(e.target as HTMLElement)?.isContentEditable
+      ) {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [searchQuery]);
+
+  // 字段排序（来自 PR #56）：'manual' 保留服务端顺序与拖拽调优先级；
+  // 其余字段按方向排序并禁用拖拽。console-ui 没有同类能力，纯增量保留。
   const [sortField, setSortField] = useState<SortField>("manual");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   // 选中排序字段：点已选字段则切换升/降序；换字段时用该字段的直观默认方向
@@ -1501,25 +1537,30 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
             {/* 筛选器 — 左（移动端两列网格并排，桌面端内联） */}
             <div className="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:flex-wrap sm:items-center">
-              {/* 模糊搜索：来源渠道（备注）/ 邮箱；移动端整行、桌面端 200px */}
-              <div className="relative col-span-2 sm:col-span-1 sm:w-[200px]">
-                <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              {/* 模糊搜索：来源渠道（备注）/ 邮箱；移动端整行、桌面端 210px */}
+              <div className="relative col-span-2 sm:col-span-1 sm:w-[210px]">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground opacity-80" />
                 <input
+                  ref={searchInputRef}
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="搜索来源渠道 / 备注 / 邮箱"
-                  className="h-8 w-full rounded-full border border-border bg-card/60 pl-5 pr-5 text-base backdrop-blur placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:text-sm"
+                  className="h-8 w-full rounded-full border border-border bg-card/60 pl-8 pr-7 text-base backdrop-blur placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:text-sm"
                 />
-                {searchQuery && (
+                {searchQuery ? (
                   <button
                     type="button"
                     onClick={() => setSearchQuery("")}
                     className="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                    title="清除搜索"
+                    title="清除搜索 (Esc)"
                   >
                     <X className="h-3.5 w-3.5" />
                   </button>
+                ) : (
+                  <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 hidden select-none rounded border border-border/70 bg-muted/60 px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-60 sm:inline-block">
+                    /
+                  </kbd>
                 )}
               </div>
               <Select
@@ -1964,16 +2005,26 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
               },
             ]}
             trailing={
-              <span className="text-[12.5px] text-muted-foreground">
+              <div className="inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-background/60 px-2.5 py-1 text-xs text-muted-foreground backdrop-blur-xs">
+                <span
+                  className={cn(
+                    "h-2 w-2 rounded-full",
+                    loadBalancingData?.mode === "balanced"
+                      ? "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)] animate-pulse"
+                      : "bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)]"
+                  )}
+                />
                 {loadBalancingData?.mode === "balanced" ? (
-                  "均衡负载"
+                  <span className="font-medium text-foreground/90">均衡负载模式</span>
                 ) : (
-                  <>
-                    当前优先{" "}
-                    <span className="console-num">#{data?.currentId || "-"}</span>
-                  </>
+                  <span>
+                    优先调度{" "}
+                    <span className="console-num font-mono font-bold text-foreground">
+                      #{data?.currentId || "-"}
+                    </span>
+                  </span>
                 )}
-              </span>
+              </div>
             }
           />
         )}

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
   RotateCcw,
   CheckCircle2,
+  CheckSquare,
   Globe,
   LogIn,
   Key,
@@ -137,10 +138,16 @@ import {
   extractErrorMessage,
   parseError,
   generateApiKey,
-  formatNumber,
   overageFailureMessage,
 } from "@/lib/utils";
-import type { BalanceResponse, CredentialStatusItem } from "@/types/api";
+import type { BalanceResponse } from "@/types/api";
+import { StatusStrip } from "@/components/console/status-strip";
+import { BulkBar } from "@/components/console/bulk-bar";
+import {
+  countByState,
+  matchesStateFilter,
+  type StateFilter,
+} from "@/components/console/credential-state";
 
 interface DashboardProps {
   onLogout: () => void;
@@ -192,55 +199,8 @@ const SORT_LABELS: Record<SortField, string> = {
   id: "ID",
 };
 
-// 按状态隐藏：勾选即隐藏对应状态的凭据。状态含义与卡片徽章一致。
-type StatusKey =
-  | "current"
-  | "enabled"
-  | "disabled"
-  | "throttled"
-  | "quotaExceeded";
-const STATUS_OPTIONS: { value: StatusKey; label: string }[] = [
-  { value: "current", label: "当前优先" },
-  { value: "enabled", label: "已启用" },
-  { value: "disabled", label: "已禁用" },
-  { value: "throttled", label: "冷却中" },
-  { value: "quotaExceeded", label: "已超额" },
-];
-
-/**
- * 判断凭据是否命中某个隐藏状态。
- *
- * `enabled` 指“正常启用且无异常态”（非禁用 / 非冷却 / 非超额）；`current` 与
- * 主状态正交（一个当前优先的凭据同时也可能是 enabled），勾选任一命中即隐藏。
- * 超额判定优先用本地验活/缓存余额，回落到 disabledReason。
- */
-function credentialHasStatus(
-  c: CredentialStatusItem,
-  key: StatusKey,
-  balance: BalanceResponse | undefined,
-): boolean {
-  const quotaByBalance = balance
-    ? balance.remaining <= 0 || balance.usagePercentage >= 100
-    : false;
-  const quotaExceeded =
-    (!c.disabled && quotaByBalance) ||
-    (c.disabled && c.disabledReason === "QuotaExceeded");
-  const throttled = !c.disabled && (c.throttledRemainingSecs ?? 0) > 0;
-  switch (key) {
-    case "current":
-      return c.isCurrent;
-    case "disabled":
-      return c.disabled;
-    case "throttled":
-      return throttled;
-    case "quotaExceeded":
-      return quotaExceeded;
-    case "enabled":
-      return !c.disabled && !throttled && !quotaExceeded;
-    default:
-      return false;
-  }
-}
+// 注：PR #56 的 StatusKey / STATUS_OPTIONS / credentialHasStatus 已随「隐藏状态」
+// 下拉一并移除，改由顶部状态账条（StatusStrip + credential-state.ts）承担同一职责。
 
 export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const confirm = useConfirm();
@@ -338,10 +298,6 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   // 字段排序：'manual' 保留服务端顺序与拖拽调优先级；其余字段按方向排序并禁用拖拽
   const [sortField, setSortField] = useState<SortField>("manual");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
-  // 按状态隐藏（多选）：集合内的状态对应的凭据不显示；空集合 = 不隐藏任何状态
-  const [hiddenStatuses, setHiddenStatuses] = useState<Set<StatusKey>>(
-    new Set(),
-  );
   // 选中排序字段：点已选字段则切换升/降序；换字段时用该字段的直观默认方向
   const applySort = (field: SortField) => {
     if (field === "manual") {
@@ -356,14 +312,12 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
     // 成功次数/最后使用默认降序（大/新在前），其余默认升序
     setSortDir(field === "successCount" || field === "lastUsedAt" ? "desc" : "asc");
   };
-  const toggleStatus = (s: StatusKey) => {
-    setHiddenStatuses((prev) => {
-      const next = new Set(prev);
-      if (next.has(s)) next.delete(s);
-      else next.add(s);
-      return next;
-    });
-  };
+  // 状态筛选：由顶部状态账条驱动。'' = 全部
+  //
+  // 默认落在「可用」而非全部：这一屏最常做的事是调排队顺序，而只有可用凭据才真的
+  // 在队列里 —— 混进禁用/超额的行会让拖拽出来的次序与实际调度顺序对不上。
+  // 其余状态的计数仍在账条上，点一下即可切过去。
+  const [stateFilter, setStateFilter] = useState<StateFilter>("healthy");
   const toggleTier = (t: Tier) => {
     setTierFilter((prev) => {
       const next = new Set(prev);
@@ -396,13 +350,13 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           (c.email ?? "").toLowerCase().includes(q),
       );
     }
-    // 按状态隐藏：命中任一被勾选状态的凭据不显示
-    if (hiddenStatuses.size > 0) {
-      out = out.filter(
-        (c) =>
-          ![...hiddenStatuses].some((s) =>
-            credentialHasStatus(c, s, balanceMap.get(c.id) || c.balance),
-          ),
+    // 状态筛选：点状态账条某一段时只留该状态的凭据
+    //
+    // 合并说明：PR #56 曾用一个多选下拉「按状态隐藏」（hiddenStatuses）做同一件事。
+    // 状态账条把计数和筛选合到一处，交互更直接，故以账条取代该下拉；字段排序保留。
+    if (stateFilter) {
+      out = out.filter((c) =>
+        matchesStateFilter(c, balanceMap.get(c.id) ?? c.balance, stateFilter),
       );
     }
     // 字段排序（'manual' 保留服务端顺序）。复制后排序，不修改筛选中间数组。
@@ -441,10 +395,17 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
     return out;
   })();
 
-  // 切换分组 / 分级筛选 / 搜索 / 状态隐藏 / 排序时复位到第 1 页，避免空页
+  // 各状态计数（状态账条用）。基于全量凭据而非当前筛选结果 ——
+  // 账条是导航器，点进某一段之后其余段的数字不该跟着变。
+  const stateCounts = countByState(
+    data?.credentials ?? [],
+    (c) => balanceMap.get(c.id) ?? c.balance,
+  );
+
+  // 切换分组 / 分级筛选 / 搜索 / 状态 / 排序时复位到第 1 页，避免空页
   useEffect(() => {
     setCurrentPage(1);
-  }, [groupFilter, tierFilter, searchQuery, hiddenStatuses, sortField, sortDir]);
+  }, [groupFilter, tierFilter, searchQuery, stateFilter, sortField, sortDir]);
 
   // pageSize === 0 表示“全部”：单页容纳全部已筛选凭据
   const effectivePageSize =
@@ -505,15 +466,48 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
     const newOrder = arrayMove(ids, oldIndex, newIndex);
     setPageOrder(newOrder);
 
-    // 按新视觉顺序赋连续递增的 priority（全局位置 = startIndex + 页内索引）。
-    // 不依赖原有 priority 值域：即使原值全为默认 0 / 相同，也能保证数字更新、排序持久化；
-    // 跨页也不冲突（第 1 页 0..11、第 2 页 12..23）。只对实际变化的卡片发请求。
-    const prevPriority = new Map(
-      currentCredentials.map((c) => [c.id, c.priority]),
+    // 把新的视觉顺序写回 priority。
+    //
+    // 关键约束：当前页只是全量凭据的一个**子集**（筛选 + 分页），页内索引不等于全局
+    // 位置。若直接按页内索引赋值（早先的 startIndex + i 就是这么做的），筛选态下拖拽
+    // 会写出与被隐藏凭据撞号的 priority —— 例如筛「可用」时隐藏了一个 priority=2 的
+    // 禁用凭据，可见项又被赋了 2，同值再按 id 排序，最终顺序就不是拖出来的那个。
+    //
+    // 正确做法：只在这批被拖动的凭据**原本占据的那些全局槽位**里重新分配。
+    // 隐藏的凭据一格都不动，可见的几个在自己已有的槽位之间换位。
+    const queue = [...(data?.credentials ?? [])].sort(
+      (a, b) => a.priority - b.priority || a.id - b.id,
     );
-    const updates = newOrder
-      .map((id, i) => ({ id, priority: startIndex + i }))
-      .filter((u) => prevPriority.get(u.id) !== u.priority);
+    const dragged = new Set(ids);
+    // 这些凭据当前占用的 priority 值，升序 —— 即可供重排的槽位
+    const slots = queue
+      .filter((c) => dragged.has(c.id))
+      .map((c) => c.priority)
+      .sort((a, b) => a - b);
+
+    const prevPriority = new Map(queue.map((c) => [c.id, c.priority]));
+
+    // 槽位必须严格递增才能表达顺序。全新账号池的 priority 默认全是 0，此时
+    // slots = [0,0,0…]，换位换不出任何差别（同值只能靠 id 排），拖了像没反应。
+    // 这种情况下退回到"给整个队列重编号"：按当前全局顺序（已含本次拖动）写 0..n-1。
+    // 写入量大一些，但只会在第一次拖拽时发生 —— 编号完成后各值互不相同，
+    // 后续拖拽都走上面那条只动几格的轻路径。
+    const slotsUsable = slots.every((v, i) => i === 0 || v > slots[i - 1]);
+
+    let updates: { id: number; priority: number }[];
+    if (slotsUsable) {
+      updates = newOrder.map((id, i) => ({ id, priority: slots[i] }));
+    } else {
+      // 用新顺序替换掉队列中这批凭据的相对次序，其余保持原位
+      const reordered = [...newOrder];
+      const globalOrder = queue.map((c) =>
+        dragged.has(c.id) ? reordered.shift()! : c.id,
+      );
+      updates = globalOrder.map((id, i) => ({ id, priority: i }));
+    }
+    updates = updates.filter(
+      (u) => u.priority != null && prevPriority.get(u.id) !== u.priority,
+    );
     if (updates.length === 0) return;
 
     Promise.all(
@@ -522,7 +516,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
       ),
     )
       .then(() => {
-        toast.success("优先级顺序已更新");
+        toast.success("顺序已保存 · 越靠上越先被使用");
         queryClient.invalidateQueries({ queryKey: ["credentials"] });
       })
       .catch((err) => {
@@ -1404,60 +1398,14 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           </div>
         </div>
 
-        {/* 统计卡片 */}
-        <div className="mb-5 grid grid-cols-3 gap-2 sm:mb-6 sm:gap-4">
-          <Card className="hover:shadow-apple-lg hover:-translate-y-0.5">
-            <CardContent className="p-3 sm:p-5">
-              <div className="text-[11px] font-medium text-muted-foreground sm:text-[13px]">
-                凭据总数
-              </div>
-              <div className="mt-1.5 text-2xl font-semibold tracking-tight tabular-nums sm:mt-2 sm:text-3xl">
-                {formatNumber(data?.total)}
-              </div>
-            </CardContent>
-          </Card>
-          <Card className="hover:shadow-apple-lg hover:-translate-y-0.5">
-            <CardContent className="p-3 sm:p-5">
-              <div className="text-[11px] font-medium text-muted-foreground sm:text-[13px]">
-                可用凭据
-              </div>
-              <div className="mt-1.5 text-2xl font-semibold tracking-tight tabular-nums text-emerald-600 dark:text-emerald-400 sm:mt-2 sm:text-3xl">
-                {formatNumber(data?.available)}
-              </div>
-            </CardContent>
-          </Card>
-          <Card className="hover:shadow-apple-lg hover:-translate-y-0.5">
-            <CardContent className="p-3 sm:p-5">
-              <div className="text-[11px] font-medium text-muted-foreground sm:text-[13px]">
-                {loadBalancingData?.mode === "balanced" ? "调度模式" : "当前优先"}
-              </div>
-              <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1.5 sm:mt-2 sm:gap-2">
-                <span className="truncate text-2xl font-semibold tracking-tight tabular-nums sm:text-3xl">
-                  {loadBalancingData?.mode === "balanced"
-                    ? "均衡负载"
-                    : `#${data?.currentId || "-"}`}
-                </span>
-                {loadBalancingData?.mode === "balanced" ? (
-                  <Badge variant="secondary">动态选择</Badge>
-                ) : (
-                  data?.currentId && <Badge variant="success">当前优先</Badge>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+        {/* 状态标签条已下移到紧贴列表处（见下方 <StatusStrip />）：
+            它是列表的表头兼筛选器，放在标题下方会与它筛选的列表隔开两行工具栏。 */}
 
         {/* 工具栏 */}
         <div className="mb-5 flex flex-col gap-3">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <h2 className="text-lg font-semibold tracking-tight">凭据列表</h2>
-            {data?.credentials && data.credentials.length > 0 && (
-              <Badge variant="secondary">
-                {groupFilter || tierFilter.size > 0
-                  ? `${filteredCredentials.length} / ${data.credentials.length}`
-                  : data.credentials.length}
-              </Badge>
-            )}
+            {/* 原先这里有「凭据列表」标题 + 总数徽章：标题与页面大标题「凭据管理」
+                说的是同一件事，总数已由状态标签条的「全部 N」给出，两者都删掉。 */}
             {groupFilter && (
               <Badge variant="outline" className="gap-1">
                 筛选：{groupFilter === "__none__" ? "未分组" : groupFilter}
@@ -1488,47 +1436,9 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
               </Badge>
             )}
 
-            {currentCredentials.length > 0 && (
-              <Button
-                size="sm"
-                variant="ghost"
-                className="px-2 sm:px-3"
-                onClick={toggleSelectCurrentPage}
-                title={currentPageAllSelected ? "取消选择当前页" : "全选当前页"}
-              >
-                {currentPageAllSelected ? "取消全选" : "全选当前页"}
-              </Button>
-            )}
-            {filteredCredentials.length > currentCredentials.length && (
-              <Button
-                size="sm"
-                variant="ghost"
-                className="px-2 sm:px-3"
-                onClick={toggleSelectAllFiltered}
-                title={
-                  allFilteredSelected
-                    ? "取消选择全部筛选结果"
-                    : `全选所有 ${filteredCredentials.length} 个筛选结果`
-                }
-              >
-                {allFilteredSelected
-                  ? "取消全选所有页"
-                  : `全选所有页 (${filteredCredentials.length})`}
-              </Button>
-            )}
-            {selectedIds.size > 0 && (
-              <>
-                <Badge variant="default">已选 {selectedIds.size}</Badge>
-                <Button
-                  onClick={deselectAll}
-                  size="sm"
-                  variant="ghost"
-                  className="px-2 sm:px-3"
-                >
-                  取消选择
-                </Button>
-              </>
-            )}
+            {/* 全选按钮已移到「添加凭据」左侧，与其它操作同处一行 */}
+            {/* 已选计数与取消选择由吸底批量栏承担；状态筛选态由下方标签条的
+                激活样式直接体现，不再额外挂一枚可关闭徽章。 */}
             {verifying && !verifyDialogOpen && (
               <Button
                 onClick={() => setVerifyDialogOpen(true)}
@@ -1699,59 +1609,6 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              {/* 按状态隐藏（多选） */}
-              <DropdownMenu modal={false}>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    title="隐藏指定状态的凭据（可多选）"
-                    className="inline-flex h-8 w-full items-center justify-between gap-1 rounded-full border border-border bg-card/60 px-3 text-sm backdrop-blur hover:bg-accent sm:w-[128px]"
-                  >
-                    <span className="inline-flex min-w-0 items-center gap-1">
-                      <EyeOff
-                        className={`h-3.5 w-3.5 shrink-0 ${hiddenStatuses.size > 0 ? "text-primary" : "opacity-70"}`}
-                      />
-                      <span className="truncate">
-                        {hiddenStatuses.size > 0
-                          ? `隐藏 ·${hiddenStatuses.size}`
-                          : "隐藏状态"}
-                      </span>
-                    </span>
-                    <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-60" />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-[10rem]">
-                  <DropdownMenuLabel>隐藏这些状态</DropdownMenuLabel>
-                  {STATUS_OPTIONS.map((s) => (
-                    <DropdownMenuItem
-                      key={s.value}
-                      onSelect={(e) => {
-                        e.preventDefault();
-                        toggleStatus(s.value);
-                      }}
-                      className="gap-2"
-                    >
-                      <Checkbox checked={hiddenStatuses.has(s.value)} />
-                      <span>{s.label}</span>
-                    </DropdownMenuItem>
-                  ))}
-                  {hiddenStatuses.size > 0 && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onSelect={(e) => {
-                          e.preventDefault();
-                          setHiddenStatuses(new Set());
-                        }}
-                        className="text-muted-foreground"
-                      >
-                        显示全部状态
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-
               {/* 卡片 / 列表 视图切换（iOS 分段控件） */}
               <div className="col-span-2 inline-flex h-8 shrink-0 items-center justify-self-start rounded-full border border-border bg-card/60 p-0.5 backdrop-blur sm:col-span-1">
                 <button
@@ -1787,33 +1644,42 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
 
             {/* 操作 — 右（移动端整宽两列网格，桌面端右对齐内联） */}
             <div className="ml-auto grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:flex-wrap sm:items-center">
-              {selectedIds.size > 0 && (
-                <>
-                  <Button
-                    onClick={() => setBatchEditDialogOpen(true)}
-                    size="sm"
-                    variant="outline"
-                    title="批量编辑分组 / 来源渠道"
-                  >
-                    <Tags className="h-3.5 w-3.5" />
-                    分组/来源
-                  </Button>
-                  <Button
-                    onClick={handleBatchDelete}
-                    size="sm"
-                    variant="destructive"
-                    className="w-full sm:w-auto"
-                    disabled={selectedIds.size === 0 || batchDeleting}
-                  >
-                    {batchDeleting ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Trash2 className="h-3.5 w-3.5" />
-                    )}
-                    删除
-                  </Button>
-                  <span className="mx-1 hidden h-5 w-px bg-border/70 sm:inline-block" />
-                </>
+              {/* 选中后的批量操作已移到吸底批量栏，见本页底部 BulkBar */}
+
+              {/* 全选：紧邻主操作，因为"先选再批量操作"是同一条动线 */}
+              {currentCredentials.length > 0 && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  onClick={toggleSelectCurrentPage}
+                  title={
+                    currentPageAllSelected
+                      ? "取消选择当前页"
+                      : `全选当前页 ${currentCredentials.length} 个`
+                  }
+                >
+                  <CheckSquare className="h-3.5 w-3.5" />
+                  {currentPageAllSelected ? "取消全选" : "全选当前页"}
+                </Button>
+              )}
+              {filteredCredentials.length > currentCredentials.length && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  onClick={toggleSelectAllFiltered}
+                  title={
+                    allFilteredSelected
+                      ? "取消选择全部筛选结果"
+                      : `全选所有 ${filteredCredentials.length} 个筛选结果`
+                  }
+                >
+                  <CheckSquare className="h-3.5 w-3.5" />
+                  {allFilteredSelected
+                    ? "取消全选所有页"
+                    : `全选所有页 (${filteredCredentials.length})`}
+                </Button>
               )}
 
               {/* 主操作 */}
@@ -1896,36 +1762,12 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuLabel>批量操作</DropdownMenuLabel>
-                  <DropdownMenuItem
-                    onSelect={handleBatchVerify}
-                    disabled={selectedIds.size === 0}
-                  >
-                    <CheckCircle2 />
-                    批量验活
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onSelect={(e) => {
-                      e.preventDefault();
-                      handleBatchForceRefresh();
-                    }}
-                    disabled={selectedIds.size === 0 || batchRefreshing}
-                  >
-                    <RefreshCw
-                      className={batchRefreshing ? "animate-spin" : ""}
-                    />
-                    {batchRefreshing
-                      ? `刷新中… ${batchRefreshProgress.current}/${batchRefreshProgress.total}`
-                      : "刷新 Token"}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onSelect={handleBatchResetFailure}
-                    disabled={selectedIds.size === 0}
-                  >
-                    <RotateCcw />
-                    恢复异常
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
+                  {/*
+                    批量操作（验活 / 刷新 Token / 恢复异常 / 分组 / 删除）已移到吸底
+                    批量栏：它们只在选中若干行后才有意义，藏在二级菜单里等于选完还要
+                    再点两层，而且操作入口会随页面滚动离开视野。
+                    这里只保留与选中无关的全局维护动作。
+                  */}
                   <DropdownMenuLabel>维护</DropdownMenuLabel>
                   <DropdownMenuItem
                     onSelect={(e) => {
@@ -2029,6 +1871,73 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           </div>
         </div>
 
+        {/*
+          状态标签条 —— 列表的表头兼筛选器。
+          位置刻意压到工具栏之下、列表之上：上面那些控件是"缩小候选集"（搜索 / 分组 /
+          分级），这里回答的是"看哪一批结果"，所以它属于列表本身，紧贴着列表才说得清
+          改哪个数字影响哪片区域。激活项的底边线用该状态的色轨色，与下方行的左侧色轨
+          是同一个信号。
+        */}
+        {(data?.credentials.length ?? 0) > 0 && (
+          <StatusStrip
+            className="mb-2"
+            segments={[
+              {
+                label: "全部",
+                count: stateCounts.total,
+                tone: "none",
+                active: stateFilter === "",
+                onClick: () => setStateFilter(""),
+                hint: "不按状态筛选",
+              },
+              {
+                label: "可用",
+                count: stateCounts.healthy,
+                tone: "ok",
+                active: stateFilter === "healthy",
+                onClick: () => setStateFilter("healthy"),
+                hint: "正常参与调度的凭据 —— 排队顺序只在这批里生效",
+              },
+              {
+                label: "冷却",
+                count: stateCounts.throttled,
+                tone: "cool",
+                active: stateFilter === "throttled",
+                onClick: () => setStateFilter("throttled"),
+                hint: "账号级风控冷却中，到期自动恢复",
+              },
+              {
+                label: "超额",
+                count: stateCounts.quota,
+                tone: "warn",
+                active: stateFilter === "quota",
+                onClick: () => setStateFilter("quota"),
+                hint: "额度用尽，需等重置或开启超额",
+              },
+              {
+                label: "禁用",
+                count: stateCounts.dead,
+                tone: "dead",
+                active: stateFilter === "dead",
+                onClick: () => setStateFilter("dead"),
+                hint: "鉴权失败 / 封禁 / 手动禁用，需要处置",
+              },
+            ]}
+            trailing={
+              <span className="text-[12.5px] text-muted-foreground">
+                {loadBalancingData?.mode === "balanced" ? (
+                  "均衡负载"
+                ) : (
+                  <>
+                    当前优先{" "}
+                    <span className="console-num">#{data?.currentId || "-"}</span>
+                  </>
+                )}
+              </span>
+            }
+          />
+        )}
+
         {/* 列表 */}
         {data?.credentials.length === 0 ? (
           <Card>
@@ -2039,6 +1948,37 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
               <p className="text-sm text-muted-foreground">
                 暂无凭据，点击右上角“添加凭据”开始
               </p>
+            </CardContent>
+          </Card>
+        ) : filteredCredentials.length === 0 ? (
+          /*
+            有凭据但当前筛选下一个都不剩。默认筛「可用」时这很容易发生（全池超额
+            或全被禁用），此时说"暂无凭据，去添加"是假话 —— 凭据在，只是都不健康。
+            空态要说清真实情况，并给出下一步。
+          */
+          <Card>
+            <CardContent className="py-16 text-center">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary text-muted-foreground">
+                <Server className="h-5 w-5" />
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {stateFilter === "healthy" && stateCounts.total > 0
+                  ? `${stateCounts.total} 个凭据里没有可用的：冷却 ${stateCounts.throttled} · 超额 ${stateCounts.quota} · 禁用 ${stateCounts.dead}`
+                  : "当前筛选条件下没有凭据"}
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="mt-3"
+                onClick={() => {
+                  setStateFilter("");
+                  setGroupFilter("");
+                  setTierFilter(new Set());
+                  setSearchQuery("");
+                }}
+              >
+                显示全部凭据
+              </Button>
             </CardContent>
           </Card>
         ) : (
@@ -2086,6 +2026,74 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 </div>
               </SortableContext>
             </DndContext>
+
+            {/*
+              吸底批量栏：选中 > 0 时滑入，操作直接摆在表面。
+              解决的是"选完还要去顶部菜单里翻"以及"滚到列表中段后操作入口已滚出视野"。
+            */}
+            <BulkBar
+              count={selectedIds.size}
+              onClear={deselectAll}
+              noun="个凭据"
+            >
+              <Button
+                onClick={() => setBatchEditDialogOpen(true)}
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2.5 text-xs"
+                title="批量编辑分组 / 来源渠道"
+              >
+                <Tags className="h-3.5 w-3.5" />
+                分组/来源
+              </Button>
+              <Button
+                onClick={handleBatchVerify}
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2.5 text-xs"
+                disabled={verifying}
+              >
+                <CheckCircle2
+                  className={`h-3.5 w-3.5 ${verifying ? "animate-spin" : ""}`}
+                />
+                {verifying
+                  ? `验活中 ${verifyProgress.current}/${verifyProgress.total}`
+                  : "验活"}
+              </Button>
+              <Button
+                onClick={handleBatchForceRefresh}
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2.5 text-xs"
+                disabled={batchRefreshing}
+              >
+                <RefreshCw
+                  className={`h-3.5 w-3.5 ${batchRefreshing ? "animate-spin" : ""}`}
+                />
+                {batchRefreshing
+                  ? `刷新中 ${batchRefreshProgress.current}/${batchRefreshProgress.total}`
+                  : "刷新 Token"}
+              </Button>
+              <Button
+                onClick={handleBatchResetFailure}
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2.5 text-xs"
+                title="清零失败计数并恢复禁用状态"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                恢复异常
+              </Button>
+              <Button
+                onClick={handleBatchDelete}
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2.5 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                删除
+              </Button>
+            </BulkBar>
 
             {filteredCredentials.length > 0 && (
               <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:mt-8 sm:flex-row sm:gap-5">

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -140,7 +140,7 @@ import {
   generateApiKey,
   overageFailureMessage,
 } from "@/lib/utils";
-import type { BalanceResponse } from "@/types/api";
+import type { BalanceResponse, CredentialStatusItem } from "@/types/api";
 import { StatusStrip } from "@/components/console/status-strip";
 import { BulkBar } from "@/components/console/bulk-bar";
 import {
@@ -173,6 +173,43 @@ const TIER_LABELS: Record<Tier, string> = {
 
 // 每页数量可选项；另有“全部”（pageSize = 0）由下拉单独追加
 const PAGE_SIZE_OPTIONS = [12, 24, 48, 96] as const;
+
+/** 仅供本地开发预览卡片布局，不会随生产构建或任何 API 请求出现。 */
+const DEV_PREVIEW_CREDENTIAL: CredentialStatusItem = {
+  id: -1,
+  priority: 0,
+  disabled: false,
+  failureCount: 0,
+  totalFailureCount: 0,
+  isCurrent: true,
+  expiresAt: null,
+  authMethod: "api_key",
+  hasProfileArn: false,
+  email: "demo.credential@preview.local",
+  subscriptionTitle: "KIRO PRO",
+  maskedApiKey: "ksk_…demo",
+  successCount: 1_284,
+  lastUsedAt: new Date().toISOString(),
+  hasProxy: true,
+  proxyUrl: "http://demo:demo@127.0.0.1:8080",
+  refreshFailureCount: 0,
+  endpoint: "ide",
+  groups: ["开发预览"],
+  sourceChannel: "Demo（不保存）",
+  metadata: { type: "normal", saleStatus: "not_for_sale" },
+  balance: {
+    id: -1,
+    subscriptionTitle: "KIRO PRO",
+    currentUsage: 186.5,
+    usageLimit: 500,
+    remaining: 313.5,
+    usagePercentage: 37.3,
+    nextResetAt: 1780300800,
+    overageCapable: true,
+    overageEnabled: false,
+  },
+  createdAt: "2026-08-01T10:30:00Z",
+};
 
 // 字段排序：'manual' = 服务端顺序（保留拖拽调优先级）；其余字段选中后拖拽自动禁用
 type SortField =
@@ -288,6 +325,9 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   const { data: updateCheck } = useUpdateCheck();
   const { data: failureStatsMap } = useFailureStats();
   const groupOptions = useGroupOptions();
+  const allCredentials = import.meta.env.DEV
+    ? [DEV_PREVIEW_CREDENTIAL, ...(data?.credentials ?? [])]
+    : (data?.credentials ?? []);
 
   // 分组筛选：'' = 全部；'__none__' = 仅显示未分组；其他 = 按分组名筛选
   const [groupFilter, setGroupFilter] = useState<string>("");
@@ -329,7 +369,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
 
   // 应用分组 + 分级筛选后的凭据全集（分页前先过滤，确保翻页粒度正确）
   const filteredCredentials = (() => {
-    const all = data?.credentials ?? [];
+    const all = allCredentials;
     let out = all;
     if (groupFilter) {
       out =
@@ -1939,7 +1979,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
         )}
 
         {/* 列表 */}
-        {data?.credentials.length === 0 ? (
+        {allCredentials.length === 0 ? (
           <Card>
             <CardContent className="py-16 text-center">
               <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary text-muted-foreground">
@@ -2020,7 +2060,8 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                         handleRefreshBalance(credential.id)
                       }
                       failureStats={failureStatsMap?.[String(credential.id)]}
-                      dragDisabled={dragDisabled}
+                      dragDisabled={dragDisabled || credential.id === DEV_PREVIEW_CREDENTIAL.id}
+                      preview={credential.id === DEV_PREVIEW_CREDENTIAL.id}
                       metadataSchema={data?.metadataSchema}
                     />
                   ))}

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -197,7 +197,23 @@ const DEV_PREVIEW_CREDENTIAL: CredentialStatusItem = {
   endpoint: "ide",
   groups: ["开发预览"],
   sourceChannel: "Demo（不保存）",
-  metadata: { type: "normal", saleStatus: "for_sale", salePrice: 99 },
+  metadata: {
+    type: {
+      title: "账号类型",
+      description: "账号运营分类，仅用于标记，不参与调度。",
+      value: "normal",
+    },
+    saleStatus: {
+      title: "在售状态",
+      description: "账号运营销售状态，仅用于标记，不参与调度。",
+      value: "for_sale",
+    },
+    salePrice: {
+      title: "销售价格（CNY）",
+      description: "账号销售价格，单位为人民币。",
+      value: 99,
+    },
+  },
   balance: {
     id: -1,
     subscriptionTitle: "KIRO PRO",
@@ -394,6 +410,12 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
   // 在队列里 —— 混进禁用/超额的行会让拖拽出来的次序与实际调度顺序对不上。
   // 其余状态的计数仍在账条上，点一下即可切过去。
   const [stateFilter, setStateFilter] = useState<StateFilter>("healthy");
+  const clearAllFilters = () => {
+    setSearchQuery("");
+    setGroupFilter("");
+    setTierFilter(new Set());
+    setStateFilter("");
+  };
   const toggleTier = (t: Tier) => {
     setTierFilter((prev) => {
       const next = new Set(prev);
@@ -2061,12 +2083,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 size="sm"
                 variant="outline"
                 className="mt-3"
-                onClick={() => {
-                  setStateFilter("");
-                  setGroupFilter("");
-                  setTierFilter(new Set());
-                  setSearchQuery("");
-                }}
+                onClick={clearAllFilters}
               >
                 显示全部凭据
               </Button>

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -196,7 +196,7 @@ const DEV_PREVIEW_CREDENTIAL: CredentialStatusItem = {
   endpoint: "ide",
   groups: ["开发预览"],
   sourceChannel: "Demo（不保存）",
-  metadata: { type: "normal", saleStatus: "not_for_sale" },
+  metadata: { type: "normal", saleStatus: "for_sale", salePrice: 99 },
   balance: {
     id: -1,
     subscriptionTitle: "KIRO PRO",

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -2069,6 +2069,9 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
               </SortableContext>
             </DndContext>
 
+            {/* 隔开与 BulkBar 吸底栏的垂直安全间距 */}
+            <div className="h-6 sm:h-8" />
+
             {/*
               吸底批量栏：选中 > 0 时滑入，操作直接摆在表面。
               解决的是"选完还要去顶部菜单里翻"以及"滚到列表中段后操作入口已滚出视野"。

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -2082,7 +2082,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 onClick={() => setBatchEditDialogOpen(true)}
                 size="sm"
                 variant="ghost"
-                className="h-7 px-2.5 text-xs"
+                className="h-8 px-3 text-xs gap-1.5 rounded-full hover:bg-accent"
                 title="批量编辑分组 / 来源渠道"
               >
                 <Tags className="h-3.5 w-3.5" />
@@ -2092,7 +2092,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 onClick={handleBatchVerify}
                 size="sm"
                 variant="ghost"
-                className="h-7 px-2.5 text-xs"
+                className="h-8 px-3 text-xs gap-1.5 rounded-full hover:bg-accent"
                 disabled={verifying}
               >
                 <CheckCircle2
@@ -2106,7 +2106,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 onClick={handleBatchForceRefresh}
                 size="sm"
                 variant="ghost"
-                className="h-7 px-2.5 text-xs"
+                className="h-8 px-3 text-xs gap-1.5 rounded-full hover:bg-accent"
                 disabled={batchRefreshing}
               >
                 <RefreshCw
@@ -2120,7 +2120,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 onClick={handleBatchResetFailure}
                 size="sm"
                 variant="ghost"
-                className="h-7 px-2.5 text-xs"
+                className="h-8 px-3 text-xs gap-1.5 rounded-full hover:bg-accent"
                 title="清零失败计数并恢复禁用状态"
               >
                 <RotateCcw className="h-3.5 w-3.5" />
@@ -2130,7 +2130,8 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                 onClick={handleBatchDelete}
                 size="sm"
                 variant="ghost"
-                className="h-7 px-2.5 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+                disabled={batchDeleting}
+                className="h-8 px-3 text-xs gap-1.5 rounded-full text-destructive hover:bg-destructive/10 hover:text-destructive"
               >
                 <Trash2 className="h-3.5 w-3.5" />
                 删除

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -2027,13 +2027,13 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
               },
             ]}
             trailing={
-              <div className="inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-background/60 px-2.5 py-1 text-xs text-muted-foreground backdrop-blur-xs">
+              <div className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs text-muted-foreground">
                 <span
                   className={cn(
-                    "h-2 w-2 rounded-full",
+                    "h-2 w-2 rounded-sm",
                     loadBalancingData?.mode === "balanced"
-                      ? "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)] animate-pulse"
-                      : "bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)]"
+                      ? "bg-emerald-500 animate-pulse"
+                      : "bg-blue-500"
                   )}
                 />
                 {loadBalancingData?.mode === "balanced" ? (

--- a/admin-ui/src/components/dashboard.tsx
+++ b/admin-ui/src/components/dashboard.tsx
@@ -2021,6 +2021,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
                       }
                       failureStats={failureStatsMap?.[String(credential.id)]}
                       dragDisabled={dragDisabled}
+                      metadataSchema={data?.metadataSchema}
                     />
                   ))}
                 </div>
@@ -2165,6 +2166,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
       <AddCredentialDialog
         open={addDialogOpen}
         onOpenChange={setAddDialogOpen}
+        metadataSchema={data?.metadataSchema}
       />
       <BatchImportDialog
         open={batchImportDialogOpen}
@@ -2177,6 +2179,7 @@ export function Dashboard({ onLogout, embedded = false }: DashboardProps) {
           selectedIds.has(c.id),
         )}
         groupOptions={groupOptions}
+        metadataSchema={data?.metadataSchema}
         onDone={deselectAll}
       />
       <SocialLoginDialog

--- a/admin-ui/src/components/edit-credential-dialog.tsx
+++ b/admin-ui/src/components/edit-credential-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { toast } from 'sonner'
 import { useQuery } from '@tanstack/react-query'
+import { Tags, Settings2 } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -23,10 +24,17 @@ import { Input } from '@/components/ui/input'
 import { useUpdateCredential } from '@/hooks/use-credentials'
 import { useGroupOptions } from '@/hooks/use-groups'
 import { getProxyPool } from '@/api/credentials'
-import { extractErrorMessage, maskProxyUrl } from '@/lib/utils'
+import { extractErrorMessage, maskProxyUrl, cn } from '@/lib/utils'
 import { GroupMultiSelect } from '@/components/group-select'
 import { CredentialMetadataEditor, metadataDefaults } from '@/components/credential-metadata-field'
 import type { CredentialMetadata, CredentialMetadataSchema, CredentialStatusItem } from '@/types/api'
+
+type TabKey = 'general' | 'metadata'
+
+const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+  { key: 'general', label: '基本', icon: <Settings2 className="h-3.5 w-3.5" /> },
+  { key: 'metadata', label: 'Metadata', icon: <Tags className="h-3.5 w-3.5" /> },
+]
 
 interface EditCredentialDialogProps {
   open: boolean
@@ -48,6 +56,7 @@ export function EditCredentialDialog({
   credential,
   metadataSchema,
 }: EditCredentialDialogProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>('general')
   const [email, setEmail] = useState(credential.email ?? '')
   const [proxyUrl, setProxyUrl] = useState(credential.proxyUrl ?? '')
   const [proxyUsername, setProxyUsername] = useState('')
@@ -70,6 +79,7 @@ export function EditCredentialDialog({
   // 每次打开时重置表单为当前凭据值
   useEffect(() => {
     if (open) {
+      setActiveTab('general')
       setEmail(credential.email ?? '')
       setProxyUrl(credential.proxyUrl ?? '')
       setProxyUsername('')
@@ -137,135 +147,161 @@ export function EditCredentialDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit}>
-          <div className="space-y-4 py-4">
-            {/* 邮箱 */}
-            <div className="space-y-2">
-              <label htmlFor="email" className="text-sm font-medium">
-                邮箱（用于显示标识）
-              </label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="例: user@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                disabled={isPending}
-              />
-              <p className="text-xs text-muted-foreground">
-                留空则显示凭据 ID，清除请提交空值
-              </p>
-            </div>
-
-            {/* 账号分组 */}
-            <div className="space-y-2">
-              <label className="text-sm font-medium">账号分组</label>
-              <GroupMultiSelect
-                value={groups}
-                options={groupOptions}
-                onChange={setGroups}
-                disabled={isPending}
-              />
-              <p className="text-xs text-muted-foreground">
-                绑定了某分组的客户端 Key 只会调度到含该分组的账号。不选表示不属于任何分组。
-              </p>
-            </div>
-
-            {/* 账号来源渠道 */}
-            <div className="space-y-2">
-              <label htmlFor="sourceChannel" className="text-sm font-medium">
-                账号来源渠道（备注）
-              </label>
-              <Input
-                id="sourceChannel"
-                placeholder="例: 官方, 转售商A, 采购平台X"
-                value={sourceChannel}
-                onChange={(e) => setSourceChannel(e.target.value)}
-                disabled={isPending}
-              />
-              <p className="text-xs text-muted-foreground">
-                纯备注，标记此账号的购买来源/渠道，便于追踪。留空表示清除。
-              </p>
-            </div>
-
-            <CredentialMetadataEditor
-              schema={metadataSchema}
-              value={metadata}
-              onChange={setMetadata}
-              disabled={isPending}
-            />
-
-            {/* 代理配置 */}
-            <div className="space-y-2">
-              <label className="text-sm font-medium">代理配置</label>
-
-              {/* 下拉选择代理 */}
-              <Select
-                value={selectValue === '' ? '__global__' : selectValue}
-                onValueChange={(val) => {
-                  if (val === '__custom__') {
-                    setManualMode(true)
-                    // 保留当前 proxyUrl 作为初始值让用户编辑
-                  } else {
-                    setManualMode(false)
-                    setProxyUrl(val === '__global__' ? '' : val)
-                  }
-                }}
-                disabled={isPending}
-              >
-                <SelectTrigger className="h-10 rounded-xl px-3.5">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__global__">使用全局代理配置</SelectItem>
-                  <SelectItem value="direct">直连（不使用代理）</SelectItem>
-                  {enabledProxies.length > 0 && (
-                    <SelectGroup>
-                      <SelectLabel>代理池</SelectLabel>
-                      {enabledProxies.map((p) => (
-                        <SelectItem key={p.id} value={p.url}>
-                          {p.label ? `${p.label} | ${maskProxyUrl(p.url)}` : maskProxyUrl(p.url)}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  )}
-                  <SelectItem value="__custom__">手动输入...</SelectItem>
-                </SelectContent>
-              </Select>
-
-              {/* 自定义 URL 手动输入框 */}
-              {showManualInput && (
-                <Input
-                  placeholder='自定义代理 URL（如 socks5://user:pass@host:port）'
-                  value={proxyUrl}
-                  onChange={(e) => setProxyUrl(e.target.value)}
-                  disabled={isPending}
-                  className="font-mono text-sm"
-                />
+        {/* 标签导航 */}
+        <nav className="-mx-1 flex gap-0.5" aria-label="编辑分区">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[13px] transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+                activeTab === tab.key
+                  ? 'bg-primary/12 font-medium text-foreground'
+                  : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
               )}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </nav>
 
-              {/* 代理认证（仅在需要时显示） */}
-              <div className="grid grid-cols-2 gap-2">
-                <Input
-                  id="proxyUsername"
-                  placeholder="代理用户名（留空不修改）"
-                  value={proxyUsername}
-                  onChange={(e) => setProxyUsername(e.target.value)}
-                  disabled={isPending}
-                />
-                <Input
-                  id="proxyPassword"
-                  type="password"
-                  placeholder="代理密码（留空不修改）"
-                  value={proxyPassword}
-                  onChange={(e) => setProxyPassword(e.target.value)}
-                  disabled={isPending}
-                />
-              </div>
-              <p className="text-xs text-muted-foreground">
-                用户名/密码留空表示不修改；代理 URL 已包含凭据时无需填写
-              </p>
-            </div>
+        <form onSubmit={handleSubmit}>
+          <div className="min-h-[280px] space-y-4 py-2">
+            {activeTab === 'general' && (
+              <>
+                {/* 邮箱 */}
+                <div className="space-y-2">
+                  <label htmlFor="email" className="text-sm font-medium">
+                    邮箱（用于显示标识）
+                  </label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="例: user@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    disabled={isPending}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    留空则显示凭据 ID，清除请提交空值
+                  </p>
+                </div>
+
+                {/* 账号分组 */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">账号分组</label>
+                  <GroupMultiSelect
+                    value={groups}
+                    options={groupOptions}
+                    onChange={setGroups}
+                    disabled={isPending}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    绑定了某分组的客户端 Key 只会调度到含该分组的账号。不选表示不属于任何分组。
+                  </p>
+                </div>
+
+                {/* 账号来源渠道 */}
+                <div className="space-y-2">
+                  <label htmlFor="sourceChannel" className="text-sm font-medium">
+                    账号来源渠道（备注）
+                  </label>
+                  <Input
+                    id="sourceChannel"
+                    placeholder="例: 官方, 转售商A, 采购平台X"
+                    value={sourceChannel}
+                    onChange={(e) => setSourceChannel(e.target.value)}
+                    disabled={isPending}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    纯备注，标记此账号的购买来源/渠道，便于追踪。留空表示清除。
+                  </p>
+                </div>
+
+                {/* 代理配置 */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">代理配置</label>
+
+                  {/* 下拉选择代理 */}
+                  <Select
+                    value={selectValue === '' ? '__global__' : selectValue}
+                    onValueChange={(val) => {
+                      if (val === '__custom__') {
+                        setManualMode(true)
+                      } else {
+                        setManualMode(false)
+                        setProxyUrl(val === '__global__' ? '' : val)
+                      }
+                    }}
+                    disabled={isPending}
+                  >
+                    <SelectTrigger className="h-10 rounded-xl px-3.5">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__global__">使用全局代理配置</SelectItem>
+                      <SelectItem value="direct">直连（不使用代理）</SelectItem>
+                      {enabledProxies.length > 0 && (
+                        <SelectGroup>
+                          <SelectLabel>代理池</SelectLabel>
+                          {enabledProxies.map((p) => (
+                            <SelectItem key={p.id} value={p.url}>
+                              {p.label ? `${p.label} | ${maskProxyUrl(p.url)}` : maskProxyUrl(p.url)}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      )}
+                      <SelectItem value="__custom__">手动输入...</SelectItem>
+                    </SelectContent>
+                  </Select>
+
+                  {/* 自定义 URL 手动输入框 */}
+                  {showManualInput && (
+                    <Input
+                      placeholder="自定义代理 URL（如 socks5://user:pass@host:port）"
+                      value={proxyUrl}
+                      onChange={(e) => setProxyUrl(e.target.value)}
+                      disabled={isPending}
+                      className="font-mono text-sm"
+                    />
+                  )}
+
+                  {/* 代理认证（仅在需要时显示） */}
+                  <div className="grid grid-cols-2 gap-2">
+                    <Input
+                      id="proxyUsername"
+                      placeholder="代理用户名（留空不修改）"
+                      value={proxyUsername}
+                      onChange={(e) => setProxyUsername(e.target.value)}
+                      disabled={isPending}
+                    />
+                    <Input
+                      id="proxyPassword"
+                      type="password"
+                      placeholder="代理密码（留空不修改）"
+                      value={proxyPassword}
+                      onChange={(e) => setProxyPassword(e.target.value)}
+                      disabled={isPending}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    用户名/密码留空表示不修改；代理 URL 已包含凭据时无需填写
+                  </p>
+                </div>
+              </>
+            )}
+
+            {activeTab === 'metadata' && (
+              <CredentialMetadataEditor
+                schema={metadataSchema}
+                value={metadata}
+                onChange={setMetadata}
+                disabled={isPending}
+              />
+            )}
           </div>
 
           <DialogFooter>

--- a/admin-ui/src/components/edit-credential-dialog.tsx
+++ b/admin-ui/src/components/edit-credential-dialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -24,18 +25,21 @@ import { useGroupOptions } from '@/hooks/use-groups'
 import { getProxyPool } from '@/api/credentials'
 import { extractErrorMessage, maskProxyUrl } from '@/lib/utils'
 import { GroupMultiSelect } from '@/components/group-select'
-import type { CredentialStatusItem } from '@/types/api'
+import { CredentialMetadataEditor, metadataDefaults } from '@/components/credential-metadata-field'
+import type { CredentialMetadata, CredentialMetadataSchema, CredentialStatusItem } from '@/types/api'
 
 interface EditCredentialDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   credential: CredentialStatusItem
+  metadataSchema?: CredentialMetadataSchema
 }
 
 export function EditCredentialDialog({
   open,
   onOpenChange,
   credential,
+  metadataSchema,
 }: EditCredentialDialogProps) {
   const [email, setEmail] = useState(credential.email ?? '')
   const [proxyUrl, setProxyUrl] = useState(credential.proxyUrl ?? '')
@@ -43,6 +47,7 @@ export function EditCredentialDialog({
   const [proxyPassword, setProxyPassword] = useState('')
   const [groups, setGroups] = useState<string[]>(credential.groups ?? [])
   const [sourceChannel, setSourceChannel] = useState(credential.sourceChannel ?? '')
+  const [metadata, setMetadata] = useState<CredentialMetadata>(credential.metadata ?? { type: 'normal' })
   const [manualMode, setManualMode] = useState(false)
 
   const groupOptions = useGroupOptions()
@@ -62,9 +67,10 @@ export function EditCredentialDialog({
       setProxyPassword('')
       setGroups(credential.groups ?? [])
       setSourceChannel(credential.sourceChannel ?? '')
+      setMetadata({ ...metadataDefaults(metadataSchema), ...(credential.metadata ?? { type: 'normal' }) })
       setManualMode(false)
     }
-  }, [open, credential])
+  }, [open, credential, metadataSchema])
 
   const { mutate, isPending } = useUpdateCredential()
 
@@ -81,6 +87,7 @@ export function EditCredentialDialog({
           proxyPassword: proxyPassword || undefined,
           groups: groups,
           sourceChannel: sourceChannel,
+          metadata,
         },
       },
       {
@@ -113,6 +120,9 @@ export function EditCredentialDialog({
           <DialogTitle>
             编辑凭据 #{credential.id}
           </DialogTitle>
+          <DialogDescription>
+            修改凭据标识、分组、Metadata 与代理配置。
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit}>
@@ -165,6 +175,13 @@ export function EditCredentialDialog({
                 纯备注，标记此账号的购买来源/渠道，便于追踪。留空表示清除。
               </p>
             </div>
+
+            <CredentialMetadataEditor
+              schema={metadataSchema}
+              value={metadata}
+              onChange={setMetadata}
+              disabled={isPending}
+            />
 
             {/* 代理配置 */}
             <div className="space-y-2">

--- a/admin-ui/src/components/edit-credential-dialog.tsx
+++ b/admin-ui/src/components/edit-credential-dialog.tsx
@@ -47,7 +47,9 @@ export function EditCredentialDialog({
   const [proxyPassword, setProxyPassword] = useState('')
   const [groups, setGroups] = useState<string[]>(credential.groups ?? [])
   const [sourceChannel, setSourceChannel] = useState(credential.sourceChannel ?? '')
-  const [metadata, setMetadata] = useState<CredentialMetadata>(credential.metadata ?? { type: 'normal' })
+  const [metadata, setMetadata] = useState<CredentialMetadata>(
+    credential.metadata ?? { type: 'normal', saleStatus: 'not_for_sale' },
+  )
   const [manualMode, setManualMode] = useState(false)
 
   const groupOptions = useGroupOptions()
@@ -67,7 +69,10 @@ export function EditCredentialDialog({
       setProxyPassword('')
       setGroups(credential.groups ?? [])
       setSourceChannel(credential.sourceChannel ?? '')
-      setMetadata({ ...metadataDefaults(metadataSchema), ...(credential.metadata ?? { type: 'normal' }) })
+      setMetadata({
+        ...metadataDefaults(metadataSchema),
+        ...(credential.metadata ?? { type: 'normal', saleStatus: 'not_for_sale' }),
+      })
       setManualMode(false)
     }
   }, [open, credential, metadataSchema])

--- a/admin-ui/src/components/edit-credential-dialog.tsx
+++ b/admin-ui/src/components/edit-credential-dialog.tsx
@@ -35,6 +35,13 @@ interface EditCredentialDialogProps {
   metadataSchema?: CredentialMetadataSchema
 }
 
+/** 状态接口的 metadata 带展示信息；编辑时只回填其中的实际值。 */
+function metadataValues(metadata: CredentialStatusItem['metadata']): Partial<CredentialMetadata> {
+  return Object.fromEntries(
+    Object.entries(metadata ?? {}).map(([key, detail]) => [key, detail.value]),
+  ) as Partial<CredentialMetadata>
+}
+
 export function EditCredentialDialog({
   open,
   onOpenChange,
@@ -48,7 +55,7 @@ export function EditCredentialDialog({
   const [groups, setGroups] = useState<string[]>(credential.groups ?? [])
   const [sourceChannel, setSourceChannel] = useState(credential.sourceChannel ?? '')
   const [metadata, setMetadata] = useState<CredentialMetadata>(
-    credential.metadata ?? { type: 'normal', saleStatus: 'not_for_sale' },
+    { ...metadataDefaults(metadataSchema), ...metadataValues(credential.metadata) },
   )
   const [manualMode, setManualMode] = useState(false)
 
@@ -71,7 +78,7 @@ export function EditCredentialDialog({
       setSourceChannel(credential.sourceChannel ?? '')
       setMetadata({
         ...metadataDefaults(metadataSchema),
-        ...(credential.metadata ?? { type: 'normal', saleStatus: 'not_for_sale' }),
+        ...metadataValues(credential.metadata),
       })
       setManualMode(false)
     }

--- a/admin-ui/src/components/idc-login-dialog.tsx
+++ b/admin-ui/src/components/idc-login-dialog.tsx
@@ -9,114 +9,12 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
-import {
-  Select,
-  SelectGroup,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { RegionSelect } from '@/components/region-select'
 import { startIdcLogin, pollIdcLogin } from '@/api/credentials'
 import type { StartIdcLoginResponse } from '@/types/api'
 import { extractErrorMessage } from '@/lib/utils'
-
-/** 预设 SSO 区域（分组 + 显示名），与 AWS 常用区域一致 */
-const SSO_REGION_GROUPS: { group: string; items: [string, string][] }[] = [
-  {
-    group: 'US',
-    items: [
-      ['us-east-1', 'us-east-1 (N. Virginia)'],
-      ['us-east-2', 'us-east-2 (Ohio)'],
-      ['us-west-1', 'us-west-1 (N. California)'],
-      ['us-west-2', 'us-west-2 (Oregon)'],
-    ],
-  },
-  {
-    group: 'Europe',
-    items: [
-      ['eu-west-1', 'eu-west-1 (Ireland)'],
-      ['eu-west-2', 'eu-west-2 (London)'],
-      ['eu-west-3', 'eu-west-3 (Paris)'],
-      ['eu-central-1', 'eu-central-1 (Frankfurt)'],
-      ['eu-north-1', 'eu-north-1 (Stockholm)'],
-      ['eu-south-1', 'eu-south-1 (Milan)'],
-    ],
-  },
-  {
-    group: 'Asia Pacific',
-    items: [
-      ['ap-northeast-1', 'ap-northeast-1 (Tokyo)'],
-      ['ap-northeast-2', 'ap-northeast-2 (Seoul)'],
-      ['ap-northeast-3', 'ap-northeast-3 (Osaka)'],
-      ['ap-southeast-1', 'ap-southeast-1 (Singapore)'],
-      ['ap-southeast-2', 'ap-southeast-2 (Sydney)'],
-      ['ap-south-1', 'ap-south-1 (Mumbai)'],
-      ['ap-east-1', 'ap-east-1 (Hong Kong)'],
-    ],
-  },
-  {
-    group: 'Other',
-    items: [
-      ['ca-central-1', 'ca-central-1 (Canada)'],
-      ['sa-east-1', 'sa-east-1 (São Paulo)'],
-      ['me-south-1', 'me-south-1 (Bahrain)'],
-      ['af-south-1', 'af-south-1 (Cape Town)'],
-    ],
-  },
-]
-
-const KNOWN_SSO_REGIONS = SSO_REGION_GROUPS.flatMap((g) => g.items.map(([v]) => v))
-
-/** SSO 区域选择：下拉预设区域 + 始终可输入的自定义文本框 */
-function RegionSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const selectValue = KNOWN_SSO_REGIONS.includes(value) ? value : 'custom'
-  const handleSelectChange = (v: string) => {
-    if (v !== 'custom') {
-      onChange(v)
-      return
-    }
-    if (KNOWN_SSO_REGIONS.includes(value)) onChange('')
-    requestAnimationFrame(() => inputRef.current?.focus())
-  }
-
-  return (
-    <div className="flex gap-2">
-      <Select value={selectValue} onValueChange={handleSelectChange}>
-        <SelectTrigger className="flex-1 h-10">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {SSO_REGION_GROUPS.map((g) => (
-            <SelectGroup key={g.group}>
-              <SelectLabel>{g.group}</SelectLabel>
-              {g.items.map(([v, label]) => (
-                <SelectItem key={v} value={v}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          ))}
-          <SelectGroup>
-            <SelectLabel>自定义</SelectLabel>
-            <SelectItem value="custom">-- 自定义输入 --</SelectItem>
-          </SelectGroup>
-        </SelectContent>
-      </Select>
-      <Input
-        ref={inputRef}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="例如: cn-north-1"
-        className="w-36"
-      />
-    </div>
-  )
-}
 
 interface IdcLoginDialogProps {
   open: boolean

--- a/admin-ui/src/components/region-select.tsx
+++ b/admin-ui/src/components/region-select.tsx
@@ -1,0 +1,147 @@
+import { useRef } from 'react'
+import {
+  Select,
+  SelectGroup,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
+
+/** 预设 AWS 区域（分组 + 显示名） */
+export const AWS_REGION_GROUPS: { group: string; items: [string, string][] }[] = [
+  {
+    group: 'US',
+    items: [
+      ['us-east-1', 'us-east-1 (N. Virginia)'],
+      ['us-east-2', 'us-east-2 (Ohio)'],
+      ['us-west-1', 'us-west-1 (N. California)'],
+      ['us-west-2', 'us-west-2 (Oregon)'],
+    ],
+  },
+  {
+    group: 'Europe',
+    items: [
+      ['eu-west-1', 'eu-west-1 (Ireland)'],
+      ['eu-west-2', 'eu-west-2 (London)'],
+      ['eu-west-3', 'eu-west-3 (Paris)'],
+      ['eu-central-1', 'eu-central-1 (Frankfurt)'],
+      ['eu-north-1', 'eu-north-1 (Stockholm)'],
+      ['eu-south-1', 'eu-south-1 (Milan)'],
+    ],
+  },
+  {
+    group: 'Asia Pacific',
+    items: [
+      ['ap-northeast-1', 'ap-northeast-1 (Tokyo)'],
+      ['ap-northeast-2', 'ap-northeast-2 (Seoul)'],
+      ['ap-northeast-3', 'ap-northeast-3 (Osaka)'],
+      ['ap-southeast-1', 'ap-southeast-1 (Singapore)'],
+      ['ap-southeast-2', 'ap-southeast-2 (Sydney)'],
+      ['ap-south-1', 'ap-south-1 (Mumbai)'],
+      ['ap-east-1', 'ap-east-1 (Hong Kong)'],
+    ],
+  },
+  {
+    group: 'Other',
+    items: [
+      ['ca-central-1', 'ca-central-1 (Canada)'],
+      ['sa-east-1', 'sa-east-1 (São Paulo)'],
+      ['me-south-1', 'me-south-1 (Bahrain)'],
+      ['af-south-1', 'af-south-1 (Cape Town)'],
+    ],
+  },
+]
+
+export const KNOWN_AWS_REGIONS = AWS_REGION_GROUPS.flatMap((g) => g.items.map(([v]) => v))
+
+// shadcn Select 不允许 SelectItem 用空字符串作 value，故用哨兵值代表两种非预设状态
+const CUSTOM = 'custom'
+const INHERIT = 'inherit'
+
+/**
+ * AWS 区域选择：下拉预设区域 + 始终可输入的自定义文本框。
+ *
+ * `allowInherit` 区分两种调用语义：登录场景 region 必填（不传该项，空值落到「自定义」
+ * 让用户去填）；凭据级 region 可留空表示回退全局配置（传 true，空值显式显示为
+ * 「跟随全局配置」）。都用「非预设即自定义」会把「留空是合法的」这件事藏起来 ——
+ * 用户看到 `-- 自定义输入 --` 只会以为自己漏填了。
+ */
+export function RegionSelect({
+  value,
+  onChange,
+  allowInherit = false,
+  inheritLabel = '跟随全局配置',
+  placeholder = '例如: cn-north-1',
+  disabled,
+}: {
+  value: string
+  onChange: (v: string) => void
+  allowInherit?: boolean
+  inheritLabel?: string
+  placeholder?: string
+  disabled?: boolean
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const isInherit = allowInherit && value === ''
+  const selectValue = KNOWN_AWS_REGIONS.includes(value)
+    ? value
+    : isInherit
+      ? INHERIT
+      : CUSTOM
+
+  const handleSelectChange = (v: string) => {
+    if (v === INHERIT) {
+      onChange('')
+      return
+    }
+    if (v !== CUSTOM) {
+      onChange(v)
+      return
+    }
+    // 从预设切到自定义：清空并聚焦，避免残留的预设值被误当成手填内容
+    if (KNOWN_AWS_REGIONS.includes(value)) onChange('')
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }
+
+  return (
+    <div className="flex gap-2">
+      <Select value={selectValue} onValueChange={handleSelectChange} disabled={disabled}>
+        <SelectTrigger className="flex-1 h-10">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {allowInherit && (
+            <SelectGroup>
+              <SelectItem value={INHERIT}>{inheritLabel}</SelectItem>
+            </SelectGroup>
+          )}
+          {AWS_REGION_GROUPS.map((g) => (
+            <SelectGroup key={g.group}>
+              <SelectLabel>{g.group}</SelectLabel>
+              {g.items.map(([v, label]) => (
+                <SelectItem key={v} value={v}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          ))}
+          <SelectGroup>
+            <SelectLabel>自定义</SelectLabel>
+            <SelectItem value={CUSTOM}>-- 自定义输入 --</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <Input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={isInherit ? '' : placeholder}
+        className="w-36"
+        disabled={disabled}
+      />
+    </div>
+  )
+}

--- a/admin-ui/src/components/settings-page.tsx
+++ b/admin-ui/src/components/settings-page.tsx
@@ -1,4 +1,5 @@
 import {
+  Cpu,
   Gauge,
   Globe,
   ScrollText,
@@ -15,6 +16,7 @@ import { LogSection } from '@/components/settings/log-section'
 import { SystemSection } from '@/components/settings/system-section'
 import { SecuritySection } from '@/components/settings/security-section'
 import { MetadataSection } from '@/components/settings/metadata-section'
+import { ModelsSection } from '@/components/settings/models-section'
 
 /**
  * 设置页 —— 把此前散在三处的 7 个配置端点收拢到一处。
@@ -27,7 +29,7 @@ import { MetadataSection } from '@/components/settings/metadata-section'
  * 一次点击就该切换完；但参数（冷却时长、连续上限、保留天数这些）全部移到这里 ——
  * 下拉菜单里塞数字输入框本来就不是它该干的事。
  */
-type SectionKey = 'dispatch' | 'metadata' | 'network' | 'log' | 'system' | 'security'
+type SectionKey = 'dispatch' | 'metadata' | 'network' | 'log' | 'models' | 'system' | 'security'
 
 const SECTIONS: {
   key: SectionKey
@@ -58,6 +60,12 @@ const SECTIONS: {
     label: '日志',
     hint: '链路追踪与保留期',
     icon: <ScrollText className="h-4 w-4" />,
+  },
+  {
+    key: 'models',
+    label: '模型',
+    hint: '自定义模型别名与元数据',
+    icon: <Cpu className="h-4 w-4" />,
   },
   {
     key: 'system',
@@ -129,6 +137,7 @@ export function SettingsPage() {
 
             {active === 'dispatch' && <DispatchSection />}
             {active === 'metadata' && <MetadataSection />}
+            {active === 'models' && <ModelsSection />}
             {active === 'network' && <NetworkSection />}
             {active === 'log' && <LogSection />}
             {active === 'system' && <SystemSection />}

--- a/admin-ui/src/components/settings-page.tsx
+++ b/admin-ui/src/components/settings-page.tsx
@@ -4,6 +4,7 @@ import {
   ScrollText,
   PackageOpen,
   ShieldCheck,
+  Tags,
 } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { useUrlState } from '@/hooks/use-url-state'
@@ -13,6 +14,7 @@ import { NetworkSection } from '@/components/settings/network-section'
 import { LogSection } from '@/components/settings/log-section'
 import { SystemSection } from '@/components/settings/system-section'
 import { SecuritySection } from '@/components/settings/security-section'
+import { MetadataSection } from '@/components/settings/metadata-section'
 
 /**
  * 设置页 —— 把此前散在三处的 7 个配置端点收拢到一处。
@@ -25,7 +27,7 @@ import { SecuritySection } from '@/components/settings/security-section'
  * 一次点击就该切换完；但参数（冷却时长、连续上限、保留天数这些）全部移到这里 ——
  * 下拉菜单里塞数字输入框本来就不是它该干的事。
  */
-type SectionKey = 'dispatch' | 'network' | 'log' | 'system' | 'security'
+type SectionKey = 'dispatch' | 'metadata' | 'network' | 'log' | 'system' | 'security'
 
 const SECTIONS: {
   key: SectionKey
@@ -38,6 +40,12 @@ const SECTIONS: {
     label: '调度',
     hint: '凭据怎么选、失败怎么转、禁用怎么恢复',
     icon: <Gauge className="h-4 w-4" />,
+  },
+  {
+    key: 'metadata',
+    label: '凭据字段',
+    hint: '定义 metadata 的 key、类型、默认值和枚举 value',
+    icon: <Tags className="h-4 w-4" />,
   },
   {
     key: 'network',
@@ -120,6 +128,7 @@ export function SettingsPage() {
             </div>
 
             {active === 'dispatch' && <DispatchSection />}
+            {active === 'metadata' && <MetadataSection />}
             {active === 'network' && <NetworkSection />}
             {active === 'log' && <LogSection />}
             {active === 'system' && <SystemSection />}

--- a/admin-ui/src/components/settings-page.tsx
+++ b/admin-ui/src/components/settings-page.tsx
@@ -1,0 +1,132 @@
+import {
+  Gauge,
+  Globe,
+  ScrollText,
+  PackageOpen,
+  ShieldCheck,
+} from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { useUrlState } from '@/hooks/use-url-state'
+import { cn } from '@/lib/utils'
+import { DispatchSection } from '@/components/settings/dispatch-section'
+import { NetworkSection } from '@/components/settings/network-section'
+import { LogSection } from '@/components/settings/log-section'
+import { SystemSection } from '@/components/settings/system-section'
+import { SecuritySection } from '@/components/settings/security-section'
+
+/**
+ * 设置页 —— 把此前散在三处的 7 个配置端点收拢到一处。
+ *
+ * 改造前它们分别住在：顶栏按钮（负载均衡）、顶栏两个下拉（风控故障转移、自愈）、
+ * 顶栏设置菜单（登录密钥）、日志页下拉（日志治理）、代理池弹窗内（全局代理）、
+ * 镜像更新弹窗内（更新配置）。同一类东西分在六个地方，找一个配置得先记住它藏在哪。
+ *
+ * 顶栏**保留**三个快捷开关（负载均衡 / 故障转移 / 自愈），因为它们是运维高频动作，
+ * 一次点击就该切换完；但参数（冷却时长、连续上限、保留天数这些）全部移到这里 ——
+ * 下拉菜单里塞数字输入框本来就不是它该干的事。
+ */
+type SectionKey = 'dispatch' | 'network' | 'log' | 'system' | 'security'
+
+const SECTIONS: {
+  key: SectionKey
+  label: string
+  hint: string
+  icon: React.ReactNode
+}[] = [
+  {
+    key: 'dispatch',
+    label: '调度',
+    hint: '凭据怎么选、失败怎么转、禁用怎么恢复',
+    icon: <Gauge className="h-4 w-4" />,
+  },
+  {
+    key: 'network',
+    label: '网络',
+    hint: '出站代理',
+    icon: <Globe className="h-4 w-4" />,
+  },
+  {
+    key: 'log',
+    label: '日志',
+    hint: '链路追踪与保留期',
+    icon: <ScrollText className="h-4 w-4" />,
+  },
+  {
+    key: 'system',
+    label: '系统',
+    hint: '镜像在线更新',
+    icon: <PackageOpen className="h-4 w-4" />,
+  },
+  {
+    key: 'security',
+    label: '安全',
+    hint: '管理面板登录密钥',
+    icon: <ShieldCheck className="h-4 w-4" />,
+  },
+]
+
+export function SettingsPage() {
+  const [urlState, patchUrl] = useUrlState('settings', { s: 'dispatch' })
+  const active = (SECTIONS.some((x) => x.key === urlState.s)
+    ? urlState.s
+    : 'dispatch') as SectionKey
+
+  const current = SECTIONS.find((s) => s.key === active)!
+
+  return (
+    <div className="console-scope space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight">设置</h2>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          改动即时生效并写入 config.json，无需重启。
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-4 lg:flex-row">
+        {/* 分区导航：桌面端竖排侧栏，窄屏横向滚动的胶囊行 */}
+        <nav
+          className="flex shrink-0 gap-1 overflow-x-auto pb-1 lg:w-48 lg:flex-col lg:overflow-visible lg:pb-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          aria-label="设置分区"
+        >
+          {SECTIONS.map((s) => (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => patchUrl({ s: s.key })}
+              aria-current={active === s.key ? 'page' : undefined}
+              className={cn(
+                'inline-flex shrink-0 items-center gap-2 rounded-lg px-3 py-2 text-left text-[13px] transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+                active === s.key
+                  ? 'bg-primary/12 font-medium text-foreground ring-1 ring-primary/25'
+                  : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
+              )}
+            >
+              {s.icon}
+              <span className="whitespace-nowrap">{s.label}</span>
+            </button>
+          ))}
+        </nav>
+
+        <Card className="min-w-0 flex-1">
+          <CardContent className="p-4 sm:p-5">
+            <div className="mb-3 border-b border-border/60 pb-3">
+              <h3 className="text-[15px] font-semibold tracking-tight">
+                {current.label}
+              </h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {current.hint}
+              </p>
+            </div>
+
+            {active === 'dispatch' && <DispatchSection />}
+            {active === 'network' && <NetworkSection />}
+            {active === 'log' && <LogSection />}
+            {active === 'system' && <SystemSection />}
+            {active === 'security' && <SecuritySection />}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/components/settings/dispatch-section.tsx
+++ b/admin-ui/src/components/settings/dispatch-section.tsx
@@ -1,6 +1,8 @@
 import {
   useAccountThrottleConfig,
   useSetAccountThrottleConfig,
+  useAccountRpmLimitConfig,
+  useSetAccountRpmLimitConfig,
   useLoadBalancingMode,
   useSetLoadBalancingMode,
   useSelfHealConfig,
@@ -17,6 +19,9 @@ import {
 import { reportSaveError } from '@/components/settings/report-error'
 
 const SECS_PER_MIN = 60
+// 与后端 SetAccountRpmLimitConfigRequest 的校验区间保持一致
+const MIN_RPM_LIMIT = 1
+const MAX_RPM_LIMIT = 100000
 
 /**
  * 调度分区：凭据怎么选、失败怎么转、禁用怎么恢复。
@@ -30,6 +35,7 @@ export function DispatchSection() {
     <div className="space-y-6">
       <LoadBalancingGroup />
       <ThrottleGroup />
+      <RpmLimitGroup />
       <SelfHealGroup />
     </div>
   )
@@ -102,6 +108,55 @@ function ThrottleGroup() {
         pending={saver.isSaving('cooldown')}
         saved={saver.isSaved('cooldown')}
         disabled={isLoading || !failover}
+      />
+    </SettingGroup>
+  )
+}
+
+/**
+ * 单账号 RPM 主动限流。
+ *
+ * 紧跟「账号级风控」是有意的：两者都是账号级限速，区别只在谁先动手 ——
+ * 风控是上游 429 之后的被动补救，这里是我们自己先掐住不让它撞上去。
+ * 摆在一起，配了主动限流还在等风控兜底这种误解就不容易发生。
+ */
+function RpmLimitGroup() {
+  const { data, isLoading } = useAccountRpmLimitConfig()
+  const { mutate } = useSetAccountRpmLimitConfig()
+  const saver = useFieldSaver(mutate, reportSaveError)
+  const enabled = data?.enabled ?? false
+  const limit = data?.limit ?? 60
+
+  return (
+    <SettingGroup
+      title="单账号限流"
+      description="主动掐住单个账号的每分钟请求数，别等上游风控才反应"
+    >
+      <SettingSwitch
+        label="启用 RPM 限流"
+        hint={
+          enabled
+            ? '每个凭据独立计 60 秒滑动窗口，超限的临时跳过并切到下一个可用凭据'
+            : '关闭时不计数、不影响调度'
+        }
+        checked={enabled}
+        onChange={(next) => saver.save('enabled', { enabled: next })}
+        pending={saver.isSaving('enabled')}
+        saved={saver.isSaved('enabled')}
+        disabled={isLoading}
+      />
+      <SettingNumber
+        label="每分钟上限"
+        hint="单个凭据 60 秒内最多放行多少请求。所有凭据都超限时请求返回 429"
+        value={limit}
+        onCommit={(n) => saver.save('limit', { limit: n })}
+        min={MIN_RPM_LIMIT}
+        max={MAX_RPM_LIMIT}
+        unit="次/分钟"
+        presets={[10, 30, 60, 120, 300]}
+        pending={saver.isSaving('limit')}
+        saved={saver.isSaved('limit')}
+        disabled={isLoading || !enabled}
       />
     </SettingGroup>
   )

--- a/admin-ui/src/components/settings/dispatch-section.tsx
+++ b/admin-ui/src/components/settings/dispatch-section.tsx
@@ -1,0 +1,176 @@
+import {
+  useAccountThrottleConfig,
+  useSetAccountThrottleConfig,
+  useLoadBalancingMode,
+  useSetLoadBalancingMode,
+  useSelfHealConfig,
+  useSetSelfHealConfig,
+} from '@/hooks/use-credentials'
+import {
+  SettingGroup,
+  SettingNumber,
+  SettingReadout,
+  SettingSegments,
+  SettingSwitch,
+  useFieldSaver,
+} from '@/components/console/setting-row'
+import { reportSaveError } from '@/components/settings/report-error'
+
+const SECS_PER_MIN = 60
+
+/**
+ * 调度分区：凭据怎么选、失败怎么转、禁用怎么恢复。
+ *
+ * 三组配置放在一屏里是有意的 —— 它们互相牵制，分开看容易配出自相矛盾的组合。
+ * 最典型的是「自愈开着 + 冷却间隔为 0」：403 持续时会陷入 全禁 → 自愈 → 403 → 再禁
+ * 的死循环（0.7.4 修的就是这个）。摆在一起，间隔和上限这两个刹车就跟自愈开关同时在视野里。
+ */
+export function DispatchSection() {
+  return (
+    <div className="space-y-6">
+      <LoadBalancingGroup />
+      <ThrottleGroup />
+      <SelfHealGroup />
+    </div>
+  )
+}
+
+function LoadBalancingGroup() {
+  const { data, isLoading } = useLoadBalancingMode()
+  const { mutate } = useSetLoadBalancingMode()
+  const saver = useFieldSaver(mutate, reportSaveError)
+
+  return (
+    <SettingGroup title="凭据选择">
+      <SettingSegments
+        label="负载均衡模式"
+        hint={
+          data?.mode === 'balanced'
+            ? '按用量动态挑选凭据，把请求摊平到整个池子'
+            : '按优先级数字从小到大用：先用完 0 号，再换 1 号'
+        }
+        value={data?.mode ?? 'priority'}
+        options={[
+          { value: 'priority', label: '按优先级', hint: '小数字先用，顺序耗尽' },
+          { value: 'balanced', label: '均衡负载', hint: '按用量动态摊平' },
+        ]}
+        onChange={(next) => saver.save('mode', next)}
+        pending={saver.isSaving('mode')}
+        saved={saver.isSaved('mode')}
+        disabled={isLoading}
+      />
+    </SettingGroup>
+  )
+}
+
+function ThrottleGroup() {
+  const { data, isLoading } = useAccountThrottleConfig()
+  const { mutate } = useSetAccountThrottleConfig()
+  const saver = useFieldSaver(mutate, reportSaveError)
+  const failover = data?.failover ?? true
+  const cooldownSecs = data?.cooldownSecs ?? 30 * SECS_PER_MIN
+
+  return (
+    <SettingGroup
+      title="账号级风控"
+      description="上游对单个账号触发临时限速（429 + suspicious activity）时怎么处理"
+    >
+      <SettingSwitch
+        label="故障转移"
+        hint={
+          failover
+            ? '冷却该凭据并立即切到下一个可用凭据'
+            : '仅按瞬态错误重试，不切换凭据'
+        }
+        checked={failover}
+        onChange={(next) => saver.save('failover', { failover: next })}
+        pending={saver.isSaving('failover')}
+        saved={saver.isSaved('failover')}
+        disabled={isLoading}
+      />
+      <SettingNumber
+        label="冷却时长"
+        hint="被风控的凭据要静默多久才重新参与调度"
+        value={cooldownSecs}
+        toDisplay={(secs) => Math.round(secs / SECS_PER_MIN)}
+        fromDisplay={(min) => min * SECS_PER_MIN}
+        onCommit={(secs) => saver.save('cooldown', { cooldownSecs: secs })}
+        min={1}
+        max={1440}
+        unit="分钟"
+        presets={[5, 15, 30, 60]}
+        pending={saver.isSaving('cooldown')}
+        saved={saver.isSaved('cooldown')}
+        disabled={isLoading || !failover}
+      />
+    </SettingGroup>
+  )
+}
+
+function SelfHealGroup() {
+  const { data, isLoading } = useSelfHealConfig()
+  const { mutate } = useSetSelfHealConfig()
+  const saver = useFieldSaver(mutate, reportSaveError)
+  const enabled = data?.enabled ?? true
+
+  return (
+    <SettingGroup
+      title="凭据自愈"
+      description="请求池全灭时自动把禁用的凭据放回来重试"
+    >
+      <SettingSwitch
+        label="启用自愈"
+        hint="当前作用域内已无可用凭据时，按作用域批量恢复被禁用的凭据"
+        checked={enabled}
+        onChange={(next) => saver.save('enabled', { enabled: next })}
+        pending={saver.isSaving('enabled')}
+        saved={saver.isSaved('enabled')}
+        disabled={isLoading}
+      />
+      <SettingSwitch
+        label="403 封禁识别"
+        hint="命中封禁文案的 403 直接禁用且不参与自愈，避免为已封账号反复重试"
+        checked={data?.suspendedDetectionEnabled ?? true}
+        onChange={(next) =>
+          saver.save('suspended', { suspendedDetectionEnabled: next })
+        }
+        pending={saver.isSaving('suspended')}
+        saved={saver.isSaved('suspended')}
+        disabled={isLoading}
+      />
+      <SettingNumber
+        label="自愈冷却间隔"
+        hint="两次自愈之间的最小间隔。设 0 表示不冷却 —— 上游持续 403 时这是唯一能打断死循环的刹车，不建议设 0"
+        value={data?.minIntervalSecs ?? 0}
+        toDisplay={(secs) => Math.round(secs / SECS_PER_MIN)}
+        fromDisplay={(min) => min * SECS_PER_MIN}
+        onCommit={(secs) => saver.save('interval', { minIntervalSecs: secs })}
+        min={0}
+        max={1440}
+        unit="分钟"
+        presets={[0, 1, 5, 15]}
+        pending={saver.isSaving('interval')}
+        saved={saver.isSaved('interval')}
+        disabled={isLoading || !enabled}
+      />
+      <SettingNumber
+        label="连续自愈上限"
+        hint="连续自愈达到该轮数且期间无任何成功请求则停止自愈。0 = 不限"
+        value={data?.maxConsecutiveRounds ?? 5}
+        onCommit={(n) => saver.save('rounds', { maxConsecutiveRounds: n })}
+        min={0}
+        max={1000}
+        unit="轮"
+        pending={saver.isSaving('rounds')}
+        saved={saver.isSaved('rounds')}
+        disabled={isLoading || !enabled}
+      />
+      <SettingReadout
+        label="运行状态"
+        hint="当前连续自愈轮数 / 累计恢复凭据次数"
+      >
+        连续 {data?.consecutiveRounds ?? 0} 轮 · 累计恢复 {data?.totalCount ?? 0} 次
+      </SettingReadout>
+    </SettingGroup>
+  )
+}

--- a/admin-ui/src/components/settings/log-section.tsx
+++ b/admin-ui/src/components/settings/log-section.tsx
@@ -1,0 +1,77 @@
+import {
+  useLogGovernanceConfig,
+  useSetLogGovernanceConfig,
+} from '@/hooks/use-credentials'
+import {
+  SettingGroup,
+  SettingNumber,
+  SettingSwitch,
+  useFieldSaver,
+} from '@/components/console/setting-row'
+import { reportSaveError } from '@/components/settings/report-error'
+
+/**
+ * 日志分区：链路追踪开关与两类日志的保留期。
+ *
+ * 从日志页的「治理设置」下拉搬过来。留在那里的问题不是位置不对，而是它把
+ * 「查日志」和「配日志」混在同一个工具栏 —— 排查现场需要的是筛选器，不是配置项，
+ * 而配置项一年可能只改两次却常驻占位。
+ */
+export function LogSection() {
+  const { data, isLoading } = useLogGovernanceConfig()
+  const { mutate } = useSetLogGovernanceConfig()
+  const saver = useFieldSaver(mutate, reportSaveError)
+  const enabled = data?.traceEnabled ?? true
+
+  return (
+    <div className="space-y-6">
+      <SettingGroup title="链路追踪">
+        <SettingSwitch
+          label="记录请求链路"
+          hint={
+            enabled
+              ? '每次请求的完整重试链路写入 traces.db，请求日志页据此展示故障转移过程'
+              : '不再写入新链路；已有记录仍可查询'
+          }
+          checked={enabled}
+          onChange={(next) => saver.save('traceEnabled', { traceEnabled: next })}
+          pending={saver.isSaving('traceEnabled')}
+          saved={saver.isSaved('traceEnabled')}
+          disabled={isLoading}
+        />
+        <SettingNumber
+          label="链路保留期"
+          hint="超过天数的 trace 由后台任务定期清理"
+          value={data?.traceRetentionDays ?? 7}
+          onCommit={(n) => saver.save('traceDays', { traceRetentionDays: n })}
+          min={1}
+          max={365}
+          unit="天"
+          presets={[3, 7, 30]}
+          pending={saver.isSaving('traceDays')}
+          saved={saver.isSaved('traceDays')}
+          disabled={isLoading}
+        />
+      </SettingGroup>
+
+      <SettingGroup
+        title="用量日志"
+        description="按凭据 / 模型聚合的统计数据，概览页的图表来源"
+      >
+        <SettingNumber
+          label="用量日志保留期"
+          hint="影响概览页能回看多久的趋势"
+          value={data?.usageLogRetentionDays ?? 30}
+          onCommit={(n) => saver.save('usageDays', { usageLogRetentionDays: n })}
+          min={1}
+          max={365}
+          unit="天"
+          presets={[7, 30, 90]}
+          pending={saver.isSaving('usageDays')}
+          saved={saver.isSaved('usageDays')}
+          disabled={isLoading}
+        />
+      </SettingGroup>
+    </div>
+  )
+}

--- a/admin-ui/src/components/settings/metadata-section.tsx
+++ b/admin-ui/src/components/settings/metadata-section.tsx
@@ -3,6 +3,7 @@ import { Plus, Save, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Select,
   SelectContent,
@@ -16,6 +17,7 @@ import {
   useSetCredentialMetadataSchema,
 } from '@/hooks/use-credentials'
 import { extractErrorMessage } from '@/lib/utils'
+import { validateMetadataCss } from '@/lib/credential-metadata-style'
 import type {
   CredentialMetadataFieldSchema,
   CredentialMetadataSchema,
@@ -31,17 +33,19 @@ interface FieldDraft {
   type: ValueType
   defaultValue: string
   options: string
+  css: string
 }
 
 function schemaToDrafts(schema: CredentialMetadataSchema): FieldDraft[] {
   return Object.entries(schema.properties).map(([key, field]) => ({
-    locked: key === 'type',
+    locked: ['type', 'saleStatus', 'salePrice'].includes(key),
     key,
     title: field.title,
     description: field.description ?? '',
     type: field.type,
     defaultValue: field.default == null ? '' : String(field.default),
     options: field.oneOf?.map((option) => `${String(option.const)}:${option.title}`).join(', ') ?? '',
+    css: field['x-css'] ?? '',
   }))
 }
 
@@ -80,13 +84,15 @@ function draftsToSchema(
         return { const: parsed, title: labelParts.join(':').trim() || raw }
       })
     if (options.length > 0) field.oneOf = options
+    if (draft.css.trim()) field['x-css'] = draft.css.trim()
+    if (draft.key.trim() === 'salePrice') field.minimum = 0
     properties[draft.key.trim()] = field
   }
   return {
     ...base,
     type: 'object',
     properties,
-    required: ['type'],
+    required: ['type', 'saleStatus'],
     additionalProperties: true,
   }
 }
@@ -115,6 +121,7 @@ export function MetadataSection() {
         type: 'string',
         defaultValue: '',
         options: '',
+        css: '',
       },
     ])
   }
@@ -130,9 +137,11 @@ export function MetadataSection() {
       toast.error('字段 key 不能重复')
       return
     }
-    const typeField = drafts.find((field) => field.key === 'type')
-    if (!typeField) {
-      toast.error('内置 type 字段不能删除')
+    const missingBuiltin = ['type', 'saleStatus', 'salePrice'].find(
+      (key) => !drafts.some((field) => field.key === key),
+    )
+    if (missingBuiltin) {
+      toast.error(`内置 ${missingBuiltin} 字段不能删除`)
       return
     }
     for (const field of drafts) {
@@ -150,6 +159,11 @@ export function MetadataSection() {
         toast.error(`${field.key} 的默认值类型不正确`)
         return
       }
+      const cssError = validateMetadataCss(field.css)
+      if (cssError) {
+        toast.error(`${field.key}: ${cssError}`)
+        return
+      }
     }
     mutate(
       { schema: draftsToSchema(data.schema, drafts) },
@@ -163,7 +177,7 @@ export function MetadataSection() {
   return (
     <SettingGroup
       title="凭据 Metadata Schema"
-      description="定义凭据 metadata 的字段 key、值类型、默认值和枚举 value。type 是内置必填字段。"
+      description="定义凭据 metadata 的字段 key、值类型、默认值和枚举 value。type、saleStatus 和 salePrice 是内置字段。"
     >
       <div className="space-y-3 py-2">
         {drafts.map((field, index) => {
@@ -228,6 +242,18 @@ export function MetadataSection() {
                   disabled={builtIn || isPending}
                   className="font-mono text-xs"
                 />
+              </div>
+              <div className="space-y-1.5">
+                <Textarea
+                  value={field.css}
+                  onChange={(event) => update(index, { css: event.target.value })}
+                  placeholder="字段值 CSS，例如：color: #b45309; background-color: #fffbeb; font-weight: 600"
+                  disabled={isPending}
+                  className="min-h-16 font-mono text-xs"
+                />
+                <p className="text-[11px] text-muted-foreground">
+                  应用于卡片中的字段值；不允许外链、脚本表达式及会脱离卡片布局的属性。
+                </p>
               </div>
             </div>
           )

--- a/admin-ui/src/components/settings/metadata-section.tsx
+++ b/admin-ui/src/components/settings/metadata-section.tsx
@@ -55,15 +55,15 @@ export interface FieldDraft {
 // 快速 CSS 预设集
 const CSS_PRESETS = [
   {
-    name: '琥珀高亮',
+    name: '琥珀',
     css: 'color: #b45309; background-color: #fffbeb; border-color: #fde68a; font-weight: 600;',
   },
   {
-    name: '翡翠绿',
+    name: '翡翠',
     css: 'color: #047857; background-color: #ecfdf5; border-color: #a7f3d0; font-weight: 600;',
   },
   {
-    name: '玫瑰红',
+    name: '玫瑰',
     css: 'color: #b91c1c; background-color: #fef2f2; border-color: #fecaca; font-weight: 600;',
   },
   {
@@ -71,7 +71,7 @@ const CSS_PRESETS = [
     css: 'color: #6d28d9; background-color: #f5f3ff; border-color: #ddd6fe; font-weight: 600;',
   },
   {
-    name: '中性灰',
+    name: '中性',
     css: 'color: #374151; background-color: #f3f4f6; border-color: #e5e7eb;',
   },
 ]
@@ -128,7 +128,7 @@ function schemaToDrafts(schema: CredentialMetadataSchema): FieldDraft[] {
         label: option.title,
       })) ?? [],
     css: field['x-css'] ?? '',
-    expanded: true,
+    expanded: false, // 默认收起为超紧凑数据行
   }))
 }
 
@@ -172,7 +172,6 @@ function draftsToSchema(
     properties[draft.key.trim()] = field
   }
 
-  // 保证 required 里始终保留存在的 type 和 saleStatus
   const required = ['type', 'saleStatus'].filter((k) =>
     Object.prototype.hasOwnProperty.call(properties, k),
   )
@@ -318,83 +317,100 @@ export function MetadataSection() {
       title="凭据 Metadata Schema"
       description="自定义凭据属性结构。全量开放编辑字段 Key、标题、类型、枚举值、默认值、CSS 胶囊样式与卡片展示顺序。"
     >
-      <div className="space-y-4 py-2">
+      <div className="space-y-2 py-1">
         {drafts.map((field, index) => {
           const builtIn = field.locked
-          const isExpanded = field.expanded ?? true
+          const isExpanded = field.expanded ?? false
           const parsedStyle = metadataCssToStyle(field.css)
 
           return (
             <div
               key={`field-${field.key || index}`}
-              className="rounded-2xl border border-border/80 bg-card shadow-apple-sm hover:shadow-apple transition-all"
+              className="rounded-xl border border-border/70 bg-card shadow-apple-sm hover:border-border transition-all overflow-hidden"
             >
-              {/* 卡片 Header: Key、Title、类型 Badge、排序与操作 */}
-              <div className="flex flex-wrap items-center justify-between gap-2 p-3 sm:px-4">
-                <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                  <button
-                    type="button"
-                    onClick={() => toggleExpand(index)}
-                    className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                    title={isExpanded ? '折叠详情' : '展开详情'}
-                  >
+              {/* 高密度紧凑 Header 行 (仅 ~40px 高度) */}
+              <div
+                onClick={() => toggleExpand(index)}
+                className="flex items-center justify-between gap-2 px-3 py-2 cursor-pointer hover:bg-accent/40 select-none transition-colors"
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-2">
+                  <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground">
                     <ChevronRight
-                      className={`h-4 w-4 transition-transform duration-200 ${
+                      className={`h-3.5 w-3.5 transition-transform duration-200 ${
                         isExpanded ? 'rotate-90' : ''
                       }`}
                     />
-                  </button>
-
-                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
-                    <span className="font-mono text-sm font-semibold text-foreground">
-                      {field.key || <span className="text-muted-foreground italic">未命名 key</span>}
-                    </span>
-
-                    {field.title && (
-                      <span className="text-xs text-muted-foreground">
-                        ({field.title})
-                      </span>
-                    )}
-
-                    <Badge variant="outline" className="text-[10px] uppercase font-mono">
-                      {field.type}
-                    </Badge>
-
-                    {builtIn && (
-                      <Badge
-                        variant="secondary"
-                        className="bg-primary/10 text-primary border-primary/20 text-[10px]"
-                      >
-                        系统默认
-                      </Badge>
-                    )}
                   </div>
+
+                  {/* Key & Title */}
+                  <span className="font-mono text-xs font-bold text-foreground shrink-0">
+                    {field.key || <span className="text-muted-foreground italic">未命名 key</span>}
+                  </span>
+
+                  {field.title && (
+                    <span className="text-xs text-muted-foreground/80 truncate max-w-[120px]">
+                      ({field.title})
+                    </span>
+                  )}
+
+                  <Badge variant="outline" className="text-[9px] uppercase font-mono px-1 py-0 h-4">
+                    {field.type}
+                  </Badge>
+
+                  {builtIn && (
+                    <Badge
+                      variant="secondary"
+                      className="bg-primary/10 text-primary border-primary/20 text-[9px] px-1 py-0 h-4"
+                    >
+                      默认
+                    </Badge>
+                  )}
+
+                  {/* 默认值的内联微展示 */}
+                  {field.defaultValue && (
+                    <span className="hidden md:inline-flex text-[10px] text-muted-foreground/70 font-mono bg-muted/50 px-1.5 py-0.5 rounded">
+                      默认: {field.defaultValue}
+                    </span>
+                  )}
+
+                  {/* 实时微型渲染胶囊预览 (无需展开直接查看效果) */}
+                  {field.css && (
+                    <span
+                      className="ml-auto hidden sm:inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none"
+                      style={parsedStyle}
+                    >
+                      {field.title || field.key}: 示例
+                    </span>
+                  )}
                 </div>
 
                 {/* 快捷操作区 */}
-                <div className="flex items-center gap-1">
+                <div
+                  className="flex items-center gap-0.5 shrink-0"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <Button
                     type="button"
                     size="icon"
                     variant="ghost"
-                    className="h-8 w-8"
+                    className="h-7 w-7"
                     disabled={index === 0 || isPending}
                     onClick={() => moveField(index, 'up')}
                     title="向上移动排序"
                   >
-                    <ChevronUp className="h-4 w-4" />
+                    <ChevronUp className="h-3.5 w-3.5" />
                   </Button>
 
                   <Button
                     type="button"
                     size="icon"
                     variant="ghost"
-                    className="h-8 w-8"
+                    className="h-7 w-7"
                     disabled={index === drafts.length - 1 || isPending}
                     onClick={() => moveField(index, 'down')}
                     title="向下移动排序"
                   >
-                    <ChevronDown className="h-4 w-4" />
+                    <ChevronDown className="h-3.5 w-3.5" />
                   </Button>
 
                   <Button
@@ -405,22 +421,22 @@ export function MetadataSection() {
                     onClick={() =>
                       setDrafts((current) => current.filter((_, i) => i !== index))
                     }
-                    className="h-8 w-8 text-destructive/80 hover:text-destructive hover:bg-destructive/10"
+                    className="h-7 w-7 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
                     title="删除字段"
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                 </div>
               </div>
 
-              {/* 展开的完整编辑面板 */}
+              {/* 展开的超高密度编辑面板 */}
               {isExpanded && (
-                <div className="space-y-4 border-t border-border/40 p-3 sm:p-4 bg-muted/5">
-                  {/* 核心三元组：Key, Title, Type */}
-                  <div className="grid gap-3 sm:grid-cols-3">
-                    <div className="space-y-1">
-                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
-                        字段 Key
+                <div className="space-y-2.5 border-t border-border/40 p-2.5 sm:p-3 bg-muted/10 text-xs">
+                  {/* 第一行 (4列): Key, Title, Type, DefaultValue */}
+                  <div className="grid gap-2 grid-cols-2 sm:grid-cols-4">
+                    <div className="space-y-0.5">
+                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
+                        Key
                       </label>
                       <Input
                         value={field.key}
@@ -429,13 +445,13 @@ export function MetadataSection() {
                         }
                         placeholder="例如: salePrice"
                         disabled={isPending}
-                        className="font-mono text-sm"
+                        className="h-8 font-mono text-xs px-2"
                       />
                     </div>
 
-                    <div className="space-y-1">
-                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
-                        显示名称 (Title)
+                    <div className="space-y-0.5">
+                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
+                        显示名称
                       </label>
                       <Input
                         value={field.title}
@@ -444,13 +460,13 @@ export function MetadataSection() {
                         }
                         placeholder="例如: 售卖价格"
                         disabled={isPending}
-                        className="text-sm"
+                        className="h-8 text-xs px-2"
                       />
                     </div>
 
-                    <div className="space-y-1">
-                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
-                        数据类型 (Type)
+                    <div className="space-y-0.5">
+                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
+                        数据类型
                       </label>
                       <Select
                         value={field.type}
@@ -459,7 +475,7 @@ export function MetadataSection() {
                         }
                         disabled={isPending}
                       >
-                        <SelectTrigger className="text-sm">
+                        <SelectTrigger className="h-8 text-xs px-2">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -470,27 +486,9 @@ export function MetadataSection() {
                         </SelectContent>
                       </Select>
                     </div>
-                  </div>
 
-                  {/* 字段描述 & 默认值 */}
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    <div className="space-y-1">
-                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
-                        字段说明
-                      </label>
-                      <Input
-                        value={field.description}
-                        onChange={(event) =>
-                          update(index, { description: event.target.value })
-                        }
-                        placeholder="在编辑弹窗和提示中展示的说明"
-                        disabled={isPending}
-                        className="text-sm"
-                      />
-                    </div>
-
-                    <div className="space-y-1">
-                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
+                    <div className="space-y-0.5">
+                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
                         默认值
                       </label>
                       <Input
@@ -498,43 +496,90 @@ export function MetadataSection() {
                         onChange={(event) =>
                           update(index, { defaultValue: event.target.value })
                         }
-                        placeholder={
-                          field.type === 'boolean'
-                            ? 'true 或 false'
-                            : '可选，新建凭据时的初始值'
-                        }
+                        placeholder={field.type === 'boolean' ? 'true / false' : '初始默认值'}
                         disabled={isPending}
-                        className="font-mono text-sm"
+                        className="h-8 font-mono text-xs px-2"
                       />
                     </div>
                   </div>
 
-                  {/* 可视化枚举选项 (Options Visual Editor) */}
-                  <div className="space-y-2 rounded-xl border border-border/50 bg-background/60 p-3">
+                  {/* 第二行 (2列): 字段说明 & CSS + 预设 */}
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <div className="space-y-0.5">
+                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
+                        说明文案
+                      </label>
+                      <Input
+                        value={field.description}
+                        onChange={(event) =>
+                          update(index, { description: event.target.value })
+                        }
+                        placeholder="表单和卡片中的提示文案"
+                        disabled={isPending}
+                        className="h-8 text-xs px-2"
+                      />
+                    </div>
+
+                    <div className="space-y-0.5">
+                      <div className="flex items-center justify-between">
+                        <label className="text-[10px] font-semibold text-muted-foreground uppercase flex items-center gap-1">
+                          <Palette className="h-3 w-3 text-primary" />
+                          CSS 样式
+                        </label>
+                        {/* 快捷配色 */}
+                        <div className="flex items-center gap-1">
+                          {CSS_PRESETS.map((preset) => (
+                            <button
+                              key={preset.name}
+                              type="button"
+                              onClick={() => update(index, { css: preset.css })}
+                              disabled={isPending}
+                              className="rounded px-1 text-[9px] border border-border/50 bg-muted/40 hover:bg-accent hover:text-primary transition-colors"
+                            >
+                              {preset.name}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+
+                      <Input
+                        value={field.css}
+                        onChange={(event) =>
+                          update(index, { css: event.target.value })
+                        }
+                        placeholder="例如: color: #b45309; background-color: #fffbeb;"
+                        disabled={isPending}
+                        className="h-8 font-mono text-xs px-2"
+                      />
+                    </div>
+                  </div>
+
+                  {/* 第三行: 枚举选项 (Options Visual Editor) */}
+                  <div className="space-y-1.5 rounded-lg border border-border/40 bg-background/50 p-2">
                     <div className="flex items-center justify-between">
-                      <span className="flex items-center gap-1.5 text-[11px] font-semibold text-muted-foreground uppercase">
-                        <Sliders className="h-3.5 w-3.5 text-primary" />
+                      <span className="flex items-center gap-1 text-[10px] font-semibold text-muted-foreground uppercase">
+                        <Sliders className="h-3 w-3 text-primary" />
                         枚举选项 (OneOf Options)
                       </span>
                       <Button
                         type="button"
                         size="sm"
                         variant="ghost"
-                        className="h-7 text-xs text-primary"
+                        className="h-6 px-1.5 text-[11px] text-primary"
                         onClick={() => addOption(index)}
                         disabled={isPending}
                       >
-                        <Plus className="mr-1 h-3.5 w-3.5" />
-                        添加选项
+                        <Plus className="mr-0.5 h-3 w-3" />
+                        加项
                       </Button>
                     </div>
 
                     {field.options.length > 0 ? (
-                      <div className="space-y-2 pt-1">
+                      <div className="grid gap-1.5 sm:grid-cols-2">
                         {field.options.map((opt, optIdx) => (
                           <div
                             key={`opt-${optIdx}`}
-                            className="flex items-center gap-2"
+                            className="flex items-center gap-1.5"
                           >
                             <Input
                               value={opt.value}
@@ -543,11 +588,11 @@ export function MetadataSection() {
                                   value: e.target.value,
                                 })
                               }
-                              placeholder="存储值 (const)"
+                              placeholder="存储值"
                               disabled={isPending}
-                              className="h-8 font-mono text-xs flex-1"
+                              className="h-7 font-mono text-[11px] px-1.5 flex-1"
                             />
-                            <span className="text-muted-foreground/60 text-xs">:</span>
+                            <span className="text-muted-foreground/60 text-[10px]">:</span>
                             <Input
                               value={opt.label}
                               onChange={(e) =>
@@ -555,84 +600,29 @@ export function MetadataSection() {
                                   label: e.target.value,
                                 })
                               }
-                              placeholder="显示名称 (label)"
+                              placeholder="显示名"
                               disabled={isPending}
-                              className="h-8 text-xs flex-1"
+                              className="h-7 text-[11px] px-1.5 flex-1"
                             />
                             <Button
                               type="button"
                               size="icon"
                               variant="ghost"
-                              className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                              className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
                               disabled={isPending}
                               onClick={() => removeOption(index, optIdx)}
                               title="删除选项"
                             >
-                              <Trash2 className="h-3.5 w-3.5" />
+                              <Trash2 className="h-3 w-3" />
                             </Button>
                           </div>
                         ))}
                       </div>
                     ) : (
-                      <p className="text-[11px] text-muted-foreground/70 italic py-1">
-                        暂未配置枚举选项（任意输入格式）。
+                      <p className="text-[10px] text-muted-foreground/60 italic">
+                        未设置枚举限制。
                       </p>
                     )}
-                  </div>
-
-                  {/* 样式控制 & 实时预览 (Live CSS Preview) */}
-                  <div className="space-y-2 rounded-xl border border-border/50 bg-background/60 p-3">
-                    <div className="flex items-center justify-between flex-wrap gap-2">
-                      <span className="flex items-center gap-1.5 text-[11px] font-semibold text-muted-foreground uppercase">
-                        <Palette className="h-3.5 w-3.5 text-primary" />
-                        样式与卡片实时渲染预览 (Live Preview)
-                      </span>
-                      {/* 快捷 Preset 按钮组 */}
-                      <div className="flex items-center gap-1 flex-wrap">
-                        <span className="text-[10px] text-muted-foreground mr-1">
-                          快捷配色:
-                        </span>
-                        {CSS_PRESETS.map((preset) => (
-                          <button
-                            key={preset.name}
-                            type="button"
-                            onClick={() => update(index, { css: preset.css })}
-                            disabled={isPending}
-                            className="rounded px-1.5 py-0.5 text-[10px] border border-border/60 bg-muted/40 hover:bg-accent hover:text-primary transition-colors"
-                          >
-                            {preset.name}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-
-                    <div className="grid gap-3 sm:grid-cols-[1fr_auto] items-center pt-1">
-                      <Input
-                        value={field.css}
-                        onChange={(event) =>
-                          update(index, { css: event.target.value })
-                        }
-                        placeholder="例如: color: #b45309; background-color: #fffbeb; font-weight: 600;"
-                        disabled={isPending}
-                        className="font-mono text-xs"
-                      />
-
-                      {/* 实时胶囊预览 */}
-                      <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-card p-2">
-                        <span className="text-[10px] font-semibold text-muted-foreground">
-                          效果:
-                        </span>
-                        <span
-                          className="inline-flex min-w-0 max-w-full items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-all"
-                          style={parsedStyle}
-                        >
-                          <span className="opacity-70 mr-1">
-                            {field.title || field.key || '字段'}:
-                          </span>
-                          <span>示例值</span>
-                        </span>
-                      </div>
-                    </div>
                   </div>
                 </div>
               )}
@@ -641,15 +631,15 @@ export function MetadataSection() {
         })}
 
         {/* 底部保存与添加控制 */}
-        <div className="flex flex-wrap justify-between gap-3 pt-2 border-t border-border/40">
+        <div className="flex flex-wrap justify-between gap-2 pt-2 border-t border-border/40">
           <Button
             type="button"
             variant="outline"
             onClick={addField}
             disabled={isLoading || isPending}
-            className="h-9 px-4 text-xs font-medium"
+            className="h-8 px-3 text-xs font-medium"
           >
-            <Plus className="mr-1.5 h-4 w-4" />
+            <Plus className="mr-1 h-3.5 w-3.5" />
             新增字段
           </Button>
 
@@ -657,9 +647,9 @@ export function MetadataSection() {
             type="button"
             onClick={save}
             disabled={isLoading || isPending || drafts.length === 0}
-            className="h-9 px-5 text-xs font-semibold shadow-apple-sm"
+            className="h-8 px-4 text-xs font-semibold shadow-apple-sm"
           >
-            <Save className="mr-1.5 h-4 w-4" />
+            <Save className="mr-1 h-3.5 w-3.5" />
             {isPending ? '保存中…' : '保存 Schema 配置'}
           </Button>
         </div>

--- a/admin-ui/src/components/settings/metadata-section.tsx
+++ b/admin-ui/src/components/settings/metadata-section.tsx
@@ -1,9 +1,18 @@
 import { useEffect, useState } from 'react'
-import { Plus, Save, Trash2 } from 'lucide-react'
+import {
+  Plus,
+  Save,
+  Trash2,
+  ChevronUp,
+  ChevronDown,
+  ChevronRight,
+  Palette,
+  Sliders,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
 import {
   Select,
   SelectContent,
@@ -12,12 +21,13 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { SettingGroup } from '@/components/console/setting-row'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   useCredentialMetadataSchema,
   useSetCredentialMetadataSchema,
 } from '@/hooks/use-credentials'
 import { extractErrorMessage } from '@/lib/utils'
-import { validateMetadataCss } from '@/lib/credential-metadata-style'
+import { validateMetadataCss, metadataCssToStyle } from '@/lib/credential-metadata-style'
 import type {
   CredentialMetadataFieldSchema,
   CredentialMetadataSchema,
@@ -25,16 +35,46 @@ import type {
 
 type ValueType = CredentialMetadataFieldSchema['type']
 
-interface FieldDraft {
+export interface OptionDraft {
+  value: string
+  label: string
+}
+
+export interface FieldDraft {
   locked: boolean
   key: string
   title: string
   description: string
   type: ValueType
   defaultValue: string
-  options: string
+  options: OptionDraft[]
   css: string
+  expanded?: boolean
 }
+
+// 快速 CSS 预设集
+const CSS_PRESETS = [
+  {
+    name: '琥珀高亮',
+    css: 'color: #b45309; background-color: #fffbeb; border-color: #fde68a; font-weight: 600;',
+  },
+  {
+    name: '翡翠绿',
+    css: 'color: #047857; background-color: #ecfdf5; border-color: #a7f3d0; font-weight: 600;',
+  },
+  {
+    name: '玫瑰红',
+    css: 'color: #b91c1c; background-color: #fef2f2; border-color: #fecaca; font-weight: 600;',
+  },
+  {
+    name: '紫罗兰',
+    css: 'color: #6d28d9; background-color: #f5f3ff; border-color: #ddd6fe; font-weight: 600;',
+  },
+  {
+    name: '中性灰',
+    css: 'color: #374151; background-color: #f3f4f6; border-color: #e5e7eb;',
+  },
+]
 
 function schemaToDrafts(schema: CredentialMetadataSchema): FieldDraft[] {
   return Object.entries(schema.properties).map(([key, field]) => ({
@@ -44,8 +84,13 @@ function schemaToDrafts(schema: CredentialMetadataSchema): FieldDraft[] {
     description: field.description ?? '',
     type: field.type,
     defaultValue: field.default == null ? '' : String(field.default),
-    options: field.oneOf?.map((option) => `${String(option.const)}:${option.title}`).join(', ') ?? '',
+    options:
+      field.oneOf?.map((option) => ({
+        value: String(option.const),
+        label: option.title,
+      })) ?? [],
     css: field['x-css'] ?? '',
+    expanded: true,
   }))
 }
 
@@ -69,35 +114,42 @@ function draftsToSchema(
     if (draft.description.trim()) field.description = draft.description.trim()
     const defaultValue = parseDefault(draft.defaultValue.trim(), draft.type)
     if (defaultValue !== undefined) field.default = defaultValue
+
     const options = draft.options
-      .split(',')
-      .map((item) => item.trim())
-      .filter(Boolean)
-      .map((item) => {
-        const [value, ...labelParts] = item.split(':')
-        const raw = value.trim()
-        const parsed = draft.type === 'boolean'
-          ? raw === 'true'
-          : draft.type === 'number' || draft.type === 'integer'
+      .filter((opt) => opt.value.trim() !== '')
+      .map((opt) => {
+        const raw = opt.value.trim()
+        const parsed =
+          draft.type === 'boolean'
+            ? raw === 'true'
+            : draft.type === 'number' || draft.type === 'integer'
             ? Number(raw)
             : raw
-        return { const: parsed, title: labelParts.join(':').trim() || raw }
+        return { const: parsed, title: opt.label.trim() || raw }
       })
+
     if (options.length > 0) field.oneOf = options
     if (draft.css.trim()) field['x-css'] = draft.css.trim()
     if (draft.key.trim() === 'salePrice') field.minimum = 0
     properties[draft.key.trim()] = field
   }
+
+  // 保证 required 里始终保留存在的 type 和 saleStatus
+  const required = ['type', 'saleStatus'].filter((k) =>
+    Object.prototype.hasOwnProperty.call(properties, k),
+  )
+
   return {
     ...base,
     type: 'object',
     properties,
-    required: ['type', 'saleStatus'],
+    required,
     additionalProperties: true,
   }
 }
 
 export function MetadataSection() {
+  const queryClient = useQueryClient()
   const { data, isLoading } = useCredentialMetadataSchema()
   const { mutate, isPending } = useSetCredentialMetadataSchema()
   const [drafts, setDrafts] = useState<FieldDraft[]>([])
@@ -107,7 +159,29 @@ export function MetadataSection() {
   }, [data])
 
   const update = (index: number, patch: Partial<FieldDraft>) => {
-    setDrafts((current) => current.map((field, i) => (i === index ? { ...field, ...patch } : field)))
+    setDrafts((current) =>
+      current.map((field, i) => (i === index ? { ...field, ...patch } : field)),
+    )
+  }
+
+  const toggleExpand = (index: number) => {
+    setDrafts((current) =>
+      current.map((field, i) =>
+        i === index ? { ...field, expanded: !field.expanded } : field,
+      ),
+    )
+  }
+
+  const moveField = (index: number, direction: 'up' | 'down') => {
+    setDrafts((current) => {
+      const targetIndex = direction === 'up' ? index - 1 : index + 1
+      if (targetIndex < 0 || targetIndex >= current.length) return current
+      const next = [...current]
+      const temp = next[index]
+      next[index] = next[targetIndex]
+      next[targetIndex] = temp
+      return next
+    })
   }
 
   const addField = () => {
@@ -120,10 +194,35 @@ export function MetadataSection() {
         description: '',
         type: 'string',
         defaultValue: '',
-        options: '',
+        options: [],
         css: '',
+        expanded: true,
       },
     ])
+  }
+
+  const addOption = (fieldIndex: number) => {
+    const field = drafts[fieldIndex]
+    const nextOptions = [...field.options, { value: '', label: '' }]
+    update(fieldIndex, { options: nextOptions })
+  }
+
+  const updateOption = (
+    fieldIndex: number,
+    optionIndex: number,
+    patch: Partial<OptionDraft>,
+  ) => {
+    const field = drafts[fieldIndex]
+    const nextOptions = field.options.map((opt, i) =>
+      i === optionIndex ? { ...opt, ...patch } : opt,
+    )
+    update(fieldIndex, { options: nextOptions })
+  }
+
+  const removeOption = (fieldIndex: number, optionIndex: number) => {
+    const field = drafts[fieldIndex]
+    const nextOptions = field.options.filter((_, i) => i !== optionIndex)
+    update(fieldIndex, { options: nextOptions })
   }
 
   const save = () => {
@@ -137,24 +236,21 @@ export function MetadataSection() {
       toast.error('字段 key 不能重复')
       return
     }
-    const missingBuiltin = ['type', 'saleStatus', 'salePrice'].find(
-      (key) => !drafts.some((field) => field.key === key),
-    )
-    if (missingBuiltin) {
-      toast.error(`内置 ${missingBuiltin} 字段不能删除`)
-      return
-    }
     for (const field of drafts) {
       const defaultValue = field.defaultValue.trim()
-      if (defaultValue && field.type === 'boolean' && !['true', 'false'].includes(defaultValue)) {
+      if (
+        defaultValue &&
+        field.type === 'boolean' &&
+        !['true', 'false'].includes(defaultValue)
+      ) {
         toast.error(`${field.key} 的布尔默认值只能是 true 或 false`)
         return
       }
       if (
-        defaultValue
-        && (field.type === 'number' || field.type === 'integer')
-        && (!Number.isFinite(Number(defaultValue))
-          || (field.type === 'integer' && !Number.isInteger(Number(defaultValue))))
+        defaultValue &&
+        (field.type === 'number' || field.type === 'integer') &&
+        (!Number.isFinite(Number(defaultValue)) ||
+          (field.type === 'integer' && !Number.isInteger(Number(defaultValue))))
       ) {
         toast.error(`${field.key} 的默认值类型不正确`)
         return
@@ -168,8 +264,13 @@ export function MetadataSection() {
     mutate(
       { schema: draftsToSchema(data.schema, drafts) },
       {
-        onSuccess: () => toast.success('凭据 metadata schema 已保存'),
-        onError: (error) => toast.error(`保存失败: ${extractErrorMessage(error)}`),
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ['credentials'] })
+          queryClient.invalidateQueries({ queryKey: ['credential-metadata-schema'] })
+          toast.success('凭据 Metadata Schema 已保存（已被实时保存至配置文件）')
+        },
+        onError: (error) =>
+          toast.error(`保存失败: ${extractErrorMessage(error)}`),
       },
     )
   }
@@ -177,94 +278,351 @@ export function MetadataSection() {
   return (
     <SettingGroup
       title="凭据 Metadata Schema"
-      description="定义凭据 metadata 的字段 key、值类型、默认值和枚举 value。type、saleStatus 和 salePrice 是内置字段。"
+      description="自定义凭据属性结构。全量开放编辑字段 Key、标题、类型、枚举值、默认值、CSS 胶囊样式与卡片展示顺序。"
     >
-      <div className="space-y-3 py-2">
+      <div className="space-y-4 py-2">
         {drafts.map((field, index) => {
           const builtIn = field.locked
+          const isExpanded = field.expanded ?? true
+          const parsedStyle = metadataCssToStyle(field.css)
+
           return (
-            <div key={`${builtIn ? 'builtin' : 'field'}-${index}`} className="space-y-3 rounded-xl border border-border/60 p-3">
-              <div className="grid gap-2 sm:grid-cols-[1fr_1fr_140px_auto]">
-                <Input
-                  value={field.key}
-                  onChange={(event) => update(index, { key: event.target.value })}
-                  placeholder="字段 key"
-                  disabled={builtIn || isPending}
-                  className="font-mono"
-                />
-                <Input
-                  value={field.title}
-                  onChange={(event) => update(index, { title: event.target.value })}
-                  placeholder="显示名称"
-                  disabled={isPending}
-                />
-                <Select
-                  value={field.type}
-                  onValueChange={(value) => update(index, { type: value as ValueType })}
-                  disabled={builtIn || isPending}
-                >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="string">字符串</SelectItem>
-                    <SelectItem value="number">数字</SelectItem>
-                    <SelectItem value="integer">整数</SelectItem>
-                    <SelectItem value="boolean">布尔值</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  disabled={builtIn || isPending}
-                  onClick={() => setDrafts((current) => current.filter((_, i) => i !== index))}
-                  title={builtIn ? '内置字段不能删除' : '删除字段'}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
+            <div
+              key={`field-${field.key || index}`}
+              className="rounded-2xl border border-border/80 bg-card shadow-apple-sm hover:shadow-apple transition-all"
+            >
+              {/* 卡片 Header: Key、Title、类型 Badge、排序与操作 */}
+              <div className="flex flex-wrap items-center justify-between gap-2 p-3 sm:px-4">
+                <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                  <button
+                    type="button"
+                    onClick={() => toggleExpand(index)}
+                    className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    title={isExpanded ? '折叠详情' : '展开详情'}
+                  >
+                    <ChevronRight
+                      className={`h-4 w-4 transition-transform duration-200 ${
+                        isExpanded ? 'rotate-90' : ''
+                      }`}
+                    />
+                  </button>
+
+                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                    <span className="font-mono text-sm font-semibold text-foreground">
+                      {field.key || <span className="text-muted-foreground italic">未命名 key</span>}
+                    </span>
+
+                    {field.title && (
+                      <span className="text-xs text-muted-foreground">
+                        ({field.title})
+                      </span>
+                    )}
+
+                    <Badge variant="outline" className="text-[10px] uppercase font-mono">
+                      {field.type}
+                    </Badge>
+
+                    {builtIn && (
+                      <Badge
+                        variant="secondary"
+                        className="bg-primary/10 text-primary border-primary/20 text-[10px]"
+                      >
+                        系统默认
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+
+                {/* 快捷操作区 */}
+                <div className="flex items-center gap-1">
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    disabled={index === 0 || isPending}
+                    onClick={() => moveField(index, 'up')}
+                    title="向上移动排序"
+                  >
+                    <ChevronUp className="h-4 w-4" />
+                  </Button>
+
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    disabled={index === drafts.length - 1 || isPending}
+                    onClick={() => moveField(index, 'down')}
+                    title="向下移动排序"
+                  >
+                    <ChevronDown className="h-4 w-4" />
+                  </Button>
+
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    disabled={isPending}
+                    onClick={() =>
+                      setDrafts((current) => current.filter((_, i) => i !== index))
+                    }
+                    className="h-8 w-8 text-destructive/80 hover:text-destructive hover:bg-destructive/10"
+                    title="删除字段"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
-              <Input
-                value={field.description}
-                onChange={(event) => update(index, { description: event.target.value })}
-                placeholder="字段说明"
-                disabled={isPending}
-              />
-              <div className="grid gap-2 sm:grid-cols-2">
-                <Input
-                  value={field.defaultValue}
-                  onChange={(event) => update(index, { defaultValue: event.target.value })}
-                  placeholder="默认值（可选）"
-                  disabled={builtIn || isPending}
-                />
-                <Input
-                  value={field.options}
-                  onChange={(event) => update(index, { options: event.target.value })}
-                  placeholder="枚举：value:名称, value:名称"
-                  disabled={builtIn || isPending}
-                  className="font-mono text-xs"
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Textarea
-                  value={field.css}
-                  onChange={(event) => update(index, { css: event.target.value })}
-                  placeholder="字段值 CSS，例如：color: #b45309; background-color: #fffbeb; font-weight: 600"
-                  disabled={isPending}
-                  className="min-h-16 font-mono text-xs"
-                />
-                <p className="text-[11px] text-muted-foreground">
-                  应用于卡片中的字段值；不允许外链、脚本表达式及会脱离卡片布局的属性。
-                </p>
-              </div>
+
+              {/* 展开的完整编辑面板 */}
+              {isExpanded && (
+                <div className="space-y-4 border-t border-border/40 p-3 sm:p-4 bg-muted/5">
+                  {/* 核心三元组：Key, Title, Type */}
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="space-y-1">
+                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
+                        字段 Key
+                      </label>
+                      <Input
+                        value={field.key}
+                        onChange={(event) =>
+                          update(index, { key: event.target.value })
+                        }
+                        placeholder="例如: salePrice"
+                        disabled={isPending}
+                        className="font-mono text-sm"
+                      />
+                    </div>
+
+                    <div className="space-y-1">
+                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
+                        显示名称 (Title)
+                      </label>
+                      <Input
+                        value={field.title}
+                        onChange={(event) =>
+                          update(index, { title: event.target.value })
+                        }
+                        placeholder="例如: 售卖价格"
+                        disabled={isPending}
+                        className="text-sm"
+                      />
+                    </div>
+
+                    <div className="space-y-1">
+                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
+                        数据类型 (Type)
+                      </label>
+                      <Select
+                        value={field.type}
+                        onValueChange={(value) =>
+                          update(index, { type: value as ValueType })
+                        }
+                        disabled={isPending}
+                      >
+                        <SelectTrigger className="text-sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="string">字符串 (String)</SelectItem>
+                          <SelectItem value="number">数字 (Number)</SelectItem>
+                          <SelectItem value="integer">整数 (Integer)</SelectItem>
+                          <SelectItem value="boolean">布尔值 (Boolean)</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  {/* 字段描述 & 默认值 */}
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
+                        字段说明
+                      </label>
+                      <Input
+                        value={field.description}
+                        onChange={(event) =>
+                          update(index, { description: event.target.value })
+                        }
+                        placeholder="在编辑弹窗和提示中展示的说明"
+                        disabled={isPending}
+                        className="text-sm"
+                      />
+                    </div>
+
+                    <div className="space-y-1">
+                      <label className="text-[11px] font-semibold text-muted-foreground uppercase">
+                        默认值
+                      </label>
+                      <Input
+                        value={field.defaultValue}
+                        onChange={(event) =>
+                          update(index, { defaultValue: event.target.value })
+                        }
+                        placeholder={
+                          field.type === 'boolean'
+                            ? 'true 或 false'
+                            : '可选，新建凭据时的初始值'
+                        }
+                        disabled={isPending}
+                        className="font-mono text-sm"
+                      />
+                    </div>
+                  </div>
+
+                  {/* 可视化枚举选项 (Options Visual Editor) */}
+                  <div className="space-y-2 rounded-xl border border-border/50 bg-background/60 p-3">
+                    <div className="flex items-center justify-between">
+                      <span className="flex items-center gap-1.5 text-[11px] font-semibold text-muted-foreground uppercase">
+                        <Sliders className="h-3.5 w-3.5 text-primary" />
+                        枚举选项 (OneOf Options)
+                      </span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 text-xs text-primary"
+                        onClick={() => addOption(index)}
+                        disabled={isPending}
+                      >
+                        <Plus className="mr-1 h-3.5 w-3.5" />
+                        添加选项
+                      </Button>
+                    </div>
+
+                    {field.options.length > 0 ? (
+                      <div className="space-y-2 pt-1">
+                        {field.options.map((opt, optIdx) => (
+                          <div
+                            key={`opt-${optIdx}`}
+                            className="flex items-center gap-2"
+                          >
+                            <Input
+                              value={opt.value}
+                              onChange={(e) =>
+                                updateOption(index, optIdx, {
+                                  value: e.target.value,
+                                })
+                              }
+                              placeholder="存储值 (const)"
+                              disabled={isPending}
+                              className="h-8 font-mono text-xs flex-1"
+                            />
+                            <span className="text-muted-foreground/60 text-xs">:</span>
+                            <Input
+                              value={opt.label}
+                              onChange={(e) =>
+                                updateOption(index, optIdx, {
+                                  label: e.target.value,
+                                })
+                              }
+                              placeholder="显示名称 (label)"
+                              disabled={isPending}
+                              className="h-8 text-xs flex-1"
+                            />
+                            <Button
+                              type="button"
+                              size="icon"
+                              variant="ghost"
+                              className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                              disabled={isPending}
+                              onClick={() => removeOption(index, optIdx)}
+                              title="删除选项"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-[11px] text-muted-foreground/70 italic py-1">
+                        暂未配置枚举选项（任意输入格式）。
+                      </p>
+                    )}
+                  </div>
+
+                  {/* 样式控制 & 实时预览 (Live CSS Preview) */}
+                  <div className="space-y-2 rounded-xl border border-border/50 bg-background/60 p-3">
+                    <div className="flex items-center justify-between flex-wrap gap-2">
+                      <span className="flex items-center gap-1.5 text-[11px] font-semibold text-muted-foreground uppercase">
+                        <Palette className="h-3.5 w-3.5 text-primary" />
+                        样式与卡片实时渲染预览 (Live Preview)
+                      </span>
+                      {/* 快捷 Preset 按钮组 */}
+                      <div className="flex items-center gap-1 flex-wrap">
+                        <span className="text-[10px] text-muted-foreground mr-1">
+                          快捷配色:
+                        </span>
+                        {CSS_PRESETS.map((preset) => (
+                          <button
+                            key={preset.name}
+                            type="button"
+                            onClick={() => update(index, { css: preset.css })}
+                            disabled={isPending}
+                            className="rounded px-1.5 py-0.5 text-[10px] border border-border/60 bg-muted/40 hover:bg-accent hover:text-primary transition-colors"
+                          >
+                            {preset.name}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-[1fr_auto] items-center pt-1">
+                      <Input
+                        value={field.css}
+                        onChange={(event) =>
+                          update(index, { css: event.target.value })
+                        }
+                        placeholder="例如: color: #b45309; background-color: #fffbeb; font-weight: 600;"
+                        disabled={isPending}
+                        className="font-mono text-xs"
+                      />
+
+                      {/* 实时胶囊预览 */}
+                      <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-card p-2">
+                        <span className="text-[10px] font-semibold text-muted-foreground">
+                          效果:
+                        </span>
+                        <span
+                          className="inline-flex min-w-0 max-w-full items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-all"
+                          style={parsedStyle}
+                        >
+                          <span className="opacity-70 mr-1">
+                            {field.title || field.key || '字段'}:
+                          </span>
+                          <span>示例值</span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           )
         })}
 
-        <div className="flex flex-wrap justify-between gap-2">
-          <Button type="button" variant="outline" onClick={addField} disabled={isLoading || isPending}>
-            <Plus className="mr-1.5 h-4 w-4" />新增字段
+        {/* 底部保存与添加控制 */}
+        <div className="flex flex-wrap justify-between gap-3 pt-2 border-t border-border/40">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={addField}
+            disabled={isLoading || isPending}
+            className="h-9 px-4 text-xs font-medium"
+          >
+            <Plus className="mr-1.5 h-4 w-4" />
+            新增字段
           </Button>
-          <Button type="button" onClick={save} disabled={isLoading || isPending || drafts.length === 0}>
-            <Save className="mr-1.5 h-4 w-4" />{isPending ? '保存中…' : '保存 Schema'}
+
+          <Button
+            type="button"
+            onClick={save}
+            disabled={isLoading || isPending || drafts.length === 0}
+            className="h-9 px-5 text-xs font-semibold shadow-apple-sm"
+          >
+            <Save className="mr-1.5 h-4 w-4" />
+            {isPending ? '保存中…' : '保存 Schema 配置'}
           </Button>
         </div>
       </div>

--- a/admin-ui/src/components/settings/metadata-section.tsx
+++ b/admin-ui/src/components/settings/metadata-section.tsx
@@ -5,9 +5,9 @@ import {
   Trash2,
   ChevronUp,
   ChevronDown,
-  ChevronRight,
   Palette,
   Sliders,
+  Settings2,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -128,7 +128,7 @@ function schemaToDrafts(schema: CredentialMetadataSchema): FieldDraft[] {
         label: option.title,
       })) ?? [],
     css: field['x-css'] ?? '',
-    expanded: false, // 默认收起为超紧凑数据行
+    expanded: false,
   }))
 }
 
@@ -315,331 +315,365 @@ export function MetadataSection() {
   return (
     <SettingGroup
       title="凭据 Metadata Schema"
-      description="自定义凭据属性结构。全量开放编辑字段 Key、标题、类型、枚举值、默认值、CSS 胶囊样式与卡片展示顺序。"
+      description="自定义凭据属性结构。通过列表清晰管理字段属性、类型、胶囊渲染样式与展示顺序。"
     >
-      <div className="space-y-2 py-1">
-        {drafts.map((field, index) => {
-          const builtIn = field.locked
-          const isExpanded = field.expanded ?? false
-          const parsedStyle = metadataCssToStyle(field.css)
+      <div className="space-y-3 py-2">
+        {/* 表格容器 */}
+        <div className="rounded-2xl border border-border/80 bg-card overflow-hidden shadow-apple-sm">
+          {/* 表头 Header Row */}
+          <div className="grid grid-cols-[48px_1.5fr_100px_1fr_1.2fr_80px] items-center gap-2 border-b border-border/60 bg-muted/40 px-3 py-2 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+            <div className="text-center">排序</div>
+            <div>字段 Key & 名称</div>
+            <div>数据类型</div>
+            <div>默认值 / 枚举</div>
+            <div>卡片渲染 Preview</div>
+            <div className="text-right">操作</div>
+          </div>
 
-          return (
-            <div
-              key={`field-${field.key || index}`}
-              className="rounded-xl border border-border/70 bg-card shadow-apple-sm hover:border-border transition-all overflow-hidden"
-            >
-              {/* 高密度紧凑 Header 行 (仅 ~40px 高度) */}
-              <div
-                onClick={() => toggleExpand(index)}
-                className="flex items-center justify-between gap-2 px-3 py-2 cursor-pointer hover:bg-accent/40 select-none transition-colors"
-              >
-                <div className="flex min-w-0 flex-1 items-center gap-2">
-                  <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground">
-                    <ChevronRight
-                      className={`h-3.5 w-3.5 transition-transform duration-200 ${
-                        isExpanded ? 'rotate-90' : ''
-                      }`}
-                    />
-                  </div>
+          {/* 表格数据行 Table Rows */}
+          <div className="divide-y divide-border/40">
+            {drafts.map((field, index) => {
+              const builtIn = field.locked
+              const isExpanded = field.expanded ?? false
+              const parsedStyle = metadataCssToStyle(field.css)
 
-                  {/* Key & Title */}
-                  <span className="font-mono text-xs font-bold text-foreground shrink-0">
-                    {field.key || <span className="text-muted-foreground italic">未命名 key</span>}
-                  </span>
-
-                  {field.title && (
-                    <span className="text-xs text-muted-foreground/80 truncate max-w-[120px]">
-                      ({field.title})
-                    </span>
-                  )}
-
-                  <Badge variant="outline" className="text-[9px] uppercase font-mono px-1 py-0 h-4">
-                    {field.type}
-                  </Badge>
-
-                  {builtIn && (
-                    <Badge
-                      variant="secondary"
-                      className="bg-primary/10 text-primary border-primary/20 text-[9px] px-1 py-0 h-4"
+              return (
+                <div key={`field-${field.key || index}`} className="transition-colors">
+                  {/* 数据行 Header Row */}
+                  <div
+                    onClick={() => toggleExpand(index)}
+                    className={`grid grid-cols-[48px_1.5fr_100px_1fr_1.2fr_80px] items-center gap-2 px-3 py-3 text-sm cursor-pointer transition-colors ${
+                      isExpanded ? 'bg-accent/40' : 'hover:bg-accent/20'
+                    }`}
+                  >
+                    {/* 列 1: 排序控制 */}
+                    <div
+                      className="flex items-center justify-center gap-0.5"
+                      onClick={(e) => e.stopPropagation()}
                     >
-                      默认
-                    </Badge>
-                  )}
-
-                  {/* 默认值的内联微展示 */}
-                  {field.defaultValue && (
-                    <span className="hidden md:inline-flex text-[10px] text-muted-foreground/70 font-mono bg-muted/50 px-1.5 py-0.5 rounded">
-                      默认: {field.defaultValue}
-                    </span>
-                  )}
-
-                  {/* 实时微型渲染胶囊预览 (无需展开直接查看效果) */}
-                  {field.css && (
-                    <span
-                      className="ml-auto hidden sm:inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none"
-                      style={parsedStyle}
-                    >
-                      {field.title || field.key}: 示例
-                    </span>
-                  )}
-                </div>
-
-                {/* 快捷操作区 */}
-                <div
-                  className="flex items-center gap-0.5 shrink-0"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    className="h-7 w-7"
-                    disabled={index === 0 || isPending}
-                    onClick={() => moveField(index, 'up')}
-                    title="向上移动排序"
-                  >
-                    <ChevronUp className="h-3.5 w-3.5" />
-                  </Button>
-
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    className="h-7 w-7"
-                    disabled={index === drafts.length - 1 || isPending}
-                    onClick={() => moveField(index, 'down')}
-                    title="向下移动排序"
-                  >
-                    <ChevronDown className="h-3.5 w-3.5" />
-                  </Button>
-
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    disabled={isPending}
-                    onClick={() =>
-                      setDrafts((current) => current.filter((_, i) => i !== index))
-                    }
-                    className="h-7 w-7 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
-                    title="删除字段"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              </div>
-
-              {/* 展开的超高密度编辑面板 */}
-              {isExpanded && (
-                <div className="space-y-2.5 border-t border-border/40 p-2.5 sm:p-3 bg-muted/10 text-xs">
-                  {/* 第一行 (4列): Key, Title, Type, DefaultValue */}
-                  <div className="grid gap-2 grid-cols-2 sm:grid-cols-4">
-                    <div className="space-y-0.5">
-                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
-                        Key
-                      </label>
-                      <Input
-                        value={field.key}
-                        onChange={(event) =>
-                          update(index, { key: event.target.value })
-                        }
-                        placeholder="例如: salePrice"
-                        disabled={isPending}
-                        className="h-8 font-mono text-xs px-2"
-                      />
-                    </div>
-
-                    <div className="space-y-0.5">
-                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
-                        显示名称
-                      </label>
-                      <Input
-                        value={field.title}
-                        onChange={(event) =>
-                          update(index, { title: event.target.value })
-                        }
-                        placeholder="例如: 售卖价格"
-                        disabled={isPending}
-                        className="h-8 text-xs px-2"
-                      />
-                    </div>
-
-                    <div className="space-y-0.5">
-                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
-                        数据类型
-                      </label>
-                      <Select
-                        value={field.type}
-                        onValueChange={(value) =>
-                          update(index, { type: value as ValueType })
-                        }
-                        disabled={isPending}
-                      >
-                        <SelectTrigger className="h-8 text-xs px-2">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="string">字符串 (String)</SelectItem>
-                          <SelectItem value="number">数字 (Number)</SelectItem>
-                          <SelectItem value="integer">整数 (Integer)</SelectItem>
-                          <SelectItem value="boolean">布尔值 (Boolean)</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <div className="space-y-0.5">
-                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
-                        默认值
-                      </label>
-                      <Input
-                        value={field.defaultValue}
-                        onChange={(event) =>
-                          update(index, { defaultValue: event.target.value })
-                        }
-                        placeholder={field.type === 'boolean' ? 'true / false' : '初始默认值'}
-                        disabled={isPending}
-                        className="h-8 font-mono text-xs px-2"
-                      />
-                    </div>
-                  </div>
-
-                  {/* 第二行 (2列): 字段说明 & CSS + 预设 */}
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    <div className="space-y-0.5">
-                      <label className="text-[10px] font-semibold text-muted-foreground uppercase">
-                        说明文案
-                      </label>
-                      <Input
-                        value={field.description}
-                        onChange={(event) =>
-                          update(index, { description: event.target.value })
-                        }
-                        placeholder="表单和卡片中的提示文案"
-                        disabled={isPending}
-                        className="h-8 text-xs px-2"
-                      />
-                    </div>
-
-                    <div className="space-y-0.5">
-                      <div className="flex items-center justify-between">
-                        <label className="text-[10px] font-semibold text-muted-foreground uppercase flex items-center gap-1">
-                          <Palette className="h-3 w-3 text-primary" />
-                          CSS 样式
-                        </label>
-                        {/* 快捷配色 */}
-                        <div className="flex items-center gap-1">
-                          {CSS_PRESETS.map((preset) => (
-                            <button
-                              key={preset.name}
-                              type="button"
-                              onClick={() => update(index, { css: preset.css })}
-                              disabled={isPending}
-                              className="rounded px-1 text-[9px] border border-border/50 bg-muted/40 hover:bg-accent hover:text-primary transition-colors"
-                            >
-                              {preset.name}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-
-                      <Input
-                        value={field.css}
-                        onChange={(event) =>
-                          update(index, { css: event.target.value })
-                        }
-                        placeholder="例如: color: #b45309; background-color: #fffbeb;"
-                        disabled={isPending}
-                        className="h-8 font-mono text-xs px-2"
-                      />
-                    </div>
-                  </div>
-
-                  {/* 第三行: 枚举选项 (Options Visual Editor) */}
-                  <div className="space-y-1.5 rounded-lg border border-border/40 bg-background/50 p-2">
-                    <div className="flex items-center justify-between">
-                      <span className="flex items-center gap-1 text-[10px] font-semibold text-muted-foreground uppercase">
-                        <Sliders className="h-3 w-3 text-primary" />
-                        枚举选项 (OneOf Options)
-                      </span>
                       <Button
                         type="button"
-                        size="sm"
+                        size="icon"
                         variant="ghost"
-                        className="h-6 px-1.5 text-[11px] text-primary"
-                        onClick={() => addOption(index)}
-                        disabled={isPending}
+                        className="h-6 w-6 text-muted-foreground/70 hover:text-foreground"
+                        disabled={index === 0 || isPending}
+                        onClick={() => moveField(index, 'up')}
+                        title="上移"
                       >
-                        <Plus className="mr-0.5 h-3 w-3" />
-                        加项
+                        <ChevronUp className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-6 w-6 text-muted-foreground/70 hover:text-foreground"
+                        disabled={index === drafts.length - 1 || isPending}
+                        onClick={() => moveField(index, 'down')}
+                        title="下移"
+                      >
+                        <ChevronDown className="h-3.5 w-3.5" />
                       </Button>
                     </div>
 
-                    {field.options.length > 0 ? (
-                      <div className="grid gap-1.5 sm:grid-cols-2">
-                        {field.options.map((opt, optIdx) => (
-                          <div
-                            key={`opt-${optIdx}`}
-                            className="flex items-center gap-1.5"
-                          >
-                            <Input
-                              value={opt.value}
-                              onChange={(e) =>
-                                updateOption(index, optIdx, {
-                                  value: e.target.value,
-                                })
-                              }
-                              placeholder="存储值"
-                              disabled={isPending}
-                              className="h-7 font-mono text-[11px] px-1.5 flex-1"
-                            />
-                            <span className="text-muted-foreground/60 text-[10px]">:</span>
-                            <Input
-                              value={opt.label}
-                              onChange={(e) =>
-                                updateOption(index, optIdx, {
-                                  label: e.target.value,
-                                })
-                              }
-                              placeholder="显示名"
-                              disabled={isPending}
-                              className="h-7 text-[11px] px-1.5 flex-1"
-                            />
-                            <Button
-                              type="button"
-                              size="icon"
-                              variant="ghost"
-                              className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
-                              disabled={isPending}
-                              onClick={() => removeOption(index, optIdx)}
-                              title="删除选项"
-                            >
-                              <Trash2 className="h-3 w-3" />
-                            </Button>
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-[10px] text-muted-foreground/60 italic">
-                        未设置枚举限制。
-                      </p>
-                    )}
+                    {/* 列 2: Key & Title */}
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="font-mono text-sm font-bold text-foreground truncate">
+                        {field.key || <span className="text-muted-foreground italic">未命名 key</span>}
+                      </span>
+                      {field.title && (
+                        <span className="text-xs text-muted-foreground truncate">
+                          ({field.title})
+                        </span>
+                      )}
+                      {builtIn && (
+                        <Badge
+                          variant="secondary"
+                          className="bg-primary/10 text-primary border-primary/20 text-[9px] px-1 py-0 h-4"
+                        >
+                          默认
+                        </Badge>
+                      )}
+                    </div>
+
+                    {/* 列 3: 数据类型 */}
+                    <div>
+                      <Badge variant="outline" className="text-[10px] font-mono uppercase">
+                        {field.type}
+                      </Badge>
+                    </div>
+
+                    {/* 列 4: 默认值 / 枚举数 */}
+                    <div className="text-xs text-muted-foreground truncate">
+                      {field.options.length > 0 ? (
+                        <span className="font-medium text-foreground">
+                          {field.options.length} 个枚举项
+                        </span>
+                      ) : field.defaultValue ? (
+                        <span className="font-mono text-[11px] bg-muted/60 px-1.5 py-0.5 rounded">
+                          默认: {field.defaultValue}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground/50 italic">-</span>
+                      )}
+                    </div>
+
+                    {/* 列 5: 卡片渲染 Preview */}
+                    <div className="flex items-center">
+                      <span
+                        className="inline-flex max-w-[140px] truncate items-center rounded border px-2 py-0.5 text-xs font-medium"
+                        style={parsedStyle}
+                      >
+                        {field.title || field.key || '字段'}: 示例
+                      </span>
+                    </div>
+
+                    {/* 列 6: 操作按钮 (设置 / 删除) */}
+                    <div
+                      className="flex items-center justify-end gap-1"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant={isExpanded ? 'secondary' : 'ghost'}
+                        className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                        onClick={() => toggleExpand(index)}
+                        title={isExpanded ? '收起配置' : '展开配置'}
+                      >
+                        <Settings2 className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        disabled={isPending}
+                        onClick={() =>
+                          setDrafts((current) => current.filter((_, i) => i !== index))
+                        }
+                        className="h-7 w-7 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
+                        title="删除字段"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </div>
+
+                  {/* 展开的平滑大方配置面板 */}
+                  {isExpanded && (
+                    <div className="space-y-4 border-t border-border/40 bg-muted/10 p-4 sm:p-5 text-sm">
+                      {/* 第一行 (4列): Key, Title, Type, DefaultValue */}
+                      <div className="grid gap-3 sm:grid-cols-4">
+                        <div className="space-y-1">
+                          <label className="text-xs font-semibold text-muted-foreground uppercase">
+                            字段 Key
+                          </label>
+                          <Input
+                            value={field.key}
+                            onChange={(event) =>
+                              update(index, { key: event.target.value })
+                            }
+                            placeholder="例如: salePrice"
+                            disabled={isPending}
+                            className="font-mono"
+                          />
+                        </div>
+
+                        <div className="space-y-1">
+                          <label className="text-xs font-semibold text-muted-foreground uppercase">
+                            显示名称 (Title)
+                          </label>
+                          <Input
+                            value={field.title}
+                            onChange={(event) =>
+                              update(index, { title: event.target.value })
+                            }
+                            placeholder="例如: 售卖价格"
+                            disabled={isPending}
+                          />
+                        </div>
+
+                        <div className="space-y-1">
+                          <label className="text-xs font-semibold text-muted-foreground uppercase">
+                            数据类型 (Type)
+                          </label>
+                          <Select
+                            value={field.type}
+                            onValueChange={(value) =>
+                              update(index, { type: value as ValueType })
+                            }
+                            disabled={isPending}
+                          >
+                            <SelectTrigger>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="string">字符串 (String)</SelectItem>
+                              <SelectItem value="number">数字 (Number)</SelectItem>
+                              <SelectItem value="integer">整数 (Integer)</SelectItem>
+                              <SelectItem value="boolean">布尔值 (Boolean)</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+
+                        <div className="space-y-1">
+                          <label className="text-xs font-semibold text-muted-foreground uppercase">
+                            默认值
+                          </label>
+                          <Input
+                            value={field.defaultValue}
+                            onChange={(event) =>
+                              update(index, { defaultValue: event.target.value })
+                            }
+                            placeholder={
+                              field.type === 'boolean'
+                                ? 'true 或 false'
+                                : '初始默认值'
+                            }
+                            disabled={isPending}
+                            className="font-mono"
+                          />
+                        </div>
+                      </div>
+
+                      {/* 第二行 (2列): 说明 & CSS 样式 */}
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="space-y-1">
+                          <label className="text-xs font-semibold text-muted-foreground uppercase">
+                            字段说明文案
+                          </label>
+                          <Input
+                            value={field.description}
+                            onChange={(event) =>
+                              update(index, { description: event.target.value })
+                            }
+                            placeholder="表单与提示框中展示的说明"
+                            disabled={isPending}
+                          />
+                        </div>
+
+                        <div className="space-y-1">
+                          <div className="flex items-center justify-between">
+                            <label className="text-xs font-semibold text-muted-foreground uppercase flex items-center gap-1.5">
+                              <Palette className="h-3.5 w-3.5 text-primary" />
+                              CSS 胶囊样式
+                            </label>
+                            <div className="flex items-center gap-1">
+                              <span className="text-[10px] text-muted-foreground">
+                                快捷配色:
+                              </span>
+                              {CSS_PRESETS.map((preset) => (
+                                <button
+                                  key={preset.name}
+                                  type="button"
+                                  onClick={() => update(index, { css: preset.css })}
+                                  disabled={isPending}
+                                  className="rounded px-1.5 py-0.5 text-[10px] border border-border/50 bg-muted/40 hover:bg-accent hover:text-primary transition-colors"
+                                >
+                                  {preset.name}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                          <Input
+                            value={field.css}
+                            onChange={(event) =>
+                              update(index, { css: event.target.value })
+                            }
+                            placeholder="例如: color: #b45309; background-color: #fffbeb;"
+                            disabled={isPending}
+                            className="font-mono text-xs"
+                          />
+                        </div>
+                      </div>
+
+                      {/* 第三行: 枚举选项 (Options Visual Editor) */}
+                      <div className="space-y-2 rounded-xl border border-border/50 bg-background/60 p-3">
+                        <div className="flex items-center justify-between">
+                          <span className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase">
+                            <Sliders className="h-3.5 w-3.5 text-primary" />
+                            枚举选项配置 (OneOf Options)
+                          </span>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 text-xs text-primary"
+                            onClick={() => addOption(index)}
+                            disabled={isPending}
+                          >
+                            <Plus className="mr-1 h-3.5 w-3.5" />
+                            添加选项
+                          </Button>
+                        </div>
+
+                        {field.options.length > 0 ? (
+                          <div className="grid gap-2 sm:grid-cols-2">
+                            {field.options.map((opt, optIdx) => (
+                              <div
+                                key={`opt-${optIdx}`}
+                                className="flex items-center gap-2"
+                              >
+                                <Input
+                                  value={opt.value}
+                                  onChange={(e) =>
+                                    updateOption(index, optIdx, {
+                                      value: e.target.value,
+                                    })
+                                  }
+                                  placeholder="存储值 (const)"
+                                  disabled={isPending}
+                                  className="h-8 font-mono text-xs flex-1"
+                                />
+                                <span className="text-muted-foreground/60 text-xs">:</span>
+                                <Input
+                                  value={opt.label}
+                                  onChange={(e) =>
+                                    updateOption(index, optIdx, {
+                                      label: e.target.value,
+                                    })
+                                  }
+                                  placeholder="显示名称 (title)"
+                                  disabled={isPending}
+                                  className="h-8 text-xs flex-1"
+                                />
+                                <Button
+                                  type="button"
+                                  size="icon"
+                                  variant="ghost"
+                                  className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                                  disabled={isPending}
+                                  onClick={() => removeOption(index, optIdx)}
+                                  title="删除选项"
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="text-xs text-muted-foreground/60 italic py-0.5">
+                            未设定固定枚举限制（接受任意对应类型的值）。
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          )
-        })}
+              )
+            })}
+          </div>
+        </div>
 
         {/* 底部保存与添加控制 */}
-        <div className="flex flex-wrap justify-between gap-2 pt-2 border-t border-border/40">
+        <div className="flex flex-wrap justify-between gap-3 pt-2">
           <Button
             type="button"
             variant="outline"
             onClick={addField}
             disabled={isLoading || isPending}
-            className="h-8 px-3 text-xs font-medium"
+            className="h-9 px-4 text-xs font-medium"
           >
-            <Plus className="mr-1 h-3.5 w-3.5" />
+            <Plus className="mr-1.5 h-4 w-4" />
             新增字段
           </Button>
 
@@ -647,9 +681,9 @@ export function MetadataSection() {
             type="button"
             onClick={save}
             disabled={isLoading || isPending || drafts.length === 0}
-            className="h-8 px-4 text-xs font-semibold shadow-apple-sm"
+            className="h-9 px-5 text-xs font-semibold shadow-apple-sm"
           >
-            <Save className="mr-1 h-3.5 w-3.5" />
+            <Save className="mr-1.5 h-4 w-4" />
             {isPending ? '保存中…' : '保存 Schema 配置'}
           </Button>
         </div>

--- a/admin-ui/src/components/settings/metadata-section.tsx
+++ b/admin-ui/src/components/settings/metadata-section.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useState } from 'react'
+import { Plus, Save, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { SettingGroup } from '@/components/console/setting-row'
+import {
+  useCredentialMetadataSchema,
+  useSetCredentialMetadataSchema,
+} from '@/hooks/use-credentials'
+import { extractErrorMessage } from '@/lib/utils'
+import type {
+  CredentialMetadataFieldSchema,
+  CredentialMetadataSchema,
+} from '@/types/api'
+
+type ValueType = CredentialMetadataFieldSchema['type']
+
+interface FieldDraft {
+  locked: boolean
+  key: string
+  title: string
+  description: string
+  type: ValueType
+  defaultValue: string
+  options: string
+}
+
+function schemaToDrafts(schema: CredentialMetadataSchema): FieldDraft[] {
+  return Object.entries(schema.properties).map(([key, field]) => ({
+    locked: key === 'type',
+    key,
+    title: field.title,
+    description: field.description ?? '',
+    type: field.type,
+    defaultValue: field.default == null ? '' : String(field.default),
+    options: field.oneOf?.map((option) => `${String(option.const)}:${option.title}`).join(', ') ?? '',
+  }))
+}
+
+function parseDefault(value: string, type: ValueType): unknown {
+  if (value === '') return undefined
+  if (type === 'boolean') return value === 'true'
+  if (type === 'number' || type === 'integer') return Number(value)
+  return value
+}
+
+function draftsToSchema(
+  base: CredentialMetadataSchema,
+  drafts: FieldDraft[],
+): CredentialMetadataSchema {
+  const properties: Record<string, CredentialMetadataFieldSchema> = {}
+  for (const draft of drafts) {
+    const field: CredentialMetadataFieldSchema = {
+      title: draft.title.trim() || draft.key,
+      type: draft.type,
+    }
+    if (draft.description.trim()) field.description = draft.description.trim()
+    const defaultValue = parseDefault(draft.defaultValue.trim(), draft.type)
+    if (defaultValue !== undefined) field.default = defaultValue
+    const options = draft.options
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .map((item) => {
+        const [value, ...labelParts] = item.split(':')
+        const raw = value.trim()
+        const parsed = draft.type === 'boolean'
+          ? raw === 'true'
+          : draft.type === 'number' || draft.type === 'integer'
+            ? Number(raw)
+            : raw
+        return { const: parsed, title: labelParts.join(':').trim() || raw }
+      })
+    if (options.length > 0) field.oneOf = options
+    properties[draft.key.trim()] = field
+  }
+  return {
+    ...base,
+    type: 'object',
+    properties,
+    required: ['type'],
+    additionalProperties: true,
+  }
+}
+
+export function MetadataSection() {
+  const { data, isLoading } = useCredentialMetadataSchema()
+  const { mutate, isPending } = useSetCredentialMetadataSchema()
+  const [drafts, setDrafts] = useState<FieldDraft[]>([])
+
+  useEffect(() => {
+    if (data?.schema) setDrafts(schemaToDrafts(data.schema))
+  }, [data])
+
+  const update = (index: number, patch: Partial<FieldDraft>) => {
+    setDrafts((current) => current.map((field, i) => (i === index ? { ...field, ...patch } : field)))
+  }
+
+  const addField = () => {
+    setDrafts((current) => [
+      ...current,
+      {
+        locked: false,
+        key: '',
+        title: '',
+        description: '',
+        type: 'string',
+        defaultValue: '',
+        options: '',
+      },
+    ])
+  }
+
+  const save = () => {
+    if (!data?.schema) return
+    const keys = drafts.map((field) => field.key.trim())
+    if (keys.some((key) => !key)) {
+      toast.error('字段 key 不能为空')
+      return
+    }
+    if (new Set(keys).size !== keys.length) {
+      toast.error('字段 key 不能重复')
+      return
+    }
+    const typeField = drafts.find((field) => field.key === 'type')
+    if (!typeField) {
+      toast.error('内置 type 字段不能删除')
+      return
+    }
+    for (const field of drafts) {
+      const defaultValue = field.defaultValue.trim()
+      if (defaultValue && field.type === 'boolean' && !['true', 'false'].includes(defaultValue)) {
+        toast.error(`${field.key} 的布尔默认值只能是 true 或 false`)
+        return
+      }
+      if (
+        defaultValue
+        && (field.type === 'number' || field.type === 'integer')
+        && (!Number.isFinite(Number(defaultValue))
+          || (field.type === 'integer' && !Number.isInteger(Number(defaultValue))))
+      ) {
+        toast.error(`${field.key} 的默认值类型不正确`)
+        return
+      }
+    }
+    mutate(
+      { schema: draftsToSchema(data.schema, drafts) },
+      {
+        onSuccess: () => toast.success('凭据 metadata schema 已保存'),
+        onError: (error) => toast.error(`保存失败: ${extractErrorMessage(error)}`),
+      },
+    )
+  }
+
+  return (
+    <SettingGroup
+      title="凭据 Metadata Schema"
+      description="定义凭据 metadata 的字段 key、值类型、默认值和枚举 value。type 是内置必填字段。"
+    >
+      <div className="space-y-3 py-2">
+        {drafts.map((field, index) => {
+          const builtIn = field.locked
+          return (
+            <div key={`${builtIn ? 'builtin' : 'field'}-${index}`} className="space-y-3 rounded-xl border border-border/60 p-3">
+              <div className="grid gap-2 sm:grid-cols-[1fr_1fr_140px_auto]">
+                <Input
+                  value={field.key}
+                  onChange={(event) => update(index, { key: event.target.value })}
+                  placeholder="字段 key"
+                  disabled={builtIn || isPending}
+                  className="font-mono"
+                />
+                <Input
+                  value={field.title}
+                  onChange={(event) => update(index, { title: event.target.value })}
+                  placeholder="显示名称"
+                  disabled={isPending}
+                />
+                <Select
+                  value={field.type}
+                  onValueChange={(value) => update(index, { type: value as ValueType })}
+                  disabled={builtIn || isPending}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="string">字符串</SelectItem>
+                    <SelectItem value="number">数字</SelectItem>
+                    <SelectItem value="integer">整数</SelectItem>
+                    <SelectItem value="boolean">布尔值</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  disabled={builtIn || isPending}
+                  onClick={() => setDrafts((current) => current.filter((_, i) => i !== index))}
+                  title={builtIn ? '内置字段不能删除' : '删除字段'}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+              <Input
+                value={field.description}
+                onChange={(event) => update(index, { description: event.target.value })}
+                placeholder="字段说明"
+                disabled={isPending}
+              />
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Input
+                  value={field.defaultValue}
+                  onChange={(event) => update(index, { defaultValue: event.target.value })}
+                  placeholder="默认值（可选）"
+                  disabled={builtIn || isPending}
+                />
+                <Input
+                  value={field.options}
+                  onChange={(event) => update(index, { options: event.target.value })}
+                  placeholder="枚举：value:名称, value:名称"
+                  disabled={builtIn || isPending}
+                  className="font-mono text-xs"
+                />
+              </div>
+            </div>
+          )
+        })}
+
+        <div className="flex flex-wrap justify-between gap-2">
+          <Button type="button" variant="outline" onClick={addField} disabled={isLoading || isPending}>
+            <Plus className="mr-1.5 h-4 w-4" />新增字段
+          </Button>
+          <Button type="button" onClick={save} disabled={isLoading || isPending || drafts.length === 0}>
+            <Save className="mr-1.5 h-4 w-4" />{isPending ? '保存中…' : '保存 Schema'}
+          </Button>
+        </div>
+      </div>
+    </SettingGroup>
+  )
+}

--- a/admin-ui/src/components/settings/metadata-section.tsx
+++ b/admin-ui/src/components/settings/metadata-section.tsx
@@ -76,8 +76,46 @@ const CSS_PRESETS = [
   },
 ]
 
+// 系统默认的基础字段模板 (type, saleStatus, salePrice)
+const DEFAULT_BUILTIN_PROPERTIES: Record<string, CredentialMetadataFieldSchema> = {
+  type: {
+    title: '账号类型',
+    description: '账号运营分类，仅用于标记，不参与调度。',
+    type: 'string',
+    default: 'normal',
+    oneOf: [
+      { const: 'normal', title: '正常号' },
+      { const: 'boom', title: '炸弹号' },
+    ],
+    'x-css': 'color: #b45309; background-color: #fffbeb; border-color: #fde68a;',
+  },
+  saleStatus: {
+    title: '在售状态',
+    description: '账号运营销售状态，仅用于标记，不参与调度。',
+    type: 'string',
+    default: 'not_for_sale',
+    oneOf: [
+      { const: 'not_for_sale', title: '非卖品' },
+      { const: 'for_sale', title: '在售' },
+      { const: 'sold', title: '已售' },
+    ],
+    'x-css': 'color: #047857; background-color: #ecfdf5; border-color: #a7f3d0;',
+  },
+  salePrice: {
+    title: '销售价格（CNY）',
+    description: '账号销售价格，单位为人民币；未设置时不在卡片显示。',
+    type: 'number',
+    minimum: 0,
+    'x-css': 'color: #0284c7; background-color: #f0f9ff; border-color: #bae6fd;',
+  },
+}
+
 function schemaToDrafts(schema: CredentialMetadataSchema): FieldDraft[] {
-  return Object.entries(schema.properties).map(([key, field]) => ({
+  const mergedProperties = {
+    ...DEFAULT_BUILTIN_PROPERTIES,
+    ...(schema?.properties ?? {}),
+  }
+  return Object.entries(mergedProperties).map(([key, field]) => ({
     locked: ['type', 'saleStatus', 'salePrice'].includes(key),
     key,
     title: field.title,

--- a/admin-ui/src/components/settings/metadata-section.tsx
+++ b/admin-ui/src/components/settings/metadata-section.tsx
@@ -192,7 +192,29 @@ export function MetadataSection() {
   const [drafts, setDrafts] = useState<FieldDraft[]>([])
 
   useEffect(() => {
-    if (data?.schema) setDrafts(schemaToDrafts(data.schema))
+    if (!data?.schema) return
+
+    const existingKeys = Object.keys(data.schema.properties ?? {})
+    const hasAllBuiltins = ['type', 'saleStatus', 'salePrice'].every((key) =>
+      existingKeys.includes(key),
+    )
+
+    const initialDrafts = schemaToDrafts(data.schema)
+    setDrafts(initialDrafts)
+
+    // 如果后端的 config.json 尚未持久化这些默认字段，自动触发一次 API 将完整 Payload 写入后端磁盘与内存
+    if (!hasAllBuiltins && !isPending) {
+      const fullSchema = draftsToSchema(data.schema, initialDrafts)
+      mutate(
+        { schema: fullSchema },
+        {
+          onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['credentials'] })
+            queryClient.invalidateQueries({ queryKey: ['credential-metadata-schema'] })
+          },
+        },
+      )
+    }
   }, [data])
 
   const update = (index: number, patch: Partial<FieldDraft>) => {

--- a/admin-ui/src/components/settings/models-section.tsx
+++ b/admin-ui/src/components/settings/models-section.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react'
+import { Plus, Trash2, Save } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { SettingGroup } from '@/components/console/setting-row'
+import { useCustomModels, useSetCustomModels } from '@/hooks/use-credentials'
+import { extractErrorMessage } from '@/lib/utils'
+import type { CustomModelItem } from '@/types/api'
+
+/** 空模型模板 */
+function emptyModel(): CustomModelItem {
+  return {
+    id: '',
+    backendId: '',
+    displayName: undefined,
+    contextWindow: undefined,
+    maxTokens: undefined,
+    supportsReasoning: false,
+    ownedBy: undefined,
+  }
+}
+
+/**
+ * 模型分区：管理 config.json 中 customModels 数组。
+ *
+ * 每条自定义模型定义一个客户端别名→Kiro 后端模型 ID 的映射，
+ * 可附带上下文窗口、最大 token 数、reasoning 支持等元数据。
+ * 改动即时写入 config.json 并运行时生效。
+ */
+export function ModelsSection() {
+  const { data, isLoading } = useCustomModels()
+  const { mutate, isPending } = useSetCustomModels()
+
+  const [drafts, setDrafts] = useState<CustomModelItem[]>([])
+  const [dirty, setDirty] = useState(false)
+
+  // 从服务端同步到本地草稿
+  useEffect(() => {
+    if (!data?.models) return
+    setDrafts(data.models.map((m) => ({ ...m })))
+    setDirty(false)
+  }, [data?.models])
+
+  const markDirty = () => setDirty(true)
+
+  const updateField = <K extends keyof CustomModelItem>(
+    index: number,
+    field: K,
+    value: CustomModelItem[K],
+  ) => {
+    setDrafts((prev) => {
+      const next = [...prev]
+      next[index] = { ...next[index], [field]: value }
+      return next
+    })
+    markDirty()
+  }
+
+  const addRow = () => {
+    setDrafts((prev) => [...prev, emptyModel()])
+    markDirty()
+  }
+
+  const removeRow = (index: number) => {
+    setDrafts((prev) => prev.filter((_, i) => i !== index))
+    markDirty()
+  }
+
+  const apply = () => {
+    // 校验
+    for (let i = 0; i < drafts.length; i++) {
+      const m = drafts[i]
+      if (!m.id.trim()) {
+        toast.error(`第 ${i + 1} 条模型的 id 不能为空`)
+        return
+      }
+      if (!m.backendId.trim()) {
+        toast.error(`第 ${i + 1} 条模型（${m.id || '未命名'}）的 backendId 不能为空`)
+        return
+      }
+    }
+    // 清除 undefined 的可选字段以防序列化噪声
+    const clean = drafts.map((m) => ({
+      ...m,
+      displayName: m.displayName?.trim() || undefined,
+      ownedBy: m.ownedBy?.trim() || undefined,
+      contextWindow: m.contextWindow ?? undefined,
+      maxTokens: m.maxTokens ?? undefined,
+    }))
+    mutate(
+      { models: clean },
+      {
+        onSuccess: () => {
+          setDirty(false)
+          toast.success(`已保存 ${clean.length} 条自定义模型`)
+        },
+        onError: (err) => {
+          toast.error('保存失败：' + extractErrorMessage(err))
+        },
+      },
+    )
+  }
+
+  const count = drafts.length
+
+  return (
+    <div className="space-y-4">
+      <SettingGroup
+        title="自定义模型"
+        description="定义客户端模型别名→Kiro 后端模型 ID 的映射。id 匹配大小写不敏感。"
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {count > 0 ? `${count} 条模型` : '暂无自定义模型'}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={addRow}
+              disabled={isPending}
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" />
+              添加模型
+            </Button>
+            <Button
+              size="sm"
+              onClick={apply}
+              disabled={isLoading || isPending || !dirty}
+            >
+              <Save className="mr-1 h-3.5 w-3.5" />
+              {isPending ? '保存中…' : '应用'}
+            </Button>
+          </div>
+        </div>
+
+        {count === 0 && !isLoading && (
+          <p className="py-6 text-center text-[13px] text-muted-foreground">
+            点击「添加模型」创建第一条映射
+          </p>
+        )}
+
+        {count > 0 && (
+          <div className="overflow-x-auto">
+            {/* 表头 */}
+            <div className="mb-1 grid min-w-[52rem] grid-cols-[1fr_1fr_80px_70px_90px_1fr_100px_36px] gap-1.5 px-1 text-[11px] font-medium text-muted-foreground">
+              <span>id</span>
+              <span>backendId</span>
+              <span>窗口</span>
+              <span>tokens</span>
+              <span>Reasoning</span>
+              <span>displayName</span>
+              <span>ownedBy</span>
+              <span />
+            </div>
+
+            {/* 行 */}
+            <div className="space-y-1">
+              {drafts.map((m, i) => (
+                <div
+                  key={i}
+                  className="grid min-w-[52rem] grid-cols-[1fr_1fr_80px_70px_90px_1fr_100px_36px] items-center gap-1.5 rounded-md border border-border/60 px-2 py-1.5"
+                >
+                  <Input
+                    value={m.id}
+                    onChange={(e) => updateField(i, 'id', e.target.value)}
+                    placeholder="my-gpt"
+                    disabled={isPending}
+                    spellCheck={false}
+                    className="h-7 text-[12.5px]"
+                  />
+                  <Input
+                    value={m.backendId}
+                    onChange={(e) => updateField(i, 'backendId', e.target.value)}
+                    placeholder="gpt-5.7"
+                    disabled={isPending}
+                    spellCheck={false}
+                    className="h-7 text-[12.5px]"
+                  />
+                  <Input
+                    type="number"
+                    value={m.contextWindow ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      updateField(i, 'contextWindow', v === '' ? undefined : Number(v))
+                    }}
+                    placeholder="200000"
+                    disabled={isPending}
+                    className="h-7 text-[12.5px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  />
+                  <Input
+                    type="number"
+                    value={m.maxTokens ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      updateField(i, 'maxTokens', v === '' ? undefined : Number(v))
+                    }}
+                    placeholder="64000"
+                    disabled={isPending}
+                    className="h-7 text-[12.5px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  />
+                  <div className="flex justify-center">
+                    <Switch
+                      checked={m.supportsReasoning ?? false}
+                      onCheckedChange={(checked) =>
+                        updateField(i, 'supportsReasoning', checked)
+                      }
+                      disabled={isPending}
+                      aria-label={`第 ${i + 1} 条模型 reasoning`}
+                    />
+                  </div>
+                  <Input
+                    value={m.displayName ?? ''}
+                    onChange={(e) =>
+                      updateField(i, 'displayName', e.target.value || undefined)
+                    }
+                    placeholder="同 id"
+                    disabled={isPending}
+                    spellCheck={false}
+                    className="h-7 text-[12.5px]"
+                  />
+                  <Input
+                    value={m.ownedBy ?? ''}
+                    onChange={(e) =>
+                      updateField(i, 'ownedBy', e.target.value || undefined)
+                    }
+                    placeholder="custom"
+                    disabled={isPending}
+                    spellCheck={false}
+                    className="h-7 text-[12.5px]"
+                  />
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => removeRow(i)}
+                    disabled={isPending}
+                    title="删除此行"
+                    className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </SettingGroup>
+    </div>
+  )
+}

--- a/admin-ui/src/components/settings/models-section.tsx
+++ b/admin-ui/src/components/settings/models-section.tsx
@@ -1,15 +1,34 @@
-import { useEffect, useState } from 'react'
-import { Plus, Trash2, Save } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
+import { Cpu, Bot, Sparkles, Wrench, Plus, Trash2, Save, Loader2, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { SettingGroup } from '@/components/console/setting-row'
-import { useCustomModels, useSetCustomModels } from '@/hooks/use-credentials'
-import { extractErrorMessage } from '@/lib/utils'
-import type { CustomModelItem } from '@/types/api'
+import { useCustomModels, useSetCustomModels, useCurrentCredentialModels } from '@/hooks/use-credentials'
+import { extractErrorMessage, cn, parseError } from '@/lib/utils'
+import type { CustomModelItem, AvailableModelItem } from '@/types/api'
 
-/** 空模型模板 */
+// ──── 厂商定义 ────────────────────────────────────────────────────────────
+
+type VendorKey = 'anthropic' | 'openai' | 'kiro' | 'custom'
+
+const VENDORS: { key: VendorKey; label: string; icon: React.ReactNode }[] = [
+  { key: 'anthropic', label: 'Anthropic', icon: <Bot className="h-3.5 w-3.5" /> },
+  { key: 'openai', label: 'OpenAI', icon: <Sparkles className="h-3.5 w-3.5" /> },
+  { key: 'kiro', label: 'Kiro', icon: <Cpu className="h-3.5 w-3.5" /> },
+  { key: 'custom', label: '自定义', icon: <Wrench className="h-3.5 w-3.5" /> },
+]
+
+/** 客户端推断模型厂商（与后端 infer_model_owner 保持一致） */
+function vendorFor(modelId: string): VendorKey {
+  const id = modelId.toLowerCase()
+  if (id.startsWith('claude-')) return 'anthropic'
+  if (id.startsWith('gpt-') || id.startsWith('chatgpt-') || id.startsWith('o1-') || id.startsWith('o3-') || id.startsWith('o4-')) return 'openai'
+  return 'kiro'
+}
+
+/** 空自定义模型模板 */
 function emptyModel(): CustomModelItem {
   return {
     id: '',
@@ -22,26 +41,78 @@ function emptyModel(): CustomModelItem {
   }
 }
 
-/**
- * 模型分区：管理 config.json 中 customModels 数组。
- *
- * 每条自定义模型定义一个客户端别名→Kiro 后端模型 ID 的映射，
- * 可附带上下文窗口、最大 token 数、reasoning 支持等元数据。
- * 改动即时写入 config.json 并运行时生效。
- */
+// ──── 模型显示行（上游只读） ──────────────────────────────────────────────
+
+function UpstreamModelRow({ model }: { model: AvailableModelItem }) {
+  return (
+    <div className="rounded-md border border-border/60 px-3 py-2.5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium">
+            {model.modelName || model.modelId}
+          </div>
+          {model.modelName && model.modelName !== model.modelId && (
+            <div className="mt-0.5 break-all font-mono text-[11px] text-muted-foreground">
+              {model.modelId}
+            </div>
+          )}
+          {model.description && (
+            <div className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+              {model.description}
+            </div>
+          )}
+        </div>
+        {(model.maxInputTokens != null || model.maxOutputTokens != null) && (
+          <div className="flex shrink-0 flex-wrap gap-1 self-start text-[11px] tabular-nums text-muted-foreground">
+            {model.maxInputTokens != null && <span>输入 {model.maxInputTokens.toLocaleString()}</span>}
+            {model.maxOutputTokens != null && <span>输出 {model.maxOutputTokens.toLocaleString()}</span>}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ──── 主组件 ──────────────────────────────────────────────────────────────
+
 export function ModelsSection() {
-  const { data, isLoading } = useCustomModels()
-  const { mutate, isPending } = useSetCustomModels()
+  const [vendor, setVendor] = useState<VendorKey>('anthropic')
+
+  // 上游模型
+  const upstreamQuery = useCurrentCredentialModels(vendor !== 'custom')
+
+  // 自定义模型
+  const { data: customData, isLoading: customLoading } = useCustomModels()
+  const { mutate: saveCustom, isPending: customSaving } = useSetCustomModels()
 
   const [drafts, setDrafts] = useState<CustomModelItem[]>([])
   const [dirty, setDirty] = useState(false)
 
-  // 从服务端同步到本地草稿
+  // 同步自定义模型草稿
   useEffect(() => {
-    if (!data?.models) return
-    setDrafts(data.models.map((m) => ({ ...m })))
+    if (!customData?.models) return
+    setDrafts(customData.models.map((m) => ({ ...m })))
     setDirty(false)
-  }, [data?.models])
+  }, [customData?.models])
+
+  // 按厂商分组上游模型
+  const vendorGroups = useMemo(() => {
+    const groups: Record<Exclude<VendorKey, 'custom'>, AvailableModelItem[]> = {
+      anthropic: [],
+      openai: [],
+      kiro: [],
+    }
+    for (const m of upstreamQuery.data?.models ?? []) {
+      const v = vendorFor(m.modelId)
+      if (v !== 'custom') groups[v].push(m)
+    }
+    return groups
+  }, [upstreamQuery.data])
+
+  const upstreamModels = vendor !== 'custom' ? vendorGroups[vendor] ?? [] : []
+  const upstreamError = upstreamQuery.error
+
+  // ── 自定义模型编辑 ────────────────────────────────────────────────────
 
   const markDirty = () => setDirty(true)
 
@@ -69,7 +140,6 @@ export function ModelsSection() {
   }
 
   const apply = () => {
-    // 校验
     for (let i = 0; i < drafts.length; i++) {
       const m = drafts[i]
       if (!m.id.trim()) {
@@ -81,7 +151,6 @@ export function ModelsSection() {
         return
       }
     }
-    // 清除 undefined 的可选字段以防序列化噪声
     const clean = drafts.map((m) => ({
       ...m,
       displayName: m.displayName?.trim() || undefined,
@@ -89,7 +158,7 @@ export function ModelsSection() {
       contextWindow: m.contextWindow ?? undefined,
       maxTokens: m.maxTokens ?? undefined,
     }))
-    mutate(
+    saveCustom(
       { models: clean },
       {
         onSuccess: () => {
@@ -103,150 +172,226 @@ export function ModelsSection() {
     )
   }
 
-  const count = drafts.length
+  const customCount = drafts.length
 
   return (
     <div className="space-y-4">
       <SettingGroup
-        title="自定义模型"
-        description="定义客户端模型别名→Kiro 后端模型 ID 的映射。id 匹配大小写不敏感。"
+        title="可用模型"
+        description="按厂商查看上游可用模型，或自定义模型别名与元数据。"
       >
-        <div className="mb-3 flex items-center justify-between">
-          <span className="text-xs text-muted-foreground">
-            {count > 0 ? `${count} 条模型` : '暂无自定义模型'}
-          </span>
-          <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={addRow}
-              disabled={isPending}
+        {/* 厂商 Tab */}
+        <nav className="mb-3 flex gap-0.5" aria-label="模型厂商">
+          {VENDORS.map((v) => (
+            <button
+              key={v.key}
+              type="button"
+              onClick={() => setVendor(v.key)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[13px] transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+                vendor === v.key
+                  ? 'bg-primary/12 font-medium text-foreground'
+                  : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground',
+              )}
             >
-              <Plus className="mr-1 h-3.5 w-3.5" />
-              添加模型
-            </Button>
-            <Button
-              size="sm"
-              onClick={apply}
-              disabled={isLoading || isPending || !dirty}
-            >
-              <Save className="mr-1 h-3.5 w-3.5" />
-              {isPending ? '保存中…' : '应用'}
-            </Button>
-          </div>
-        </div>
+              {v.icon}
+              {v.label}
+              {v.key !== 'custom' && vendorGroups[v.key] && (
+                <span className="ml-0.5 text-[11px] text-muted-foreground">
+                  {vendorGroups[v.key].length}
+                </span>
+              )}
+            </button>
+          ))}
+        </nav>
 
-        {count === 0 && !isLoading && (
-          <p className="py-6 text-center text-[13px] text-muted-foreground">
-            点击「添加模型」创建第一条映射
-          </p>
+        {/* ── 上游模型 Tab ────────────────────────────────────────────── */}
+        {vendor !== 'custom' && (
+          <div className="min-h-[120px]">
+            {upstreamQuery.isLoading && !upstreamQuery.data && (
+              <div className="flex items-center justify-center py-10 text-muted-foreground">
+                <Loader2 className="h-6 w-6 animate-spin" />
+                <span className="ml-2 text-sm">正在查询上游模型…</span>
+              </div>
+            )}
+
+            {upstreamError && <UpstreamError error={upstreamError} />}
+
+            {!upstreamQuery.isLoading && upstreamModels.length === 0 && (
+              <p className="py-10 text-center text-sm text-muted-foreground">
+                {vendor === 'anthropic' ? '暂无 Anthropic 模型'
+                  : vendor === 'openai' ? '暂无 OpenAI 模型'
+                  : '暂无 Kiro 模型'}
+              </p>
+            )}
+
+            {upstreamModels.length > 0 && (
+              <div className="space-y-2">
+                {upstreamModels.map((m) => (
+                  <UpstreamModelRow key={m.modelId} model={m} />
+                ))}
+              </div>
+            )}
+          </div>
         )}
 
-        {count > 0 && (
-          <div className="overflow-x-auto">
-            {/* 表头 */}
-            <div className="mb-1 grid min-w-[52rem] grid-cols-[1fr_1fr_80px_70px_90px_1fr_100px_36px] gap-1.5 px-1 text-[11px] font-medium text-muted-foreground">
-              <span>id</span>
-              <span>backendId</span>
-              <span>窗口</span>
-              <span>tokens</span>
-              <span>Reasoning</span>
-              <span>displayName</span>
-              <span>ownedBy</span>
-              <span />
+        {/* ── 自定义模型 Tab ───────────────────────────────────────────── */}
+        {vendor === 'custom' && (
+          <>
+            <div className="mb-3 flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">
+                {customCount > 0 ? `${customCount} 条自定义模型` : '暂无自定义模型'}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={addRow}
+                  disabled={customSaving}
+                >
+                  <Plus className="mr-1 h-3.5 w-3.5" />
+                  添加模型
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={apply}
+                  disabled={customLoading || customSaving || !dirty}
+                >
+                  <Save className="mr-1 h-3.5 w-3.5" />
+                  {customSaving ? '保存中…' : '应用'}
+                </Button>
+              </div>
             </div>
 
-            {/* 行 */}
-            <div className="space-y-1">
-              {drafts.map((m, i) => (
-                <div
-                  key={i}
-                  className="grid min-w-[52rem] grid-cols-[1fr_1fr_80px_70px_90px_1fr_100px_36px] items-center gap-1.5 rounded-md border border-border/60 px-2 py-1.5"
-                >
-                  <Input
-                    value={m.id}
-                    onChange={(e) => updateField(i, 'id', e.target.value)}
-                    placeholder="my-gpt"
-                    disabled={isPending}
-                    spellCheck={false}
-                    className="h-7 text-[12.5px]"
-                  />
-                  <Input
-                    value={m.backendId}
-                    onChange={(e) => updateField(i, 'backendId', e.target.value)}
-                    placeholder="gpt-5.7"
-                    disabled={isPending}
-                    spellCheck={false}
-                    className="h-7 text-[12.5px]"
-                  />
-                  <Input
-                    type="number"
-                    value={m.contextWindow ?? ''}
-                    onChange={(e) => {
-                      const v = e.target.value
-                      updateField(i, 'contextWindow', v === '' ? undefined : Number(v))
-                    }}
-                    placeholder="200000"
-                    disabled={isPending}
-                    className="h-7 text-[12.5px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                  />
-                  <Input
-                    type="number"
-                    value={m.maxTokens ?? ''}
-                    onChange={(e) => {
-                      const v = e.target.value
-                      updateField(i, 'maxTokens', v === '' ? undefined : Number(v))
-                    }}
-                    placeholder="64000"
-                    disabled={isPending}
-                    className="h-7 text-[12.5px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                  />
-                  <div className="flex justify-center">
-                    <Switch
-                      checked={m.supportsReasoning ?? false}
-                      onCheckedChange={(checked) =>
-                        updateField(i, 'supportsReasoning', checked)
-                      }
-                      disabled={isPending}
-                      aria-label={`第 ${i + 1} 条模型 reasoning`}
-                    />
-                  </div>
-                  <Input
-                    value={m.displayName ?? ''}
-                    onChange={(e) =>
-                      updateField(i, 'displayName', e.target.value || undefined)
-                    }
-                    placeholder="同 id"
-                    disabled={isPending}
-                    spellCheck={false}
-                    className="h-7 text-[12.5px]"
-                  />
-                  <Input
-                    value={m.ownedBy ?? ''}
-                    onChange={(e) =>
-                      updateField(i, 'ownedBy', e.target.value || undefined)
-                    }
-                    placeholder="custom"
-                    disabled={isPending}
-                    spellCheck={false}
-                    className="h-7 text-[12.5px]"
-                  />
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    onClick={() => removeRow(i)}
-                    disabled={isPending}
-                    title="删除此行"
-                    className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
+            {customCount === 0 && !customLoading && (
+              <p className="py-6 text-center text-[13px] text-muted-foreground">
+                点击「添加模型」创建第一条映射
+              </p>
+            )}
+
+            {customCount > 0 && (
+              <div className="overflow-x-auto">
+                <div className="mb-1 grid min-w-[52rem] grid-cols-[1fr_1fr_80px_70px_90px_1fr_100px_36px] gap-1.5 px-1 text-[11px] font-medium text-muted-foreground">
+                  <span>id</span>
+                  <span>backendId</span>
+                  <span>窗口</span>
+                  <span>tokens</span>
+                  <span>Reasoning</span>
+                  <span>displayName</span>
+                  <span>ownedBy</span>
+                  <span />
                 </div>
-              ))}
-            </div>
-          </div>
+
+                <div className="space-y-1">
+                  {drafts.map((m, i) => (
+                    <div
+                      key={i}
+                      className="grid min-w-[52rem] grid-cols-[1fr_1fr_80px_70px_90px_1fr_100px_36px] items-center gap-1.5 rounded-md border border-border/60 px-2 py-1.5"
+                    >
+                      <Input
+                        value={m.id}
+                        onChange={(e) => updateField(i, 'id', e.target.value)}
+                        placeholder="my-gpt"
+                        disabled={customSaving}
+                        spellCheck={false}
+                        className="h-7 text-[12.5px]"
+                      />
+                      <Input
+                        value={m.backendId}
+                        onChange={(e) => updateField(i, 'backendId', e.target.value)}
+                        placeholder="gpt-5.7"
+                        disabled={customSaving}
+                        spellCheck={false}
+                        className="h-7 text-[12.5px]"
+                      />
+                      <Input
+                        type="number"
+                        value={m.contextWindow ?? ''}
+                        onChange={(e) => {
+                          const v = e.target.value
+                          updateField(i, 'contextWindow', v === '' ? undefined : Number(v))
+                        }}
+                        placeholder="200000"
+                        disabled={customSaving}
+                        className="h-7 text-[12.5px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                      />
+                      <Input
+                        type="number"
+                        value={m.maxTokens ?? ''}
+                        onChange={(e) => {
+                          const v = e.target.value
+                          updateField(i, 'maxTokens', v === '' ? undefined : Number(v))
+                        }}
+                        placeholder="64000"
+                        disabled={customSaving}
+                        className="h-7 text-[12.5px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                      />
+                      <div className="flex justify-center">
+                        <Switch
+                          checked={m.supportsReasoning ?? false}
+                          onCheckedChange={(checked) =>
+                            updateField(i, 'supportsReasoning', checked)
+                          }
+                          disabled={customSaving}
+                          aria-label={`第 ${i + 1} 条模型 reasoning`}
+                        />
+                      </div>
+                      <Input
+                        value={m.displayName ?? ''}
+                        onChange={(e) =>
+                          updateField(i, 'displayName', e.target.value || undefined)
+                        }
+                        placeholder="同 id"
+                        disabled={customSaving}
+                        spellCheck={false}
+                        className="h-7 text-[12.5px]"
+                      />
+                      <Input
+                        value={m.ownedBy ?? ''}
+                        onChange={(e) =>
+                          updateField(i, 'ownedBy', e.target.value || undefined)
+                        }
+                        placeholder="custom"
+                        disabled={customSaving}
+                        spellCheck={false}
+                        className="h-7 text-[12.5px]"
+                      />
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => removeRow(i)}
+                        disabled={customSaving}
+                        title="删除此行"
+                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
         )}
       </SettingGroup>
+    </div>
+  )
+}
+
+// ──── 错误展示 ──────────────────────────────────────────────────────────────
+
+function UpstreamError({ error }: { error: unknown }) {
+  const parsed = parseError(error)
+  return (
+    <div className="space-y-2 py-8 text-center">
+      <div className="flex items-center justify-center gap-2 font-medium text-destructive">
+        <AlertCircle className="h-5 w-5" />
+        <span>{parsed.title}</span>
+      </div>
+      {parsed.detail && (
+        <div className="px-4 text-sm text-muted-foreground">{parsed.detail}</div>
+      )}
     </div>
   )
 }

--- a/admin-ui/src/components/settings/network-section.tsx
+++ b/admin-ui/src/components/settings/network-section.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  SettingGroup,
+  SettingRow,
+  useFieldSaver,
+} from '@/components/console/setting-row'
+import { useGlobalProxy, useSetGlobalProxy } from '@/hooks/use-credentials'
+import { maskProxyUrl } from '@/lib/utils'
+import { reportSaveError } from '@/components/settings/report-error'
+
+/**
+ * 网络分区：全局出站代理。
+ *
+ * 这一项是即时保存范式里唯一的例外，理由具体：代理地址填错会让**所有**上游请求
+ * 立刻失败，而失焦即提交意味着输到一半切走焦点就会生效。所以这里要求显式「应用」，
+ * 并且做基本的协议校验。
+ *
+ * 按凭据分配的代理池仍在凭据页的「IP 代理池管理」里 —— 那是每凭据的绑定关系，
+ * 属于凭据数据而非全局配置。
+ */
+const PROXY_SCHEMES = ['http://', 'https://', 'socks5://', 'socks5h://']
+
+export function NetworkSection() {
+  const { data, isLoading } = useGlobalProxy()
+  const { mutate } = useSetGlobalProxy()
+  const saver = useFieldSaver(mutate, reportSaveError)
+  const isPending = saver.isSaving('proxy')
+  const saved = saver.isSaved('proxy')
+  const current = data?.proxyUrl ?? null
+  const [draft, setDraft] = useState('')
+
+  useEffect(() => {
+    setDraft(current ?? '')
+  }, [current])
+
+  const apply = () => {
+    const url = draft.trim()
+    if (!url) {
+      toast.error('代理地址不能为空。要停用请点「清除」。')
+      return
+    }
+    if (!PROXY_SCHEMES.some((s) => url.toLowerCase().startsWith(s))) {
+      toast.error(`代理地址需以 ${PROXY_SCHEMES.join(' / ')} 开头`)
+      return
+    }
+    if (url === current) return
+    saver.save('proxy', { proxyUrl: url })
+  }
+
+  const clear = () => {
+    saver.save('proxy', { proxyUrl: null })
+  }
+
+  return (
+    <SettingGroup
+      title="全局出站代理"
+      description="所有上游请求默认走这个代理；未绑定专属代理的凭据都受它影响"
+    >
+      <SettingRow
+        label="代理地址"
+        hint={
+          current
+            ? `当前生效：${maskProxyUrl(current)}`
+            : '未配置，直连上游。支持 http / https / socks5，可带 user:pass 认证'
+        }
+        pending={isPending}
+        saved={saved}
+      >
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') apply()
+              if (e.key === 'Escape') setDraft(current ?? '')
+            }}
+            placeholder="socks5://user:pass@host:1080"
+            disabled={isLoading || isPending}
+            spellCheck={false}
+            autoComplete="off"
+            className="console-num h-8 w-[min(20rem,60vw)] text-[12.5px]"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={apply}
+            disabled={isLoading || isPending || !draft.trim() || draft.trim() === current}
+          >
+            应用
+          </Button>
+          {current && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={clear}
+              disabled={isPending}
+              title="停用全局代理，恢复直连"
+            >
+              清除
+            </Button>
+          )}
+        </div>
+      </SettingRow>
+    </SettingGroup>
+  )
+}

--- a/admin-ui/src/components/settings/network-section.tsx
+++ b/admin-ui/src/components/settings/network-section.tsx
@@ -14,12 +14,8 @@ import { reportSaveError } from '@/components/settings/report-error'
 /**
  * 网络分区：全局出站代理。
  *
- * 这一项是即时保存范式里唯一的例外，理由具体：代理地址填错会让**所有**上游请求
- * 立刻失败，而失焦即提交意味着输到一半切走焦点就会生效。所以这里要求显式「应用」，
- * 并且做基本的协议校验。
- *
- * 按凭据分配的代理池仍在凭据页的「IP 代理池管理」里 —— 那是每凭据的绑定关系，
- * 属于凭据数据而非全局配置。
+ * 代理地址填错会让**所有**上游请求立刻失败，所以要求显式「应用」按钮，
+ * 并对 URL 做基本协议校验。
  */
 const PROXY_SCHEMES = ['http://', 'https://', 'socks5://', 'socks5h://']
 
@@ -29,15 +25,33 @@ export function NetworkSection() {
   const saver = useFieldSaver(mutate, reportSaveError)
   const isPending = saver.isSaving('proxy')
   const saved = saver.isSaved('proxy')
-  const current = data?.proxyUrl ?? null
-  const [draft, setDraft] = useState('')
+
+  const currentUrl = data?.proxyUrl ?? null
+  const currentUsername = data?.proxyUsername ?? null
+  const currentPassword = data?.proxyPassword ?? null
+
+  const [draftUrl, setDraftUrl] = useState('')
+  const [draftUsername, setDraftUsername] = useState('')
+  const [draftPassword, setDraftPassword] = useState('')
 
   useEffect(() => {
-    setDraft(current ?? '')
-  }, [current])
+    setDraftUrl(currentUrl ?? '')
+    setDraftUsername(currentUsername ?? '')
+    setDraftPassword(currentPassword ?? '')
+  }, [currentUrl, currentUsername, currentPassword])
+
+  const buildPayload = () => {
+    const url = draftUrl.trim() || null
+    if (!url) return null
+    return {
+      proxyUrl: url,
+      proxyUsername: draftUsername.trim() || null,
+      proxyPassword: draftPassword || null,
+    }
+  }
 
   const apply = () => {
-    const url = draft.trim()
+    const url = draftUrl.trim()
     if (!url) {
       toast.error('代理地址不能为空。要停用请点「清除」。')
       return
@@ -46,38 +60,41 @@ export function NetworkSection() {
       toast.error(`代理地址需以 ${PROXY_SCHEMES.join(' / ')} 开头`)
       return
     }
-    if (url === current) return
-    saver.save('proxy', { proxyUrl: url })
+    const payload = buildPayload()
+    if (!payload) return
+    saver.save('proxy', payload)
   }
 
   const clear = () => {
+    setDraftUrl('')
+    setDraftUsername('')
+    setDraftPassword('')
     saver.save('proxy', { proxyUrl: null })
   }
+
+  const hint = currentUrl
+    ? `当前生效：${maskProxyUrl(currentUrl)}${currentUsername ? ` (${currentUsername})` : ''}`
+    : '未配置，直连上游。支持 http / https / socks5，可填写认证凭据'
 
   return (
     <SettingGroup
       title="全局出站代理"
       description="所有上游请求默认走这个代理；未绑定专属代理的凭据都受它影响"
     >
-      <SettingRow
-        label="代理地址"
-        hint={
-          current
-            ? `当前生效：${maskProxyUrl(current)}`
-            : '未配置，直连上游。支持 http / https / socks5，可带 user:pass 认证'
-        }
-        pending={isPending}
-        saved={saved}
-      >
+      <SettingRow label="代理地址" hint={hint} pending={isPending} saved={saved}>
         <div className="flex flex-wrap items-center gap-1.5">
           <Input
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
+            value={draftUrl}
+            onChange={(e) => setDraftUrl(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') apply()
-              if (e.key === 'Escape') setDraft(current ?? '')
+              if (e.key === 'Escape') {
+                setDraftUrl(currentUrl ?? '')
+                setDraftUsername(currentUsername ?? '')
+                setDraftPassword(currentPassword ?? '')
+              }
             }}
-            placeholder="socks5://user:pass@host:1080"
+            placeholder="socks5://host:1080"
             disabled={isLoading || isPending}
             spellCheck={false}
             autoComplete="off"
@@ -87,11 +104,11 @@ export function NetworkSection() {
             size="sm"
             variant="outline"
             onClick={apply}
-            disabled={isLoading || isPending || !draft.trim() || draft.trim() === current}
+            disabled={isLoading || isPending || !draftUrl.trim()}
           >
             应用
           </Button>
-          {current && (
+          {currentUrl && (
             <Button
               size="sm"
               variant="ghost"
@@ -104,6 +121,50 @@ export function NetworkSection() {
           )}
         </div>
       </SettingRow>
+
+      {(currentUrl || draftUrl.trim()) && (
+        <>
+          <SettingRow
+            label="认证用户名"
+            hint="选填，代理要求 Basic Auth 时填写"
+            pending={isPending}
+            saved={saved}
+          >
+            <Input
+              value={draftUsername}
+              onChange={(e) => setDraftUsername(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') setDraftUsername(currentUsername ?? '')
+              }}
+              placeholder="留空则不认证"
+              disabled={isLoading || isPending}
+              spellCheck={false}
+              autoComplete="off"
+              className="console-num h-8 w-[min(16rem,50vw)] text-[12.5px]"
+            />
+          </SettingRow>
+          <SettingRow
+            label="认证密码"
+            hint="选填，与用户名配合使用"
+            pending={isPending}
+            saved={saved}
+          >
+            <Input
+              type="password"
+              value={draftPassword}
+              onChange={(e) => setDraftPassword(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') setDraftPassword(currentPassword ?? '')
+              }}
+              placeholder="留空则不认证"
+              disabled={isLoading || isPending}
+              spellCheck={false}
+              autoComplete="new-password"
+              className="console-num h-8 w-[min(16rem,50vw)] text-[12.5px]"
+            />
+          </SettingRow>
+        </>
+      )}
     </SettingGroup>
   )
 }

--- a/admin-ui/src/components/settings/network-section.tsx
+++ b/admin-ui/src/components/settings/network-section.tsx
@@ -17,7 +17,14 @@ import { reportSaveError } from '@/components/settings/report-error'
  * 代理地址填错会让**所有**上游请求立刻失败，所以要求显式「应用」按钮，
  * 并对 URL 做基本协议校验。
  */
-const PROXY_SCHEMES = ['http://', 'https://', 'socks5://', 'socks5h://']
+const PROXY_SCHEMES = [
+  'http://',
+  'https://',
+  'socks4://',
+  'socks4a://',
+  'socks5://',
+  'socks5h://',
+]
 
 export function NetworkSection() {
   const { data, isLoading } = useGlobalProxy()
@@ -28,7 +35,7 @@ export function NetworkSection() {
 
   const currentUrl = data?.proxyUrl ?? null
   const currentUsername = data?.proxyUsername ?? null
-  const currentPassword = data?.proxyPassword ?? null
+  const currentPasswordSet = data?.proxyPasswordSet ?? false
 
   const [draftUrl, setDraftUrl] = useState('')
   const [draftUsername, setDraftUsername] = useState('')
@@ -37,8 +44,8 @@ export function NetworkSection() {
   useEffect(() => {
     setDraftUrl(currentUrl ?? '')
     setDraftUsername(currentUsername ?? '')
-    setDraftPassword(currentPassword ?? '')
-  }, [currentUrl, currentUsername, currentPassword])
+    setDraftPassword('')
+  }, [currentUrl, currentUsername, currentPasswordSet])
 
   const buildPayload = () => {
     const url = draftUrl.trim() || null
@@ -46,7 +53,7 @@ export function NetworkSection() {
     return {
       proxyUrl: url,
       proxyUsername: draftUsername.trim() || null,
-      proxyPassword: draftPassword || null,
+      ...(draftPassword ? { proxyPassword: draftPassword } : {}),
     }
   }
 
@@ -74,7 +81,7 @@ export function NetworkSection() {
 
   const hint = currentUrl
     ? `当前生效：${maskProxyUrl(currentUrl)}${currentUsername ? ` (${currentUsername})` : ''}`
-    : '未配置，直连上游。支持 http / https / socks5，可填写认证凭据'
+    : '未配置，直连上游。支持 HTTP / HTTPS / SOCKS，可填写认证凭据'
 
   return (
     <SettingGroup
@@ -91,7 +98,7 @@ export function NetworkSection() {
               if (e.key === 'Escape') {
                 setDraftUrl(currentUrl ?? '')
                 setDraftUsername(currentUsername ?? '')
-                setDraftPassword(currentPassword ?? '')
+                setDraftPassword('')
               }
             }}
             placeholder="socks5://host:1080"
@@ -145,7 +152,7 @@ export function NetworkSection() {
           </SettingRow>
           <SettingRow
             label="认证密码"
-            hint="选填，与用户名配合使用"
+            hint={currentPasswordSet ? '已配置密码；留空保存时保留现有密码' : '选填，与用户名配合使用'}
             pending={isPending}
             saved={saved}
           >
@@ -154,14 +161,32 @@ export function NetworkSection() {
               value={draftPassword}
               onChange={(e) => setDraftPassword(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Escape') setDraftPassword(currentPassword ?? '')
+                if (e.key === 'Escape') setDraftPassword('')
               }}
-              placeholder="留空则不认证"
+              placeholder={currentPasswordSet ? '已配置，留空则保留' : '留空则不认证'}
               disabled={isLoading || isPending}
               spellCheck={false}
               autoComplete="new-password"
               className="console-num h-8 w-[min(16rem,50vw)] text-[12.5px]"
             />
+            {currentPasswordSet && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setDraftPassword('')
+                  saver.save('proxy', {
+                    proxyUrl: currentUrl,
+                    proxyUsername: currentUsername,
+                    proxyPassword: null,
+                  })
+                }}
+                disabled={isLoading || isPending}
+                title="清除已保存的代理密码"
+              >
+                清除密码
+              </Button>
+            )}
           </SettingRow>
         </>
       )}

--- a/admin-ui/src/components/settings/report-error.ts
+++ b/admin-ui/src/components/settings/report-error.ts
@@ -1,0 +1,16 @@
+import { toast } from 'sonner'
+import { extractErrorMessage } from '@/lib/utils'
+
+/**
+ * 各设置分区共用的保存失败提示。
+ *
+ * 只报错，不报成功 —— 成功由行内那个勾表示（见 console/setting-row.tsx）。
+ * 每改一个开关弹一次"已保存"的话，连着调三个参数就是三个 toast 叠在屏幕上，
+ * 而它们说的都是用户刚刚亲手做过、且行内已经显示了的事。
+ *
+ * 单独成文件而不是放在 settings-page.tsx 里：各 section 都要用它，
+ * 从 settings-page 反向 import 会与 settings-page → section 形成循环依赖。
+ */
+export function reportSaveError(err: unknown) {
+  toast.error('保存失败：' + extractErrorMessage(err))
+}

--- a/admin-ui/src/components/settings/security-section.tsx
+++ b/admin-ui/src/components/settings/security-section.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Eye, EyeOff, Copy, Wand2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { SettingGroup, SettingRow } from '@/components/console/setting-row'
+import { storage } from '@/lib/storage'
+import { updateAdminKey } from '@/api/credentials'
+import { extractErrorMessage, generateApiKey } from '@/lib/utils'
+import { useConfirm } from '@/components/ui/confirm-dialog'
+
+/**
+ * 安全分区：管理面板的登录密钥。
+ *
+ * 这里刻意**不用**即时保存。轮换登录密钥不是调参数，是一次性的凭据替换：旧密钥
+ * 立即失效，正在用它调用 /v1/messages 的下游会全部 401。所以流程反过来 ——
+ * 先生成、先复制、二次确认，最后才提交。
+ *
+ * 提交成功后本地存储自动换成新密钥，当前会话不会被踢出登录。
+ */
+export function SecuritySection() {
+  const confirm = useConfirm()
+  const [draft, setDraft] = useState('')
+  const [plain, setPlain] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const copy = async () => {
+    if (!draft.trim()) {
+      toast.error('先生成或输入密钥再复制')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(draft)
+      setCopied(true)
+      toast.success('已复制到剪贴板')
+    } catch {
+      toast.error('复制失败，请手动选中文本')
+    }
+  }
+
+  const submit = async () => {
+    const key = draft.trim()
+    if (!key) return
+    if (!copied) {
+      const ok = await confirm({
+        title: '还没复制新密钥',
+        description:
+          '旧密钥提交后立即失效。新密钥只在这里显示一次，建议先复制保存再继续。',
+        confirmText: '仍然继续',
+      })
+      if (!ok) return
+    }
+    const ok = await confirm({
+      title: '替换登录密钥？',
+      description:
+        '旧密钥立即失效，使用旧密钥调用 API 的下游都需要换成新密钥。当前浏览器会自动切到新密钥，不会掉线。',
+      confirmText: '替换',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSubmitting(true)
+    try {
+      await updateAdminKey({ newKey: key })
+      storage.setApiKey(key)
+      toast.success('登录密钥已替换，本地已切到新密钥')
+      setDraft('')
+      setPlain(false)
+      setCopied(false)
+    } catch (err) {
+      toast.error('替换失败：' + extractErrorMessage(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <SettingGroup
+      title="登录密钥"
+      description="用于登录本管理面板，同时是 API 的主密钥（config.json 的 apiKey）"
+    >
+      <SettingRow
+        label="替换密钥"
+        hint="旧密钥立即失效。下游客户端需要同步换成新密钥才能继续调用"
+      >
+        <div className="flex flex-wrap items-center gap-1.5">
+          <div className="relative">
+            <Input
+              type={plain ? 'text' : 'password'}
+              value={draft}
+              onChange={(e) => {
+                setDraft(e.target.value)
+                setCopied(false)
+              }}
+              placeholder="输入或生成新密钥"
+              disabled={submitting}
+              spellCheck={false}
+              autoComplete="new-password"
+              className="console-num h-8 w-[min(18rem,55vw)] pr-9 text-[12.5px]"
+            />
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              onClick={() => setPlain((v) => !v)}
+              title={plain ? '隐藏' : '显示'}
+              className="absolute right-0.5 top-0.5 h-7 w-7"
+            >
+              {plain ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            </Button>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={submitting}
+            onClick={() => {
+              setDraft(generateApiKey('sk-admin-'))
+              setPlain(true)
+              setCopied(false)
+            }}
+            title="生成一个 32 位随机密钥"
+          >
+            <Wand2 className="h-3.5 w-3.5" />
+            生成
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={copy}
+            disabled={submitting || !draft.trim()}
+          >
+            <Copy className="h-3.5 w-3.5" />
+            {copied ? '已复制' : '复制'}
+          </Button>
+          <Button
+            size="sm"
+            onClick={submit}
+            disabled={submitting || !draft.trim()}
+          >
+            {submitting ? '替换中…' : '替换'}
+          </Button>
+        </div>
+      </SettingRow>
+    </SettingGroup>
+  )
+}

--- a/admin-ui/src/components/settings/system-section.tsx
+++ b/admin-ui/src/components/settings/system-section.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { UploadCloud, Eye, EyeOff } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  SettingGroup,
+  SettingRow,
+  SettingSwitch,
+  useFieldSaver,
+} from '@/components/console/setting-row'
+import { useUpdateConfig, useSetUpdateConfig } from '@/hooks/use-credentials'
+import { useUpdateCheck } from '@/hooks/use-update-check'
+import { ImageUpdateDialog } from '@/components/image-update-dialog'
+import { reportSaveError } from '@/components/settings/report-error'
+
+/**
+ * 系统分区：镜像在线更新的**配置**。
+ *
+ * 与更新弹窗的分工：这里管"什么时候自动更新、用哪个 token 查版本"，弹窗管
+ * "现在检查 / 拉取 / 应用 / 回退"这套动作流程。两边读同一个 ['update-config']
+ * query key，改任何一处另一处立即跟上。
+ *
+ * 时间格式约定 HH:MM 24 小时制，按服务器本地时区执行。
+ */
+const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/
+
+export function SystemSection() {
+  const { data, isLoading } = useUpdateConfig()
+  const { mutate } = useSetUpdateConfig()
+  const saver = useFieldSaver(mutate, reportSaveError)
+  const { data: check } = useUpdateCheck()
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const autoApply = data?.autoApply ?? false
+
+  return (
+    <>
+      <div className="space-y-6">
+        <SettingGroup
+          title="版本"
+          description="镜像更新的执行入口在更新面板里；这里只配自动化策略"
+        >
+          <SettingRow
+            label="当前版本"
+            hint={
+              check?.hasUpdate
+                ? `有新版本 v${check.latestVersion} 可用`
+                : '已是最新版本'
+            }
+          >
+            <div className="flex items-center gap-2">
+              <span className="console-num text-[13px]">
+                v{check?.currentVersion ?? '—'}
+              </span>
+              <Button size="sm" variant="outline" onClick={() => setDialogOpen(true)}>
+                <UploadCloud className="h-3.5 w-3.5" />
+                更新面板
+              </Button>
+            </div>
+          </SettingRow>
+        </SettingGroup>
+
+        <SettingGroup title="无人值守更新">
+          <SettingSwitch
+            label="自动更新"
+            hint={
+              autoApply
+                ? '每天到点检查新版本，有则自动拉取并重启容器'
+                : '仅提示新版本，更新需要手动触发'
+            }
+            checked={autoApply}
+            onChange={(next) => saver.save('autoApply', { autoApply: next })}
+            pending={saver.isSaving('autoApply')}
+            saved={saver.isSaved('autoApply')}
+            disabled={isLoading}
+          />
+          <AutoApplyTimeRow
+            value={data?.autoApplyTime ?? '03:00'}
+            onCommit={(t) => saver.save('autoApplyTime', { autoApplyTime: t })}
+            pending={saver.isSaving('autoApplyTime')}
+            saved={saver.isSaved('autoApplyTime')}
+            disabled={isLoading || !autoApply}
+          />
+        </SettingGroup>
+
+        <SettingGroup
+          title="GitHub Token"
+          description="用于查询版本，避免匿名调用触发 GitHub API 限流（每小时 60 次）"
+        >
+          <GithubTokenRow
+            tokenSet={data?.githubTokenSet ?? false}
+            onCommit={(token) => saver.save('githubToken', { githubToken: token })}
+            pending={saver.isSaving('githubToken')}
+            saved={saver.isSaved('githubToken')}
+            disabled={isLoading}
+          />
+        </SettingGroup>
+      </div>
+
+      <ImageUpdateDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </>
+  )
+}
+
+function AutoApplyTimeRow({
+  value,
+  onCommit,
+  pending,
+  saved,
+  disabled,
+}: {
+  value: string
+  onCommit: (next: string) => void
+  pending?: boolean
+  saved?: boolean
+  disabled?: boolean
+}) {
+  const [draft, setDraft] = useState(value)
+
+  useEffect(() => {
+    setDraft(value)
+  }, [value])
+
+  const commit = () => {
+    const t = draft.trim()
+    if (!TIME_PATTERN.test(t)) {
+      toast.error('时间格式为 HH:MM（24 小时制）')
+      setDraft(value)
+      return
+    }
+    if (t !== value) onCommit(t)
+  }
+
+  return (
+    <SettingRow
+      label="触发时间"
+      hint="按服务器本地时区。建议选业务低谷，更新会重启容器造成短暂中断"
+      pending={pending}
+      saved={saved}
+      disabled={disabled}
+    >
+      <Input
+        type="time"
+        value={draft}
+        disabled={disabled || pending}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.currentTarget.blur()
+          if (e.key === 'Escape') {
+            setDraft(value)
+            e.currentTarget.blur()
+          }
+        }}
+        className="console-num h-8 w-28 text-[13px]"
+      />
+    </SettingRow>
+  )
+}
+
+/**
+ * Token 行：写入型密文字段，只回布尔不回明文，所以走显式「保存」。
+ * 这是即时保存范式的第二个例外，与代理地址同理 —— 密文没有"当前值"可回显，
+ * 失焦提交会把用户输了一半的 token 存进去。
+ */
+function GithubTokenRow({
+  tokenSet,
+  onCommit,
+  pending,
+  saved,
+  disabled,
+}: {
+  tokenSet: boolean
+  onCommit: (token: string) => void
+  pending?: boolean
+  saved?: boolean
+  disabled?: boolean
+}) {
+  const [draft, setDraft] = useState('')
+  const [plain, setPlain] = useState(false)
+
+  return (
+    <SettingRow
+      label="Personal Access Token"
+      hint={
+        tokenSet
+          ? '已配置。重新输入可替换，留空点「清除」可移除'
+          : '未配置，当前以匿名身份查询版本'
+      }
+      pending={pending}
+      saved={saved}
+    >
+      <div className="flex flex-wrap items-center gap-1.5">
+        <div className="relative">
+          <Input
+            type={plain ? 'text' : 'password'}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={tokenSet ? '输入新 token 以替换' : 'ghp_…'}
+            disabled={disabled || pending}
+            spellCheck={false}
+            autoComplete="off"
+            className="console-num h-8 w-[min(16rem,50vw)] pr-9 text-[12.5px]"
+          />
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={() => setPlain((v) => !v)}
+            title={plain ? '隐藏' : '显示'}
+            className="absolute right-0.5 top-0.5 h-7 w-7"
+          >
+            {plain ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+          </Button>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={disabled || pending || !draft.trim()}
+          onClick={() => {
+            onCommit(draft.trim())
+            setDraft('')
+            setPlain(false)
+          }}
+        >
+          保存
+        </Button>
+        {tokenSet && (
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={() => {
+              onCommit('')
+              setDraft('')
+            }}
+            title="移除已保存的 token，恢复匿名查询"
+          >
+            清除
+          </Button>
+        )}
+      </div>
+    </SettingRow>
+  )
+}

--- a/admin-ui/src/components/topbar-tools.tsx
+++ b/admin-ui/src/components/topbar-tools.tsx
@@ -1,58 +1,80 @@
-import { forwardRef, useEffect, useState, type ComponentPropsWithoutRef } from 'react'
+import { useState } from 'react'
 import {
-  Activity, RefreshCw, UploadCloud, Settings, Key, Wand2, Eye, EyeOff, Copy,
-  MoreHorizontal, ShieldAlert, ShieldCheck, Boxes, HeartPulse, HeartCrack,
-  Gauge,
+  Activity,
+  RefreshCw,
+  UploadCloud,
+  MoreHorizontal,
+  ShieldAlert,
+  ShieldCheck,
+  Boxes,
+  HeartPulse,
+  HeartCrack,
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { storage } from '@/lib/storage'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Switch } from '@/components/ui/switch'
 import {
-  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription,
-} from '@/components/ui/dialog'
-import {
-  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
-  DropdownMenuItem, DropdownMenuLabel,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu'
 import {
-  useLoadBalancingMode, useSetLoadBalancingMode,
-  useAccountThrottleConfig, useSetAccountThrottleConfig,
-  useAccountRpmLimitConfig, useSetAccountRpmLimitConfig,
-  useSelfHealConfig, useSetSelfHealConfig,
+  useLoadBalancingMode,
+  useSetLoadBalancingMode,
+  useAccountThrottleConfig,
+  useSetAccountThrottleConfig,
+  useSelfHealConfig,
+  useSetSelfHealConfig,
 } from '@/hooks/use-credentials'
 import { useUpdateCheck } from '@/hooks/use-update-check'
-import { updateAdminKey, type SelfHealConfigPatch } from '@/api/credentials'
-import { extractErrorMessage, generateApiKey } from '@/lib/utils'
+import { extractErrorMessage } from '@/lib/utils'
 import { ImageUpdateDialog } from '@/components/image-update-dialog'
 import { AvailableModelsDialog } from '@/components/available-models-dialog'
 
 /**
- * 顶栏右侧通用工具栏：负载均衡切换、可用模型、刷新、在线更新、设置（Key 管理）。
+ * 顶栏工具区：三个调度开关 + 三个动作按钮。
  *
- * 与原 Dashboard 中的工具按钮等价，但全局 Tab 都可访问。刷新按钮会失效
- * 凭据/客户端 Key/统计三类查询，覆盖三个 Tab 的主要数据源。
+ * 这里此前塞了完整的配置面板 —— 冷却时长的 5 个预设按钮、自定义分钟输入、自愈连续
+ * 上限输入、登录密钥表单，还各写了 compact / full 两套。下拉菜单里放数字输入框本来
+ * 就不是它该干的事：菜单是"选一个动作"的容器，不是表单容器。
+ *
+ * 现在的分工：**顶栏只放一次点击就能完成的开关**（这三个是运维高频动作，不该退化成
+ * "进设置页找"），所有参数调整归「设置」Tab。compact 与 full 因此收敛成同一份
+ * 开关定义，窄屏只是把它们折进一个菜单。
  */
 interface TopbarToolsProps {
   compact?: boolean
 }
 
+/** 一个开关的完整描述，compact / full 两种排布共用 */
+interface ToggleSpec {
+  key: string
+  /** 当前是否开启 */
+  on: boolean
+  busy: boolean
+  /** full 模式的按钮文案 */
+  label: string
+  /** compact 模式的菜单项文案（说明这次点击会做什么） */
+  menuLabel: string
+  title: string
+  icon: React.ReactNode
+  onToggle: () => void
+}
+
 export function TopbarTools({ compact = false }: TopbarToolsProps) {
   const queryClient = useQueryClient()
-  const { data: loadBalancingData, isLoading: isLoadingMode } = useLoadBalancingMode()
-  const { mutate: setLoadBalancingMode, isPending: isSettingMode } = useSetLoadBalancingMode()
-  const { data: throttleConfig, isLoading: isLoadingThrottle } = useAccountThrottleConfig()
-  const { mutate: setThrottleConfig, isPending: isSettingThrottle } = useSetAccountThrottleConfig()
+  const { data: lbData, isLoading: lbLoading } = useLoadBalancingMode()
+  const { mutate: setLb, isPending: lbSaving } = useSetLoadBalancingMode()
+  const { data: throttle, isLoading: thLoading } = useAccountThrottleConfig()
+  const { mutate: setThrottle, isPending: thSaving } = useSetAccountThrottleConfig()
+  const { data: selfHeal, isLoading: shLoading } = useSelfHealConfig()
+  const { mutate: setSelfHeal, isPending: shSaving } = useSetSelfHealConfig()
   const { data: updateCheck } = useUpdateCheck()
 
   const [imageUpdateOpen, setImageUpdateOpen] = useState(false)
-  const [modelsDialogOpen, setModelsDialogOpen] = useState(false)
-  const [keyDialogOpen, setKeyDialogOpen] = useState(false)
-  const [newKey, setNewKey] = useState('')
-  const [showPlain, setShowPlain] = useState(false)
-  const [updating, setUpdating] = useState(false)
+  const [modelsOpen, setModelsOpen] = useState(false)
 
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['credentials'] })
@@ -63,340 +85,207 @@ export function TopbarTools({ compact = false }: TopbarToolsProps) {
     toast.success('已刷新')
   }
 
-  const handleToggleLoadBalancing = () => {
-    const cur = loadBalancingData?.mode || 'priority'
-    const next = cur === 'priority' ? 'balanced' : 'priority'
-    setLoadBalancingMode(next, {
-      onSuccess: () => toast.success(`已切换到${next === 'priority' ? '优先级模式' : '均衡负载模式'}`),
-      onError: (err) => toast.error(`切换失败: ${extractErrorMessage(err)}`),
-    })
-  }
+  const onError = (err: unknown) =>
+    toast.error('切换失败：' + extractErrorMessage(err))
 
-  const handleToggleFailover = () => {
-    const cur = throttleConfig?.failover ?? true
-    const next = !cur
-    setThrottleConfig({ failover: next }, {
-      onSuccess: () => toast.success(next ? '已开启账号级风控故障转移' : '已关闭账号级风控故障转移'),
-      onError: (err) => toast.error(`切换失败: ${extractErrorMessage(err)}`),
-    })
-  }
+  const balanced = lbData?.mode === 'balanced'
+  const failover = throttle?.failover ?? true
+  const healing = selfHeal?.enabled ?? true
+  const cooldownMin = Math.round((throttle?.cooldownSecs ?? 1800) / 60)
 
-  const openKeyDialog = () => {
-    setNewKey('')
-    setShowPlain(false)
-    setKeyDialogOpen(true)
-  }
-
-  const handleUpdateKey = async (e: React.FormEvent) => {
-    e.preventDefault()
-    const key = newKey.trim()
-    if (!key) {
-      toast.error('新登录API密钥不能为空')
-      return
-    }
-    setUpdating(true)
-    try {
-      await updateAdminKey({ newKey: key })
-      storage.setApiKey(key)
-      toast.success('登录API密钥已更新，已自动切换到新 Key')
-      setKeyDialogOpen(false)
-      setNewKey('')
-    } catch (err) {
-      toast.error(`更新失败: ${extractErrorMessage(err)}`)
-    } finally {
-      setUpdating(false)
-    }
-  }
-
-  const controls = {
-    handleRefresh,
-    handleToggleFailover,
-    handleToggleLoadBalancing,
-    isLoadingMode,
-    isLoadingThrottle,
-    isSettingMode,
-    isSettingThrottle,
-    loadBalancingMode: loadBalancingData?.mode,
-    openImageUpdate: () => setImageUpdateOpen(true),
-    openModels: () => setModelsDialogOpen(true),
-    openKeyDialog,
-    throttleConfig,
-    updateCheck,
-    updateCooldown: (secs: number) =>
-      setThrottleConfig({ cooldownSecs: secs }, {
-        onSuccess: () =>
-          toast.success(`冷却时长已设为 ${Math.round(secs / 60)} 分钟`),
-        onError: (err) => toast.error(`保存失败: ${extractErrorMessage(err)}`),
-      }),
-  }
+  const toggles: ToggleSpec[] = [
+    {
+      key: 'lb',
+      on: balanced,
+      busy: lbLoading || lbSaving,
+      label: lbLoading ? '加载中…' : balanced ? '均衡负载' : '按优先级',
+      menuLabel: balanced ? '切换到按优先级' : '切换到均衡负载',
+      title: balanced
+        ? '调度模式：均衡负载 —— 按用量动态摊平到整个池子'
+        : '调度模式：按优先级 —— 数字越小越先用，用完再换下一个',
+      icon: <Activity className="h-3.5 w-3.5" />,
+      onToggle: () =>
+        setLb(balanced ? 'priority' : 'balanced', {
+          onSuccess: () =>
+            toast.success(
+              balanced ? '已切换到按优先级调度' : '已切换到均衡负载',
+            ),
+          onError,
+        }),
+    },
+    {
+      key: 'failover',
+      on: failover,
+      busy: thLoading || thSaving,
+      label: thLoading ? '加载中…' : failover ? `故障转移 · ${cooldownMin}m` : '不切换',
+      menuLabel: failover ? '关闭故障转移' : '开启故障转移',
+      title: failover
+        ? `账号级风控故障转移：开启（冷却 ${cooldownMin} 分钟，可在设置页调整）`
+        : '账号级风控故障转移：关闭',
+      icon: failover ? (
+        <ShieldCheck className="h-3.5 w-3.5 text-emerald-600" />
+      ) : (
+        <ShieldAlert className="h-3.5 w-3.5 text-amber-500" />
+      ),
+      onToggle: () =>
+        setThrottle(
+          { failover: !failover },
+          {
+            onSuccess: () =>
+              toast.success(failover ? '已关闭故障转移' : '已开启故障转移'),
+            onError,
+          },
+        ),
+    },
+    {
+      key: 'selfheal',
+      on: healing,
+      busy: shLoading || shSaving,
+      label: shLoading ? '加载中…' : healing ? '自愈开' : '自愈关',
+      menuLabel: healing ? '关闭凭据自愈' : '开启凭据自愈',
+      title: healing
+        ? `凭据自愈：已启用（当前连续 ${selfHeal?.consecutiveRounds ?? 0} 轮，参数见设置页）`
+        : '凭据自愈：已关闭',
+      icon: healing ? (
+        <HeartPulse className="h-3.5 w-3.5 text-emerald-600" />
+      ) : (
+        <HeartCrack className="h-3.5 w-3.5 text-amber-500" />
+      ),
+      onToggle: () =>
+        setSelfHeal(
+          { enabled: !healing },
+          {
+            onSuccess: () =>
+              toast.success(healing ? '已关闭凭据自愈' : '已开启凭据自愈'),
+            onError,
+          },
+        ),
+    },
+  ]
 
   return (
     <>
-      {compact ? <CompactTools controls={controls} /> : <FullTools controls={controls} />}
+      {compact ? (
+        <CompactTools
+          toggles={toggles}
+          hasUpdate={!!updateCheck?.hasUpdate}
+          onRefresh={handleRefresh}
+          onOpenModels={() => setModelsOpen(true)}
+          onOpenImageUpdate={() => setImageUpdateOpen(true)}
+        />
+      ) : (
+        <FullTools
+          toggles={toggles}
+          updateCheck={updateCheck}
+          onRefresh={handleRefresh}
+          onOpenModels={() => setModelsOpen(true)}
+          onOpenImageUpdate={() => setImageUpdateOpen(true)}
+        />
+      )}
       <ImageUpdateDialog open={imageUpdateOpen} onOpenChange={setImageUpdateOpen} />
-      <AvailableModelsDialog
-        open={modelsDialogOpen}
-        onOpenChange={setModelsDialogOpen}
-      />
-
-      <Dialog
-        open={keyDialogOpen}
-        onOpenChange={(open) => { if (!updating) setKeyDialogOpen(open) }}
-      >
-        <DialogContent className="sm:max-w-sm">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Key className="h-4 w-4" />
-              修改登录API密钥
-            </DialogTitle>
-            <DialogDescription>
-              用于登录此管理面板。修改后将自动更新本地存储的 Key，无需重新登录。
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={handleUpdateKey} className="space-y-4 py-2">
-            <div className="relative">
-              <Input
-                type={showPlain ? 'text' : 'password'}
-                placeholder="输入或生成新的登录API密钥"
-                value={newKey}
-                onChange={(e) => setNewKey(e.target.value)}
-                disabled={updating}
-                autoFocus
-                className="pr-20 font-mono text-[13px]"
-              />
-              <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-1.5">
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className="pointer-events-auto h-7 w-7"
-                  onClick={() => setShowPlain((v) => !v)}
-                  disabled={updating}
-                  title={showPlain ? '隐藏' : '显示'}
-                >
-                  {showPlain ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-                </Button>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className="pointer-events-auto h-7 w-7"
-                  onClick={async () => {
-                    if (!newKey.trim()) {
-                      toast.error('请先输入或生成 Key 再复制')
-                      return
-                    }
-                    try {
-                      await navigator.clipboard.writeText(newKey)
-                      toast.success('已复制到剪贴板')
-                    } catch {
-                      toast.error('复制失败，请手动选择文本')
-                    }
-                  }}
-                  disabled={updating}
-                  title="复制"
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={() => {
-                  const key = generateApiKey('sk-admin-')
-                  setNewKey(key)
-                  setShowPlain(true)
-                }}
-                disabled={updating}
-              >
-                <Wand2 className="h-3.5 w-3.5" />生成随机 Key
-              </Button>
-              <p className="text-[11px] text-muted-foreground">
-                建议生成后立即复制保存，确认更新后即生效。
-              </p>
-            </div>
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setKeyDialogOpen(false)} disabled={updating}>
-                取消
-              </Button>
-              <Button type="submit" disabled={updating || !newKey.trim()}>
-                {updating ? '更新中…' : '确认更新'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <AvailableModelsDialog open={modelsOpen} onOpenChange={setModelsOpen} />
     </>
   )
 }
 
-interface ToolControls {
-  handleRefresh: () => void
-  handleToggleFailover: () => void
-  handleToggleLoadBalancing: () => void
-  isLoadingMode: boolean
-  isLoadingThrottle: boolean
-  isSettingMode: boolean
-  isSettingThrottle: boolean
-  loadBalancingMode?: 'priority' | 'balanced'
-  openImageUpdate: () => void
-  openKeyDialog: () => void
-  openModels: () => void
-  throttleConfig?: { failover: boolean; cooldownSecs: number }
-  updateCheck?: { hasUpdate: boolean; latestVersion: string; currentVersion: string }
-  updateCooldown: (secs: number) => void
+interface ToolsProps {
+  toggles: ToggleSpec[]
+  onRefresh: () => void
+  onOpenModels: () => void
+  onOpenImageUpdate: () => void
 }
 
-function FullTools({ controls }: { controls: ToolControls }) {
+function FullTools({
+  toggles,
+  updateCheck,
+  onRefresh,
+  onOpenModels,
+  onOpenImageUpdate,
+}: ToolsProps & {
+  updateCheck?: { hasUpdate: boolean; latestVersion: string; currentVersion: string }
+}) {
   return (
     <>
-      <LoadBalancingButton controls={controls} />
-      <ThrottleConfigButton
-        config={controls.throttleConfig}
-        loading={controls.isLoadingThrottle}
-        saving={controls.isSettingThrottle}
-        onToggleFailover={controls.handleToggleFailover}
-        onChangeCooldown={controls.updateCooldown}
-      />
-      <SelfHealConfigButton />
-      <AccountRpmLimitButton />
-      <ModelsButton onOpen={controls.openModels} />
-      <RefreshButton onRefresh={controls.handleRefresh} />
-      <ImageUpdateButton controls={controls} />
-      <KeySettingsMenu onOpenKeyDialog={controls.openKeyDialog} />
+      {toggles.map((t) => (
+        <Button
+          key={t.key}
+          variant="outline"
+          size="sm"
+          onClick={t.onToggle}
+          disabled={t.busy}
+          title={t.title}
+        >
+          {t.icon}
+          <span className="hidden md:inline">{t.label}</span>
+        </Button>
+      ))}
+      <Button variant="ghost" size="icon" onClick={onOpenModels} title="可用模型">
+        <Boxes className="h-4 w-4" />
+      </Button>
+      <Button variant="ghost" size="icon" onClick={onRefresh} title="刷新数据">
+        <RefreshCw className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onOpenImageUpdate}
+        title={
+          updateCheck?.hasUpdate
+            ? `发现新版本 v${updateCheck.latestVersion}（当前 v${updateCheck.currentVersion}）`
+            : '镜像在线更新'
+        }
+        className="relative"
+      >
+        <UploadCloud className="h-4 w-4" />
+        {updateCheck?.hasUpdate && <UpdateDot />}
+      </Button>
     </>
   )
 }
 
-function CompactTools({ controls }: { controls: ToolControls }) {
-  const throttleProps = {
-    config: controls.throttleConfig,
-    loading: controls.isLoadingThrottle,
-    saving: controls.isSettingThrottle,
-    onToggleFailover: controls.handleToggleFailover,
-    onChangeCooldown: controls.updateCooldown,
-  }
-
+function CompactTools({
+  toggles,
+  hasUpdate,
+  onRefresh,
+  onOpenModels,
+  onOpenImageUpdate,
+}: ToolsProps & { hasUpdate: boolean }) {
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" title="更多操作">
+        <Button variant="outline" size="icon" title="更多操作" className="relative">
           <MoreHorizontal className="h-4 w-4" />
+          {hasUpdate && <UpdateDot />}
         </Button>
       </DropdownMenuTrigger>
+      {/* 窄屏兜底：菜单项随调度开关增加时不撑出视口，超出即在菜单内滚动 */}
       <DropdownMenuContent
         align="end"
-        className="max-h-[calc(100dvh-4.5rem)] w-72 max-w-[calc(100dvw-1rem)] overflow-x-hidden overflow-y-auto overscroll-contain"
+        className="max-h-[calc(100dvh-4.5rem)] w-56 max-w-[calc(100dvw-1rem)] overflow-x-hidden overflow-y-auto overscroll-contain"
       >
-        <DropdownMenuLabel>系统操作</DropdownMenuLabel>
-        <DropdownMenuItem
-          disabled={controls.isLoadingMode || controls.isSettingMode}
-          onSelect={controls.handleToggleLoadBalancing}
-        >
-          <Activity />
-          {controls.isLoadingMode
-            ? '负载均衡加载中'
-            : controls.loadBalancingMode === 'priority'
-              ? '切换到均衡负载'
-              : '切换到优先级'}
+        <DropdownMenuLabel>调度</DropdownMenuLabel>
+        {toggles.map((t) => (
+          <DropdownMenuItem key={t.key} disabled={t.busy} onSelect={t.onToggle}>
+            {t.icon}
+            {t.menuLabel}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuLabel>操作</DropdownMenuLabel>
+        <DropdownMenuItem onSelect={onRefresh}>
+          <RefreshCw />
+          刷新数据
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={controls.handleRefresh}>
-          <RefreshCw />刷新数据
+        <DropdownMenuItem onSelect={onOpenModels}>
+          <Boxes />
+          可用模型
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={controls.openModels}>
-          <Boxes />可用模型
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={controls.openImageUpdate}>
-          <UploadCloud />镜像在线更新
-        </DropdownMenuItem>
-        <ThrottleCompactItems {...throttleProps} />
-        <SelfHealCompactItems />
-        <AccountRpmLimitCompactItems />
-        <DropdownMenuLabel>密钥管理</DropdownMenuLabel>
-        <DropdownMenuItem onSelect={controls.openKeyDialog}>
-          <Key />修改登录API密钥（管理面板登录）
+        <DropdownMenuItem onSelect={onOpenImageUpdate}>
+          <UploadCloud />
+          镜像在线更新
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )
-}
-
-function LoadBalancingButton({ controls }: { controls: ToolControls }) {
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={controls.handleToggleLoadBalancing}
-      disabled={controls.isLoadingMode || controls.isSettingMode}
-      title="切换负载均衡模式"
-    >
-      <Activity className="h-3.5 w-3.5" />
-      <span className="hidden md:inline">
-        {controls.isLoadingMode
-          ? '加载中…'
-          : controls.loadBalancingMode === 'priority'
-            ? '优先级'
-            : '均衡负载'}
-      </span>
-    </Button>
-  )
-}
-
-function ModelsButton({ onOpen }: { onOpen: () => void }) {
-  return (
-    <Button variant="ghost" size="icon" onClick={onOpen} title="可用模型">
-      <Boxes className="h-4 w-4" />
-    </Button>
-  )
-}
-
-function RefreshButton({ onRefresh }: { onRefresh: () => void }) {
-  return (
-    <Button variant="ghost" size="icon" onClick={onRefresh} title="刷新">
-      <RefreshCw className="h-4 w-4" />
-    </Button>
-  )
-}
-
-function ImageUpdateButton({ controls }: { controls: ToolControls }) {
-  return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={controls.openImageUpdate}
-      title={imageUpdateTitle(controls.updateCheck)}
-      className="relative"
-    >
-      <UploadCloud className="h-4 w-4" />
-      {controls.updateCheck?.hasUpdate && <UpdateDot />}
-    </Button>
-  )
-}
-
-function KeySettingsMenu({ onOpenKeyDialog }: { onOpenKeyDialog: () => void }) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" title="设置">
-          <Settings className="h-4 w-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuLabel>密钥管理</DropdownMenuLabel>
-        <DropdownMenuItem onSelect={onOpenKeyDialog}>
-          <Key />修改登录API密钥（管理面板登录）
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
-}
-
-function imageUpdateTitle(updateCheck: ToolControls['updateCheck']) {
-  if (!updateCheck?.hasUpdate) return '镜像在线更新'
-  return `发现新版本 v${updateCheck.latestVersion}（当前 v${updateCheck.currentVersion}）`
 }
 
 function UpdateDot() {
@@ -406,720 +295,4 @@ function UpdateDot() {
       <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
     </span>
   )
-}
-
-interface ThrottleConfigButtonProps {
-  config?: { failover: boolean; cooldownSecs: number }
-  loading: boolean
-  saving: boolean
-  onToggleFailover: () => void
-  onChangeCooldown: (secs: number) => void
-}
-
-interface ThrottleState {
-  cooldownMin: number
-  cooldownSecs: number
-  failover: boolean
-}
-
-interface CustomCooldownFormProps {
-  cooldownMin: number
-  customMin: string
-  disabled: boolean
-  onCustomMinChange: (value: string) => void
-  onSubmit: (e: React.FormEvent) => void
-}
-
-interface ThrottleTriggerProps extends ComponentPropsWithoutRef<typeof Button> {
-  loading: boolean
-  saving: boolean
-  state: ThrottleState
-}
-
-const COOLDOWN_PRESETS = [
-  { label: '5 分钟', secs: 5 * 60 },
-  { label: '15 分钟', secs: 15 * 60 },
-  { label: '30 分钟', secs: 30 * 60 },
-  { label: '1 小时', secs: 60 * 60 },
-  { label: '2 小时', secs: 2 * 60 * 60 },
-]
-
-const DEFAULT_COOLDOWN_SECS = 30 * 60
-const SECONDS_PER_MINUTE = 60
-const MIN_CUSTOM_COOLDOWN_MINUTES = 1
-const MAX_CUSTOM_COOLDOWN_MINUTES = 1440
-
-/**
- * 故障转移开关 + 冷却时长设置（紧凑下拉）
- *
- * 主按钮文案显示当前状态；下拉里:
- * - 顶部一个 Switch 切换 failover
- * - 5 个预设时长 + 一个自定义输入（分钟）
- */
-function ThrottleConfigButton({
-  config, loading, saving, onToggleFailover, onChangeCooldown,
-}: ThrottleConfigButtonProps) {
-  const [open, setOpen] = useState(false)
-  const [customMin, setCustomMin] = useState('')
-  const state = readThrottleState(config)
-
-  useEffect(() => {
-    if (!open) setCustomMin('')
-  }, [open])
-
-  const submitCustom = (e: React.FormEvent) => {
-    e.preventDefault()
-    const min = parseInt(customMin, 10)
-    if (invalidCooldownMinutes(min)) {
-      toast.error('请输入 1-1440 之间的分钟数')
-      return
-    }
-    onChangeCooldown(min * SECONDS_PER_MINUTE)
-    setOpen(false)
-  }
-
-  return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <ThrottleTrigger loading={loading} saving={saving} state={state} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-64">
-        <ThrottleStatusPanel
-          saving={saving}
-          state={state}
-          onToggleFailover={onToggleFailover}
-        />
-        <ThrottleCooldownPanel
-          customMin={customMin}
-          saving={saving}
-          state={state}
-          onChangeCooldown={onChangeCooldown}
-          onCustomMinChange={setCustomMin}
-          onDone={() => setOpen(false)}
-          onSubmitCustom={submitCustom}
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
-}
-
-const ThrottleTrigger = forwardRef<HTMLButtonElement, ThrottleTriggerProps>(
-  function ThrottleTrigger({ loading, saving, state, ...props }, ref) {
-    return (
-      <Button
-        {...props}
-        ref={ref}
-        variant="outline"
-        size="sm"
-        disabled={loading || saving}
-        title={throttleTitle(loading, state)}
-      >
-        {state.failover ? (
-          <ShieldCheck className="h-3.5 w-3.5 text-emerald-600" />
-        ) : (
-          <ShieldAlert className="h-3.5 w-3.5 text-amber-500" />
-        )}
-        <span className="hidden md:inline">
-          {throttleTriggerText(loading, state)}
-        </span>
-      </Button>
-    )
-  },
-)
-
-function ThrottleStatusPanel({
-  saving, state, onToggleFailover,
-}: {
-  saving: boolean
-  state: ThrottleState
-  onToggleFailover: () => void
-}) {
-  return (
-    <>
-      <DropdownMenuLabel>账号级风控故障转移</DropdownMenuLabel>
-      <div className="px-2 pb-2">
-        <div className="flex items-center justify-between gap-2 rounded-md bg-secondary/40 px-2.5 py-2">
-          <ThrottleStatusText failover={state.failover} />
-          <Switch
-            checked={state.failover}
-            disabled={saving}
-            onCheckedChange={() => onToggleFailover()}
-          />
-        </div>
-      </div>
-    </>
-  )
-}
-
-function ThrottleStatusText({ failover }: { failover: boolean }) {
-  return (
-    <div className="text-xs">
-      <div className="font-medium text-foreground">
-        {failover ? '开启' : '关闭'}
-      </div>
-      <div className="text-muted-foreground leading-snug">
-        {failover
-          ? '上游对当前账号触发临时限速时，自动冷却该凭据并切换到下一个可用凭据'
-          : '上游对当前账号触发临时限速时，仅按瞬态错误重试，不切换凭据'}
-      </div>
-    </div>
-  )
-}
-
-function ThrottleCooldownPanel({
-  customMin, saving, state, onChangeCooldown, onCustomMinChange, onDone, onSubmitCustom,
-}: {
-  customMin: string
-  saving: boolean
-  state: ThrottleState
-  onChangeCooldown: (secs: number) => void
-  onCustomMinChange: (value: string) => void
-  onDone?: () => void
-  onSubmitCustom: (e: React.FormEvent) => void
-}) {
-  const disabled = saving || !state.failover
-
-  return (
-    <>
-      <DropdownMenuLabel className="pt-1">冷却时长</DropdownMenuLabel>
-      <div className={cooldownPanelClassName(state.failover)}>
-        <CooldownPresetButtons
-          cooldownSecs={state.cooldownSecs}
-          disabled={disabled}
-          onChangeCooldown={onChangeCooldown}
-          onDone={onDone}
-        />
-        <CustomCooldownForm
-          cooldownMin={state.cooldownMin}
-          customMin={customMin}
-          disabled={disabled}
-          onCustomMinChange={onCustomMinChange}
-          onSubmit={onSubmitCustom}
-        />
-      </div>
-    </>
-  )
-}
-
-function CustomCooldownForm({
-  cooldownMin, customMin, disabled, onCustomMinChange, onSubmit,
-}: CustomCooldownFormProps) {
-  return (
-    <form onSubmit={onSubmit} className="mt-2 flex items-center gap-1.5">
-      <Input
-        type="number"
-        min={MIN_CUSTOM_COOLDOWN_MINUTES}
-        max={MAX_CUSTOM_COOLDOWN_MINUTES}
-        placeholder={`自定义（当前 ${cooldownMin}）`}
-        value={customMin}
-        onChange={(e) => onCustomMinChange(e.target.value)}
-        disabled={disabled}
-        className="h-7 text-xs"
-      />
-      <span className="text-xs text-muted-foreground">分钟</span>
-      <Button
-        type="submit"
-        size="sm"
-        variant="outline"
-        className="h-7 text-xs"
-        disabled={disabled || !customMin.trim()}
-      >
-        保存
-      </Button>
-    </form>
-  )
-}
-
-function ThrottleCompactItems(props: ThrottleConfigButtonProps) {
-  const { loading, saving, onToggleFailover, onChangeCooldown } = props
-  const [customMin, setCustomMin] = useState('')
-  const state = readThrottleState(props.config)
-  const busy = loading || saving
-
-  const submitCustom = (e: React.FormEvent) => {
-    e.preventDefault()
-    const min = parseInt(customMin, 10)
-    if (invalidCooldownMinutes(min)) {
-      toast.error('请输入 1-1440 之间的分钟数')
-      return
-    }
-    onChangeCooldown(min * SECONDS_PER_MINUTE)
-    setCustomMin('')
-  }
-
-  return (
-    <>
-      <DropdownMenuLabel>故障转移</DropdownMenuLabel>
-      <DropdownMenuItem
-        disabled={busy}
-        onSelect={onToggleFailover}
-      >
-        {state.failover ? <ShieldCheck /> : <ShieldAlert />}
-        {compactThrottleText(loading, state)}
-      </DropdownMenuItem>
-      <ThrottleCooldownPanel
-        customMin={customMin}
-        saving={busy}
-        state={state}
-        onChangeCooldown={onChangeCooldown}
-        onCustomMinChange={setCustomMin}
-        onSubmitCustom={submitCustom}
-      />
-    </>
-  )
-}
-
-// ============ 自愈治理 ============
-
-const SELF_HEAL_INTERVAL_PRESETS = [
-  { label: '不冷却', secs: 0 },
-  { label: '1 分钟', secs: 60 },
-  { label: '5 分钟', secs: 5 * 60 },
-  { label: '15 分钟', secs: 15 * 60 },
-  { label: '30 分钟', secs: 30 * 60 },
-]
-
-/**
- * 自愈治理设置（下拉）：
- * - 开关：是否启用凭据自愈
- * - 冷却间隔：两次自愈的最小间隔（打断持续 403 死循环的关键）
- * - 连续上限：连续自愈达到该轮数且期间无成功则停止（0=不限）
- * - 只读观测：凭据最大连续轮数 / 累计恢复凭据次数
- */
-function useSelfHealPanelState(resetInput: boolean) {
-  const { data: config, isLoading } = useSelfHealConfig()
-  const { mutate, isPending } = useSetSelfHealConfig()
-  const [roundsInput, setRoundsInput] = useState('')
-
-  useEffect(() => {
-    if (resetInput) setRoundsInput('')
-  }, [resetInput])
-
-  const enabled = config?.enabled ?? true
-  const busy = isLoading || isPending
-
-  const save = (patch: SelfHealConfigPatch, msg: string) => {
-    mutate(patch, {
-      onSuccess: () => toast.success(msg),
-      onError: (err) => toast.error(`保存失败: ${extractErrorMessage(err)}`),
-    })
-  }
-
-  const submitRounds = (e: React.FormEvent) => {
-    e.preventDefault()
-    const n = parseInt(roundsInput, 10)
-    if (Number.isNaN(n) || n < 0 || n > 1000) {
-      toast.error('请输入 0-1000 之间的轮数（0=不限）')
-      return
-    }
-    save({ maxConsecutiveRounds: n }, n === 0 ? '连续自愈已设为不限' : `连续自愈上限已设为 ${n} 轮`)
-    setRoundsInput('')
-  }
-
-  return {
-    busy,
-    config,
-    enabled,
-    isLoading,
-    roundsInput,
-    save,
-    setRoundsInput,
-    submitRounds,
-  }
-}
-
-type SelfHealPanelState = ReturnType<typeof useSelfHealPanelState>
-
-function SelfHealConfigButton() {
-  const [open, setOpen] = useState(false)
-  const panel = useSelfHealPanelState(!open)
-
-  return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={panel.busy}
-          title={panel.enabled ? '凭据自愈：已启用' : '凭据自愈：已关闭'}
-        >
-          {panel.enabled ? (
-            <HeartPulse className="h-3.5 w-3.5 text-emerald-600" />
-          ) : (
-            <HeartCrack className="h-3.5 w-3.5 text-amber-500" />
-          )}
-          <span className="hidden md:inline">
-            {panel.isLoading ? '自愈…' : panel.enabled ? '自愈开' : '自愈关'}
-          </span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-72">
-        <SelfHealConfigPanel {...panel} />
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
-}
-
-function SelfHealConfigPanel({
-  busy,
-  config,
-  enabled,
-  roundsInput,
-  save,
-  setRoundsInput,
-  submitRounds,
-}: SelfHealPanelState) {
-  return (
-    <>
-      <DropdownMenuLabel>凭据自愈</DropdownMenuLabel>
-      <div className="px-2 pb-2">
-        <div className="flex items-center justify-between gap-2 rounded-md bg-secondary/40 px-2.5 py-2">
-          <div className="min-w-0 text-xs">
-            <div className="font-medium">{enabled ? '已启用' : '已关闭'}</div>
-            <div className="text-muted-foreground">
-              当前请求池全灭时按作用域恢复凭据
-            </div>
-          </div>
-          <Switch
-            checked={enabled}
-            disabled={busy}
-            onCheckedChange={(v) => save({ enabled: v }, v ? '已开启凭据自愈' : '已关闭凭据自愈')}
-          />
-        </div>
-        {config && (
-          <div className="mt-2 flex items-center justify-between rounded-md bg-secondary/20 px-2.5 py-1.5 text-xs text-muted-foreground">
-            <span>连续 {config.consecutiveRounds} 轮</span>
-            <span>累计恢复 {config.totalCount} 次</span>
-          </div>
-        )}
-      </div>
-
-      <DropdownMenuLabel className="pt-1">403 封禁识别</DropdownMenuLabel>
-      <div className="px-2 pb-2">
-        <div className="flex items-center justify-between gap-2 rounded-md bg-secondary/40 px-2.5 py-2">
-          <div className="min-w-0 text-xs">
-            <div className="font-medium">
-              {config?.suspendedDetectionEnabled ?? true ? '已启用' : '已关闭'}
-            </div>
-            <div className="text-muted-foreground">
-              命中封禁文案的 403 立即禁用，不参与自愈
-            </div>
-          </div>
-          <Switch
-            checked={config?.suspendedDetectionEnabled ?? true}
-            disabled={busy}
-            onCheckedChange={(v) =>
-              save({ suspendedDetectionEnabled: v }, v ? '已开启 403 封禁识别' : '已关闭 403 封禁识别')
-            }
-          />
-        </div>
-      </div>
-
-      <DropdownMenuLabel className="pt-1">自愈冷却间隔</DropdownMenuLabel>
-      <div className={cooldownPanelClassName(enabled)}>
-        <div className="grid grid-cols-3 gap-1.5">
-          {SELF_HEAL_INTERVAL_PRESETS.map((p) => (
-            <Button
-              key={p.secs}
-              size="sm"
-              variant={config?.minIntervalSecs === p.secs ? 'default' : 'outline'}
-              className="h-7 text-xs"
-              disabled={busy || !enabled}
-              onClick={() => save({ minIntervalSecs: p.secs }, `自愈冷却已设为「${p.label}」`)}
-            >
-              {p.label}
-            </Button>
-          ))}
-        </div>
-
-        <DropdownMenuLabel className="px-0 pt-2">连续自愈上限（0=不限）</DropdownMenuLabel>
-        <form onSubmit={submitRounds} className="mt-1 flex items-center gap-1.5">
-          <Input
-            type="number"
-            min={0}
-            max={1000}
-            placeholder={`当前 ${config?.maxConsecutiveRounds ?? 5} 轮`}
-            value={roundsInput}
-            onChange={(e) => setRoundsInput(e.target.value)}
-            disabled={busy || !enabled}
-            className="h-7 min-w-0 text-xs"
-          />
-          <span className="text-xs text-muted-foreground">轮</span>
-          <Button
-            type="submit"
-            size="sm"
-            variant="outline"
-            className="h-7 text-xs"
-            disabled={busy || !enabled || !roundsInput.trim()}
-          >
-            保存
-          </Button>
-        </form>
-      </div>
-    </>
-  )
-}
-
-/** 紧凑菜单复用完整配置，避免移动端丢失治理选项。 */
-function SelfHealCompactItems() {
-  const panel = useSelfHealPanelState(false)
-  return <SelfHealConfigPanel {...panel} />
-}
-
-const RPM_LIMIT_PRESETS = [10, 30, 60, 120, 300]
-const MIN_RPM_LIMIT = 1
-const MAX_RPM_LIMIT = 100000
-
-/**
- * 单账号 RPM 主动限流：开关 + 每分钟上限设置（紧凑下拉）。
- *
- * 开启后每个账号独立维护 60 秒滑动窗口，达到上限时该账号被临时排除出候选，
- * 请求自动故障转移到下一个可用账号；全部超限时返回 429。
- */
-function useAccountRpmLimitPanelState(resetInput: boolean) {
-  const { data: config, isLoading } = useAccountRpmLimitConfig()
-  const { mutate, isPending } = useSetAccountRpmLimitConfig()
-  const [limitInput, setLimitInput] = useState('')
-
-  useEffect(() => {
-    if (resetInput) setLimitInput('')
-  }, [resetInput])
-
-  const enabled = config?.enabled ?? false
-  const limit = config?.limit ?? 60
-  const busy = isLoading || isPending
-
-  const save = (patch: { enabled?: boolean; limit?: number }, msg: string) => {
-    mutate(patch, {
-      onSuccess: () => toast.success(msg),
-      onError: (err) => toast.error(`保存失败: ${extractErrorMessage(err)}`),
-    })
-  }
-
-  const submitLimit = (e: React.FormEvent) => {
-    e.preventDefault()
-    const n = parseInt(limitInput, 10)
-    if (Number.isNaN(n) || n < MIN_RPM_LIMIT || n > MAX_RPM_LIMIT) {
-      toast.error(`请输入 ${MIN_RPM_LIMIT}-${MAX_RPM_LIMIT} 之间的次数`)
-      return
-    }
-    save({ limit: n }, `单账号 RPM 上限已设为 ${n} 次/分钟`)
-    setLimitInput('')
-  }
-
-  return {
-    busy,
-    config,
-    enabled,
-    isLoading,
-    limit,
-    limitInput,
-    save,
-    setLimitInput,
-    submitLimit,
-  }
-}
-
-type AccountRpmLimitPanelState = ReturnType<typeof useAccountRpmLimitPanelState>
-
-function AccountRpmLimitButton() {
-  const [open, setOpen] = useState(false)
-  const panel = useAccountRpmLimitPanelState(!open)
-
-  return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={panel.busy}
-          title={panel.enabled ? `单账号限流：${panel.limit} 次/分钟` : '单账号限流：已关闭'}
-        >
-          <Gauge className={panel.enabled ? 'h-3.5 w-3.5 text-emerald-600' : 'h-3.5 w-3.5 text-muted-foreground'} />
-          <span className="hidden md:inline">
-            {panel.isLoading ? '限流…' : panel.enabled ? `限流 ${panel.limit}/分` : '限流关'}
-          </span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-72">
-        <AccountRpmLimitPanel {...panel} />
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
-}
-
-function AccountRpmLimitPanel({
-  busy,
-  enabled,
-  limit,
-  limitInput,
-  save,
-  setLimitInput,
-  submitLimit,
-}: AccountRpmLimitPanelState) {
-  return (
-    <>
-      <DropdownMenuLabel>单账号每分钟请求限流</DropdownMenuLabel>
-      <div className="px-2 pb-2">
-        <div className="flex items-center justify-between gap-2 rounded-md bg-secondary/40 px-2.5 py-2">
-          <div className="min-w-0 text-xs">
-            <div className="font-medium">{enabled ? '已启用' : '已关闭'}</div>
-            <div className="text-muted-foreground leading-snug">
-              单账号超过每分钟上限时临时跳过并切换到下一个可用账号
-            </div>
-          </div>
-          <Switch
-            checked={enabled}
-            disabled={busy}
-            onCheckedChange={(v) => save({ enabled: v }, v ? '已开启单账号限流' : '已关闭单账号限流')}
-          />
-        </div>
-      </div>
-
-      <DropdownMenuLabel className="pt-1">每分钟上限</DropdownMenuLabel>
-      <div className={cooldownPanelClassName(enabled)}>
-        <div className="grid grid-cols-3 gap-1.5">
-          {RPM_LIMIT_PRESETS.map((n) => (
-            <Button
-              key={n}
-              size="sm"
-              variant={limit === n ? 'default' : 'outline'}
-              className="h-7 text-xs"
-              disabled={busy || !enabled}
-              onClick={() => save({ limit: n }, `单账号 RPM 上限已设为 ${n} 次/分钟`)}
-            >
-              {n}
-            </Button>
-          ))}
-        </div>
-
-        <DropdownMenuLabel className="px-0 pt-2">自定义（次/分钟）</DropdownMenuLabel>
-        <form onSubmit={submitLimit} className="mt-1 flex items-center gap-1.5">
-          <Input
-            type="number"
-            min={MIN_RPM_LIMIT}
-            max={MAX_RPM_LIMIT}
-            placeholder={`当前 ${limit} 次`}
-            value={limitInput}
-            onChange={(e) => setLimitInput(e.target.value)}
-            disabled={busy || !enabled}
-            className="h-7 min-w-0 text-xs"
-          />
-          <span className="text-xs text-muted-foreground">次</span>
-          <Button
-            type="submit"
-            size="sm"
-            variant="outline"
-            className="h-7 text-xs"
-            disabled={busy || !enabled || !limitInput.trim()}
-          >
-            保存
-          </Button>
-        </form>
-      </div>
-    </>
-  )
-}
-
-/** 紧凑菜单复用完整配置，避免移动端只能切换开关。 */
-function AccountRpmLimitCompactItems() {
-  const panel = useAccountRpmLimitPanelState(false)
-  return <AccountRpmLimitPanel {...panel} />
-}
-
-function CooldownPresetButtons({
-  cooldownSecs, disabled, onChangeCooldown, onDone,
-}: {
-  cooldownSecs: number
-  disabled: boolean
-  onChangeCooldown: (secs: number) => void
-  onDone?: () => void
-}) {
-  return (
-    <div className="grid grid-cols-3 gap-1">
-      {COOLDOWN_PRESETS.map((preset) => (
-        <CooldownPresetButton
-          key={preset.secs}
-          active={preset.secs === cooldownSecs}
-          disabled={disabled}
-          label={preset.label}
-          secs={preset.secs}
-          onChangeCooldown={onChangeCooldown}
-          onDone={onDone}
-        />
-      ))}
-    </div>
-  )
-}
-
-function CooldownPresetButton({
-  active, disabled, label, secs, onChangeCooldown, onDone,
-}: {
-  active: boolean
-  disabled: boolean
-  label: string
-  secs: number
-  onChangeCooldown: (secs: number) => void
-  onDone?: () => void
-}) {
-  return (
-    <Button
-      type="button"
-      size="sm"
-      variant={active ? 'default' : 'outline'}
-      className="h-7 text-xs"
-      disabled={disabled}
-      onClick={() => {
-        if (!active) onChangeCooldown(secs)
-        onDone?.()
-      }}
-    >
-      {label}
-    </Button>
-  )
-}
-
-function secondsToMinutes(seconds: number) {
-  return Math.round(seconds / SECONDS_PER_MINUTE)
-}
-
-function readThrottleState(
-  config: ThrottleConfigButtonProps['config'],
-): ThrottleState {
-  const cooldownSecs = config?.cooldownSecs ?? DEFAULT_COOLDOWN_SECS
-  return {
-    cooldownMin: secondsToMinutes(cooldownSecs),
-    cooldownSecs,
-    failover: config?.failover ?? true,
-  }
-}
-
-function throttleTitle(loading: boolean, state: ThrottleState) {
-  if (loading) return '加载中…'
-  if (!state.failover) return '账号级风控故障转移：关闭'
-  return `账号级风控故障转移：开启（冷却 ${state.cooldownMin} 分钟）`
-}
-
-function throttleTriggerText(loading: boolean, state: ThrottleState) {
-  if (loading) return '加载中…'
-  if (!state.failover) return '不切换'
-  return `故障转移 · ${state.cooldownMin}m`
-}
-
-function compactThrottleText(loading: boolean, state: ThrottleState) {
-  if (loading) return '故障转移加载中'
-  if (!state.failover) return '开启故障转移'
-  return `关闭故障转移 · ${state.cooldownMin}m`
-}
-
-function invalidCooldownMinutes(minutes: number) {
-  return (
-    Number.isNaN(minutes) ||
-    minutes < MIN_CUSTOM_COOLDOWN_MINUTES ||
-    minutes > MAX_CUSTOM_COOLDOWN_MINUTES
-  )
-}
-
-function cooldownPanelClassName(failover: boolean) {
-  return `px-2 pb-2 ${failover ? '' : 'opacity-60'}`
 }

--- a/admin-ui/src/components/trace-log-page.tsx
+++ b/admin-ui/src/components/trace-log-page.tsx
@@ -602,7 +602,13 @@ export function TraceLogPage() {
   const debouncedSearch = useDebounced(searchDraft)
   const searchRef = useRef<HTMLInputElement>(null)
   const [detail, setDetail] = useState<TraceRecord | null>(null)
+  const [now, setNow] = useState(() => Date.now())
   useSlashFocus(searchRef)
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 30_000)
+    return () => window.clearInterval(timer)
+  }, [])
 
   // 搜索词稳定后才写进 URL / 触发查询
   useEffect(() => {
@@ -627,13 +633,11 @@ export function TraceLogPage() {
     ...groupOptions.map((g) => ({ value: g, label: g })),
   ]
 
-  // 时间窗口按分钟数换算成起始秒。用 range 字符串做依赖，避免每次渲染都产生新的
-  // startTime 把 react-query 的 queryKey 打散（那会导致 30s 自动刷新变成每渲染必刷）。
+  // 时间窗口按分钟数换算成起始秒；随自动刷新时钟滑动，始终表示“最近 N 分钟”。
   const startTime = useMemo(() => {
-    const ms = rangeToStartMs(range)
+    const ms = rangeToStartMs(range, now)
     return ms == null ? undefined : Math.floor(ms / 1000)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [url.range])
+  }, [url.range, now])
 
   const query: TraceQuery = {
     status: url.status || undefined,

--- a/admin-ui/src/components/trace-log-page.tsx
+++ b/admin-ui/src/components/trace-log-page.tsx
@@ -1,27 +1,17 @@
-import { useState } from 'react'
-import { toast } from 'sonner'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   ScrollText,
   RefreshCw,
   ChevronRight,
   ChevronLeft,
-  ChevronDown,
   AlertTriangle,
   CheckCircle2,
   Unplug,
-  Settings2,
+  Search,
+  X,
 } from 'lucide-react'
-import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Input } from '@/components/ui/input'
-import { Switch } from '@/components/ui/switch'
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-} from '@/components/ui/dropdown-menu'
 import {
   Tooltip,
   TooltipContent,
@@ -38,11 +28,22 @@ import {
 import { useTraces } from '@/hooks/use-traces'
 import { useClientKeys } from '@/hooks/use-client-keys'
 import { useGroupOptions } from '@/hooks/use-groups'
+import { useUrlState } from '@/hooks/use-url-state'
 import {
-  useLogGovernanceConfig,
-  useSetLogGovernanceConfig,
-} from '@/hooks/use-credentials'
-import { extractErrorMessage } from '@/lib/utils'
+  ConsoleTable,
+  type ConsoleColumn,
+} from '@/components/console/data-table'
+import {
+  DetailDrawer,
+  DrawerField,
+  DrawerSection,
+} from '@/components/console/detail-drawer'
+import {
+  TimeRangePicker,
+  rangeToStartMs,
+  type TimeRange,
+} from '@/components/console/time-range'
+import { outcomeTone, railDotClass, type RailTone } from '@/components/console/rail'
 import type { TraceAttempt, TraceQuery, TraceRecord } from '@/types/api'
 
 /** 失败分类 → 中文标签 + Badge 颜色 */
@@ -70,6 +71,27 @@ function outcomeStyle(outcome: string): {
     default:
       return { label: outcome || '未知', variant: 'secondary' }
   }
+}
+
+/**
+ * 失败分类 → 轨迹节点圆点色。
+ *
+ * 委托给共享的状态轨映射：日志行的左侧色轨、凭据行的状态、这里的链路节点用同一套
+ * 四档语义，异常在三个页面里是同一个颜色。原先本页自带一份 switch，与凭据卡片各判
+ * 一次，账号风控在一边是 amber、另一边是 orange。
+ */
+function outcomeDot(outcome: string): string {
+  return railDotClass(outcomeTone(outcome))
+}
+
+/** 整条 trace 的严重度 → 左侧色轨 */
+function traceTone(rec: TraceRecord): RailTone {
+  if (rec.finalStatus === 'success') {
+    // 成功但重试过：请求被救回来了，可池子里有凭据在失败 —— 值得看一眼，但不是故障
+    return rec.totalAttempts > 1 ? 'warn' : 'none'
+  }
+  if (rec.finalStatus === 'interrupted') return 'warn'
+  return outcomeTone(rec.errorType ?? '')
 }
 
 /** 最终状态 → 徽章 */
@@ -228,77 +250,44 @@ function TokenCell({ rec }: { rec: TraceRecord }) {
   )
 }
 
-function TraceRow({ rec }: { rec: TraceRecord }) {
-  const [open, setOpen] = useState(false)
-  const errStyle = rec.errorType ? outcomeStyle(rec.errorType) : null
+/**
+ * 故障转移轨迹（本页签名元素）：把一次请求的 attempts[] 画成横向重试链路，
+ * 按每跳结果着色。单次成功只显示一个安静的圆点；重试/故障转移时展开为带凭据号
+ * 的节点串，让"这次请求怎么被救回来的"一眼可读。顺序即尝试次序。
+ */
+function AttemptChain({ rec }: { rec: TraceRecord }) {
+  const attempts = rec.attempts ?? []
+  if (attempts.length === 0) {
+    return <span className="text-muted-foreground/50">—</span>
+  }
+  if (attempts.length === 1 && rec.finalStatus === 'success') {
+    return (
+      <span className={`inline-block h-2 w-2 rounded-full ${outcomeDot(attempts[0].outcome)}`} />
+    )
+  }
   return (
-    <>
-      <tr
-        className="cursor-pointer whitespace-nowrap border-b border-border/40 hover:bg-accent/40"
-        onClick={() => setOpen((v) => !v)}
-      >
-        <td className="py-2.5 pl-3 pr-2">
-          {open ? (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
-          )}
-        </td>
-        <td className="py-2.5 pr-3 text-[13px] tabular-nums text-muted-foreground whitespace-nowrap">
-          {formatTime(rec.ts)}
-        </td>
-        <td className="py-2.5 pr-3 text-[13px]">
-          <span className="inline-block max-w-[220px] truncate align-middle">{rec.model}</span>
-          {rec.isStream && <Badge variant="outline" className="ml-1.5">流式</Badge>}
-        </td>
-        <td className="py-2.5 pr-3 text-[13px]">
-          <Badge variant="outline">{keyLabel(rec.keyId, rec.keyName)}</Badge>
-        </td>
-        <td className="py-2.5 pr-3">
-          <StatusBadge status={rec.finalStatus} />
-        </td>
-        <TraceCredentialCell rec={rec} />
-        <td className="py-2.5 pr-3 text-[12px] tabular-nums">
-          <TokenCell rec={rec} />
-        </td>
-        <td className="py-2.5 pr-3 text-[13px] tabular-nums">
-          {rec.credits != null && rec.credits > 0 ? rec.credits.toFixed(4) : '—'}
-        </td>
-        <td className="py-2.5 pr-3 text-[13px] tabular-nums text-muted-foreground">
-          {rec.firstTokenMs != null ? formatDuration(rec.firstTokenMs) : '—'}
-        </td>
-        <td className="py-2.5 pr-3">
-          {errStyle ? <Badge variant={errStyle.variant}>{errStyle.label}</Badge> : '—'}
-        </td>
-        <td className="py-2.5 pr-3 text-[13px] tabular-nums">
-          {Math.max(0, rec.totalAttempts - 1)}
-        </td>
-        <td className="py-2.5 pr-3 text-[13px] tabular-nums text-muted-foreground">
-          {formatDuration(rec.durationMs)}
-        </td>
-      </tr>
-      {open && <ExpandedTraceRow rec={rec} />}
-    </>
-  )
-}
-
-function TraceCredentialCell({ rec }: { rec: TraceRecord }) {
-  return (
-    <td className="py-2.5 pr-3 text-[13px]">
-      <span className="inline-block max-w-[220px] truncate align-middle">
-        {credLabel(rec.finalCredentialId, rec.finalEmail)}
+    <TooltipProvider delayDuration={150}>
+      <span className="inline-flex items-center gap-1">
+        {attempts.map((a, i) => (
+          <span key={a.attempt} className="inline-flex items-center gap-1">
+            {i > 0 && <span className="text-muted-foreground/40">→</span>}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex cursor-default items-center gap-1 rounded border border-border/60 bg-secondary/40 px-1.5 py-0.5 font-mono text-[11px] tabular-nums">
+                  <span className={`h-1.5 w-1.5 rounded-full ${outcomeDot(a.outcome)}`} />
+                  {a.credentialId > 0 ? `#${a.credentialId}` : '—'}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="font-mono text-[11px]">
+                第 {a.attempt + 1} 跳 · {outcomeStyle(a.outcome).label}
+                {a.httpStatus != null ? ` · HTTP ${a.httpStatus}` : ''}
+                {a.endpoint ? ` · ${a.endpoint}` : ''} · {formatDuration(a.durationMs)}
+              </TooltipContent>
+            </Tooltip>
+          </span>
+        ))}
       </span>
-    </td>
-  )
-}
-
-function ExpandedTraceRow({ rec }: { rec: TraceRecord }) {
-  return (
-    <tr className="border-b border-border/40 bg-secondary/20">
-      <td colSpan={12} className="px-3 py-3">
-        <ExpandedDetail rec={rec} />
-      </td>
-    </tr>
+    </TooltipProvider>
   )
 }
 
@@ -325,8 +314,9 @@ function CacheBillingPanel({ rec }: { rec: TraceRecord }) {
   const promptTotal = freshInput + cacheCreation + cacheRead
   const perK = promptTotal > 0 ? credit / (promptTotal / 1000) : null
 
-  const items: Array<{ label: string; value: string; hint?: string }> = [
-    { label: '真实计费', value: credit.toFixed(4), hint: 'credit（上游 metering）' },
+  // boldness 只花在一处：credit（真实成本）为主角，其余中性陪衬。
+  const items: Array<{ label: string; value: string; hint?: string; primary?: boolean }> = [
+    { label: '真实计费', value: credit.toFixed(4), hint: 'credit（上游 metering）', primary: true },
     { label: '总输入 Token', value: formatTokens(promptTotal), hint: '含缓存命中·估算' },
   ]
   if (perK != null) {
@@ -357,7 +347,13 @@ function CacheBillingPanel({ rec }: { rec: TraceRecord }) {
         {items.map((it) => (
           <div key={it.label} className="min-w-0">
             <div className="text-[11px] text-muted-foreground">{it.label}</div>
-            <div className="font-mono tabular-nums text-[15px] font-semibold text-pink-600 dark:text-pink-400">
+            <div
+              className={
+                it.primary
+                  ? 'font-mono tabular-nums text-[15px] font-semibold text-sky-700 dark:text-sky-300'
+                  : 'font-mono tabular-nums text-[15px] font-medium text-foreground/85'
+              }
+            >
               {it.value}
             </div>
             {it.hint && (
@@ -431,152 +427,221 @@ function Select({
   )
 }
 
-/** 日志治理设置下拉：trace 启用开关 + trace 保留天数 + usage 保留天数 */
-function GovernanceButton() {
-  const [open, setOpen] = useState(false)
-  const { data: cfg, isLoading } = useLogGovernanceConfig()
-  const { mutate, isPending } = useSetLogGovernanceConfig()
-  const [traceDays, setTraceDays] = useState('')
-  const [usageDays, setUsageDays] = useState('')
+const PAGE_SIZE = 50
 
-  const enabled = cfg?.traceEnabled ?? true
+/** 默认时间窗口：24 小时。够覆盖"昨天那次失败"，又不至于一上来就全表扫。 */
+const DEFAULT_RANGE_MINUTES = '1440'
 
-  const save = (patch: Record<string, unknown>, ok: string) => {
-    mutate(patch, {
-      onSuccess: () => toast.success(ok),
-      onError: (err) => toast.error('保存失败：' + extractErrorMessage(err)),
-    })
-  }
+const URL_DEFAULTS = {
+  status: '',
+  errorType: '',
+  keyId: '',
+  group: '',
+  q: '',
+  range: DEFAULT_RANGE_MINUTES,
+  page: '0',
+}
 
-  const submitDays = (
-    e: React.FormEvent,
-    field: 'traceRetentionDays' | 'usageLogRetentionDays',
-    raw: string,
-    reset: () => void,
-  ) => {
-    e.preventDefault()
-    const n = parseInt(raw, 10)
-    if (isNaN(n) || n < 1 || n > 365) {
-      toast.error('保留天数需在 1..=365')
-      return
+/** 搜索输入防抖：输入过程中不打请求，停手 300ms 再查 */
+function useDebounced<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const t = window.setTimeout(() => setDebounced(value), delay)
+    return () => window.clearTimeout(t)
+  }, [value, delay])
+  return debounced
+}
+
+/** `/` 聚焦搜索框 —— 手不离键盘就能开始筛 */
+function useSlashFocus(ref: React.RefObject<HTMLInputElement | null>) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return
+      const t = e.target as HTMLElement | null
+      if (
+        t &&
+        (t.tagName === 'INPUT' ||
+          t.tagName === 'TEXTAREA' ||
+          t.isContentEditable)
+      ) {
+        return
+      }
+      e.preventDefault()
+      ref.current?.focus()
+      ref.current?.select()
     }
-    save({ [field]: n }, '保留天数已更新')
-    reset()
-  }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [ref])
+}
 
-  return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button size="sm" variant="outline">
-          <Settings2 className="h-3.5 w-3.5" />
-          治理设置
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-72">
-        <DropdownMenuLabel>请求链路追踪</DropdownMenuLabel>
-        <div className="px-2 pb-2">
-          <div className="flex items-center justify-between gap-2 rounded-md bg-secondary/40 px-2.5 py-2">
-            <div className="text-xs">
-              <div className="font-medium text-foreground">
-                {enabled ? '已启用' : '已关闭'}
-              </div>
-              <div className="leading-snug text-muted-foreground">
-                {enabled
-                  ? '记录每次请求的完整重试链路到 traces.db'
-                  : '不再写入新链路（历史记录仍可查询）'}
-              </div>
-            </div>
-            <Switch
-              checked={enabled}
-              disabled={isLoading || isPending}
-              onCheckedChange={(v) =>
-                save({ traceEnabled: v }, v ? '已开启链路追踪' : '已关闭链路追踪')
-              }
-            />
-          </div>
-        </div>
-        <DropdownMenuLabel className="pt-1">
-          trace 保留天数（当前 {cfg?.traceRetentionDays ?? '—'}）
-        </DropdownMenuLabel>
-        <form
-          onSubmit={(e) => submitDays(e, 'traceRetentionDays', traceDays, () => setTraceDays(''))}
-          className="flex items-center gap-1.5 px-2 pb-2"
-        >
-          <Input
-            type="number"
-            min={1}
-            max={365}
-            placeholder="天数"
-            value={traceDays}
-            onChange={(e) => setTraceDays(e.target.value)}
-            disabled={isPending}
-            className="h-7 text-xs"
-          />
-          <Button type="submit" size="sm" variant="outline" className="h-7 text-xs" disabled={isPending || !traceDays.trim()}>
-            保存
-          </Button>
-        </form>
-        <DropdownMenuLabel className="pt-1">
-          usage 日志保留天数（当前 {cfg?.usageLogRetentionDays ?? '—'}）
-        </DropdownMenuLabel>
-        <form
-          onSubmit={(e) => submitDays(e, 'usageLogRetentionDays', usageDays, () => setUsageDays(''))}
-          className="flex items-center gap-1.5 px-2 pb-2"
-        >
-          <Input
-            type="number"
-            min={1}
-            max={365}
-            placeholder="天数"
-            value={usageDays}
-            onChange={(e) => setUsageDays(e.target.value)}
-            disabled={isPending}
-            className="h-7 text-xs"
-          />
-          <Button type="submit" size="sm" variant="outline" className="h-7 text-xs" disabled={isPending || !usageDays.trim()}>
-            保存
-          </Button>
-        </form>
-      </DropdownMenuContent>
-    </DropdownMenu>
+/** 表格列定义。默认 8 列，其余进列控制菜单 —— 12 列全摆开必然横向滚动。 */
+function useTraceColumns(): ConsoleColumn<TraceRecord>[] {
+  return useMemo(
+    () => [
+      {
+        id: 'ts',
+        header: '时间',
+        cell: (r) => (
+          <span className="console-num text-muted-foreground">
+            {formatTime(r.ts)}
+          </span>
+        ),
+      },
+      {
+        id: 'model',
+        header: '模型',
+        cell: (r) => (
+          <span className="inline-flex max-w-[200px] items-center gap-1.5">
+            <span className="truncate">{r.model}</span>
+            {r.isStream && (
+              <span
+                className="shrink-0 text-[10px] text-muted-foreground"
+                title="流式响应"
+              >
+                流
+              </span>
+            )}
+          </span>
+        ),
+      },
+      {
+        id: 'status',
+        header: '状态',
+        cell: (r) => <StatusBadge status={r.finalStatus} />,
+      },
+      {
+        id: 'credential',
+        header: '最终凭据',
+        cell: (r) => (
+          <span className="inline-block max-w-[190px] truncate">
+            {credLabel(r.finalCredentialId, r.finalEmail)}
+          </span>
+        ),
+      },
+      {
+        id: 'chain',
+        header: '故障转移',
+        hint: '这次请求走过的重试链路，顺序即尝试次序',
+        cell: (r) => <AttemptChain rec={r} />,
+      },
+      {
+        id: 'tokens',
+        header: 'Token',
+        cell: (r) => <TokenCell rec={r} />,
+      },
+      {
+        id: 'credits',
+        header: '费用',
+        align: 'right',
+        hint: 'credit —— 上游 metering 的真实计费',
+        cell: (r) => (
+          <span className="console-num">
+            {r.credits != null && r.credits > 0 ? r.credits.toFixed(4) : '—'}
+          </span>
+        ),
+      },
+      {
+        id: 'duration',
+        header: '耗时',
+        align: 'right',
+        cell: (r) => (
+          <span className="console-num text-muted-foreground">
+            {formatDuration(r.durationMs)}
+          </span>
+        ),
+      },
+      {
+        id: 'key',
+        header: '入口 Key',
+        optional: true,
+        cell: (r) => (
+          <Badge variant="outline">{keyLabel(r.keyId, r.keyName)}</Badge>
+        ),
+      },
+      {
+        id: 'firstToken',
+        header: '首 Token',
+        optional: true,
+        align: 'right',
+        hint: '首个 token 到达耗时，仅流式有值',
+        cell: (r) => (
+          <span className="console-num text-muted-foreground">
+            {r.firstTokenMs != null ? formatDuration(r.firstTokenMs) : '—'}
+          </span>
+        ),
+      },
+      {
+        id: 'errorType',
+        header: '错误类型',
+        optional: true,
+        cell: (r) => {
+          if (!r.errorType) return <span className="text-muted-foreground">—</span>
+          const s = outcomeStyle(r.errorType)
+          return <Badge variant={s.variant}>{s.label}</Badge>
+        },
+      },
+      {
+        id: 'traceId',
+        header: 'Trace ID',
+        optional: true,
+        cell: (r) => (
+          <span className="console-num text-[11px] text-muted-foreground">
+            {r.traceId.slice(0, 12)}
+          </span>
+        ),
+      },
+    ],
+    [],
   )
 }
 
-
-const PAGE_SIZE = 50
-
 export function TraceLogPage() {
-  const [status, setStatus] = useState('')
-  const [errorType, setErrorType] = useState('')
-  const [keyId, setKeyId] = useState('')
-  const [group, setGroup] = useState('')
-  const [onlyFailed, setOnlyFailed] = useState(false)
-  const [page, setPage] = useState(0)
+  const [url, patchUrl, resetUrl] = useUrlState('traces', URL_DEFAULTS)
+  const [searchDraft, setSearchDraft] = useState(url.q)
+  const debouncedSearch = useDebounced(searchDraft)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const [detail, setDetail] = useState<TraceRecord | null>(null)
+  useSlashFocus(searchRef)
+
+  // 搜索词稳定后才写进 URL / 触发查询
+  useEffect(() => {
+    if (debouncedSearch !== url.q) patchUrl({ q: debouncedSearch, page: '0' })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch])
+
+  const page = Number(url.page) || 0
+  const range: TimeRange = {
+    minutes: url.range === '' ? null : Number(url.range),
+  }
 
   const { data: keysData } = useClientKeys()
+  const groupOptions = useGroupOptions()
+
   const keyOptions = [
     { value: '', label: '全部 Key' },
     ...(keysData?.keys ?? []).map((k) => ({ value: String(k.id), label: k.name })),
   ]
-
-  const groupOptions = useGroupOptions()
   const groupSelectOptions = [
     { value: '', label: '全部分组' },
     ...groupOptions.map((g) => ({ value: g, label: g })),
   ]
 
-  // 筛选条件变化时回到第一页
-  const resetTo = <T,>(setter: (v: T) => void) => (v: T) => {
-    setter(v)
-    setPage(0)
-  }
+  // 时间窗口按分钟数换算成起始秒。用 range 字符串做依赖，避免每次渲染都产生新的
+  // startTime 把 react-query 的 queryKey 打散（那会导致 30s 自动刷新变成每渲染必刷）。
+  const startTime = useMemo(() => {
+    const ms = rangeToStartMs(range)
+    return ms == null ? undefined : Math.floor(ms / 1000)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url.range])
 
   const query: TraceQuery = {
-    status: status || undefined,
-    errorType: errorType || undefined,
-    keyId: keyId ? Number(keyId) : undefined,
-    group: group || undefined,
-    onlyFailed: onlyFailed || undefined,
+    status: url.status || undefined,
+    errorType: url.errorType || undefined,
+    keyId: url.keyId ? Number(url.keyId) : undefined,
+    group: url.group || undefined,
+    q: url.q || undefined,
+    startTime,
     limit: PAGE_SIZE,
     offset: page * PAGE_SIZE,
   }
@@ -584,101 +649,147 @@ export function TraceLogPage() {
   const records = data?.records ?? []
   const total = data?.total ?? 0
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const columns = useTraceColumns()
+
+  const filterCount = [url.status, url.errorType, url.keyId, url.group, url.q].filter(
+    Boolean,
+  ).length
 
   return (
-    <div className="space-y-5">
-      {/* 筛选栏 */}
-      <div className="flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-2">
-          <ScrollText className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-lg font-semibold tracking-tight">请求日志</h2>
-          {total > 0 && <Badge variant="secondary">{total}</Badge>}
-        </div>
-        <div className="ml-auto flex flex-wrap items-center gap-2">
-          <Select value={keyId} onChange={resetTo(setKeyId)} options={keyOptions} />
-          <Select value={group} onChange={resetTo(setGroup)} options={groupSelectOptions} />
-          <Select value={status} onChange={resetTo(setStatus)} options={STATUS_OPTIONS} />
-          <Select
-            value={errorType}
-            onChange={resetTo(setErrorType)}
-            options={ERROR_TYPE_OPTIONS}
-          />
+    <div className="console-scope space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <ScrollText className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-lg font-semibold tracking-tight">请求日志</h2>
+        <span className="console-num text-[13px] text-muted-foreground">
+          {total} 条
+        </span>
+        {filterCount > 0 && (
           <Button
             size="sm"
-            variant={onlyFailed ? 'default' : 'outline'}
+            variant="ghost"
             onClick={() => {
-              setOnlyFailed((v) => !v)
-              setPage(0)
+              resetUrl()
+              setSearchDraft('')
             }}
+            className="h-7 px-2 text-xs"
           >
-            只看失败
+            清除 {filterCount} 个筛选
           </Button>
-          <GovernanceButton />
-          <Button size="sm" variant="outline" onClick={() => refetch()} disabled={isFetching}>
-            <RefreshCw className={`h-3.5 w-3.5 ${isFetching ? 'animate-spin' : ''}`} />
-            刷新
-          </Button>
-        </div>
+        )}
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          <kbd className="rounded border border-border/70 px-1">/</kbd> 搜索 ·{' '}
+          <kbd className="rounded border border-border/70 px-1">j</kbd>
+          <kbd className="ml-0.5 rounded border border-border/70 px-1">k</kbd> 移动 ·{' '}
+          <kbd className="rounded border border-border/70 px-1">Enter</kbd> 详情
+        </span>
       </div>
 
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="p-6 text-sm text-muted-foreground">加载中…</div>
-          ) : records.length === 0 ? (
-            <div className="p-6 text-sm text-muted-foreground">
-              暂无记录。发起几次 /v1/messages 请求后即可看到链路。
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[1080px] text-left">
-                <thead>
-                  <tr className="whitespace-nowrap border-b border-border/60 text-[12px] uppercase tracking-wider text-muted-foreground">
-                    <th className="py-2 pl-3 pr-2 font-medium"></th>
-                    <th className="py-2 pr-3 font-medium">时间</th>
-                    <th className="py-2 pr-3 font-medium">模型</th>
-                    <th className="py-2 pr-3 font-medium">入口 Key</th>
-                    <th className="py-2 pr-3 font-medium">状态</th>
-                    <th className="py-2 pr-3 font-medium">最终凭据</th>
-                    <th className="py-2 pr-3 font-medium">Token</th>
-                    <th className="py-2 pr-3 font-medium">费用</th>
-                    <th className="py-2 pr-3 font-medium">首Token</th>
-                    <th className="py-2 pr-3 font-medium">错误类型</th>
-                    <th className="py-2 pr-3 font-medium">重试</th>
-                    <th className="py-2 pr-3 font-medium">耗时</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {records.map((rec) => (
-                    <TraceRow key={rec.traceId} rec={rec} />
-                  ))}
-                </tbody>
-              </table>
-            </div>
+      {/* 筛选栏：时间范围在最前，因为排查的第一句话通常是"刚才那几分钟" */}
+      <div className="flex flex-wrap items-center gap-2">
+        <TimeRangePicker
+          value={range}
+          onChange={(next) =>
+            patchUrl({
+              range: next.minutes == null ? '' : String(next.minutes),
+              page: '0',
+            })
+          }
+        />
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            ref={searchRef}
+            type="text"
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setSearchDraft('')
+                e.currentTarget.blur()
+              }
+            }}
+            placeholder="搜索模型 / 报错 / Trace ID"
+            aria-label="搜索日志"
+            className="console-num h-8 w-[min(15rem,52vw)] rounded-lg border border-border bg-card/60 pl-8 pr-7 text-[12.5px] backdrop-blur placeholder:font-sans placeholder:text-muted-foreground/70 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          />
+          {searchDraft && (
+            <button
+              type="button"
+              onClick={() => setSearchDraft('')}
+              title="清除搜索"
+              className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <X className="h-3 w-3" />
+            </button>
           )}
-        </CardContent>
-      </Card>
+        </div>
+        <Select
+          value={url.status}
+          onChange={(v) => patchUrl({ status: v, page: '0' })}
+          options={STATUS_OPTIONS}
+        />
+        <Select
+          value={url.errorType}
+          onChange={(v) => patchUrl({ errorType: v, page: '0' })}
+          options={ERROR_TYPE_OPTIONS}
+        />
+        <Select
+          value={url.keyId}
+          onChange={(v) => patchUrl({ keyId: v, page: '0' })}
+          options={keyOptions}
+        />
+        <Select
+          value={url.group}
+          onChange={(v) => patchUrl({ group: v, page: '0' })}
+          options={groupSelectOptions}
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          title="立即刷新（每 30 秒自动刷新）"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${isFetching ? 'animate-spin' : ''}`} />
+        </Button>
+      </div>
+
+      <ConsoleTable
+        rows={records}
+        columns={columns}
+        rowKey={(r) => r.traceId}
+        tone={traceTone}
+        onRowActivate={setDetail}
+        columnsStorageKey="kiro.traces.columns"
+        loading={isLoading}
+        empty={
+          filterCount > 0 || url.range !== ''
+            ? '当前筛选条件下没有记录。放宽时间范围或清除筛选试试。'
+            : '暂无记录。发起几次 /v1/messages 请求后即可看到链路。'
+        }
+      />
 
       {total > PAGE_SIZE && (
         <div className="flex items-center justify-center gap-2">
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            onClick={() => patchUrl({ page: String(Math.max(0, page - 1)) })}
             disabled={page === 0 || isFetching}
           >
             <ChevronLeft className="h-3.5 w-3.5" />
             上一页
           </Button>
-          <div className="px-3 text-sm tabular-nums text-muted-foreground">
+          <div className="console-num px-3 text-[13px] text-muted-foreground">
             第 <span className="font-medium text-foreground">{page + 1}</span> /{' '}
             {totalPages} 页
-            <span className="mx-1.5 text-muted-foreground/50">·</span>共 {total} 条
           </div>
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            onClick={() =>
+              patchUrl({ page: String(Math.min(totalPages - 1, page + 1)) })
+            }
             disabled={page >= totalPages - 1 || isFetching}
           >
             下一页
@@ -686,10 +797,72 @@ export function TraceLogPage() {
           </Button>
         </div>
       )}
+
+      <TraceDetailDrawer rec={detail} onClose={() => setDetail(null)} />
     </div>
   )
 }
 
+/**
+ * 详情抽屉，替掉原先的行展开。
+ *
+ * 行展开会把 34px 的行顶到几百 px，下方所有行位置突变、滚动位置跟着跳 —— 想对比
+ * 相邻两条记录时格外难受。抽屉让表格布局始终稳定，左边列表和右边详情能同时看，
+ * j/k 还能继续在列表里走。
+ */
+function TraceDetailDrawer({
+  rec,
+  onClose,
+}: {
+  rec: TraceRecord | null
+  onClose: () => void
+}) {
+  return (
+    <DetailDrawer
+      open={rec != null}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      title={rec?.model ?? ''}
+      subtitle={rec ? `${formatTime(rec.ts)} · ${rec.traceId}` : undefined}
+    >
+      {rec && (
+        <div className="space-y-1">
+          <DrawerSection title="结果">
+            <DrawerField label="状态">
+              <StatusBadge status={rec.finalStatus} />
+            </DrawerField>
+            {rec.errorType && (
+              <DrawerField label="错误类型">
+                <Badge variant={outcomeStyle(rec.errorType).variant}>
+                  {outcomeStyle(rec.errorType).label}
+                </Badge>
+              </DrawerField>
+            )}
+            <DrawerField label="最终凭据" mono>
+              {credLabel(rec.finalCredentialId, rec.finalEmail)}
+            </DrawerField>
+            <DrawerField label="入口 Key" mono>
+              {keyLabel(rec.keyId, rec.keyName)}
+            </DrawerField>
+            <DrawerField label="总耗时" mono>
+              {formatDuration(rec.durationMs)}
+            </DrawerField>
+            {rec.firstTokenMs != null && (
+              <DrawerField label="首 Token" mono>
+                {formatDuration(rec.firstTokenMs)}
+              </DrawerField>
+            )}
+            {rec.interruptedAfterBytes != null && (
+              <DrawerField label="中断前已发送" mono>
+                {rec.interruptedAfterBytes} 字节
+              </DrawerField>
+            )}
+          </DrawerSection>
 
-
-
+          <ExpandedDetail rec={rec} />
+        </div>
+      )}
+    </DetailDrawer>
+  )
+}

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -26,6 +26,8 @@ import {
   setLogGovernanceConfig,
   getGlobalProxy,
   setGlobalProxy,
+  getCustomModels,
+  setCustomModels,
   getUpdateConfig,
   setUpdateConfig,
   resetSuccessCount,
@@ -35,6 +37,7 @@ import {
 } from '@/api/credentials'
 import type {
   AddCredentialRequest,
+  CustomModelItem,
   SetGlobalProxyRequest,
   SetUpdateConfigRequest,
   UpdateCredentialRequest,
@@ -86,6 +89,7 @@ export function useCredentialModels(id: number | null) {
     queryKey: ['credential-models', id],
     queryFn: () => getCredentialModels(id!),
     enabled: id !== null,
+    staleTime: 0, // 始终视为过期，每次打开对话框都实时查上游
     retry: false, // 失败不重试，避免对被封禁/异常账号反复请求
   })
 }
@@ -96,6 +100,7 @@ export function useCurrentCredentialModels(enabled: boolean) {
     queryKey: ['current-credential-models'],
     queryFn: getCurrentCredentialModels,
     enabled,
+    staleTime: 0, // 始终视为过期，每次打开对话框都实时查上游
     retry: false,
   })
 }
@@ -345,6 +350,25 @@ export function useSetGlobalProxy() {
     mutationFn: (req: SetGlobalProxyRequest) => setGlobalProxy(req),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['global-proxy'] })
+    },
+  })
+}
+
+// 自定义模型配置
+export function useCustomModels() {
+  return useQuery({
+    queryKey: ['custom-models'],
+    queryFn: getCustomModels,
+  })
+}
+
+export function useSetCustomModels() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (req: { models: CustomModelItem[] }) =>
+      setCustomModels(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['custom-models'] })
     },
   })
 }

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -30,6 +30,8 @@ import {
   setUpdateConfig,
   resetSuccessCount,
   resetAllSuccessCount,
+  getCredentialMetadataSchema,
+  setCredentialMetadataSchema,
 } from '@/api/credentials'
 import type {
   AddCredentialRequest,
@@ -37,6 +39,7 @@ import type {
   SetUpdateConfigRequest,
   UpdateCredentialRequest,
   UpdateRefreshTokenRequest,
+  CredentialMetadataSchemaConfig,
 } from '@/types/api'
 
 // 查询凭据列表
@@ -45,6 +48,25 @@ export function useCredentials() {
     queryKey: ['credentials'],
     queryFn: getCredentials,
     refetchInterval: 30000, // 每 30 秒刷新一次
+  })
+}
+
+export function useCredentialMetadataSchema() {
+  return useQuery({
+    queryKey: ['credential-metadata-schema'],
+    queryFn: getCredentialMetadataSchema,
+  })
+}
+
+export function useSetCredentialMetadataSchema() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: CredentialMetadataSchemaConfig) =>
+      setCredentialMetadataSchema(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['credential-metadata-schema'] })
+      queryClient.invalidateQueries({ queryKey: ['credentials'] })
+    },
   })
 }
 

--- a/admin-ui/src/hooks/use-credentials.ts
+++ b/admin-ui/src/hooks/use-credentials.ts
@@ -24,10 +24,20 @@ import {
   setSelfHealConfig,
   getLogGovernanceConfig,
   setLogGovernanceConfig,
+  getGlobalProxy,
+  setGlobalProxy,
+  getUpdateConfig,
+  setUpdateConfig,
   resetSuccessCount,
   resetAllSuccessCount,
 } from '@/api/credentials'
-import type { AddCredentialRequest, UpdateCredentialRequest, UpdateRefreshTokenRequest } from '@/types/api'
+import type {
+  AddCredentialRequest,
+  SetGlobalProxyRequest,
+  SetUpdateConfigRequest,
+  UpdateCredentialRequest,
+  UpdateRefreshTokenRequest,
+} from '@/types/api'
 
 // 查询凭据列表
 export function useCredentials() {
@@ -294,6 +304,43 @@ export function useSetLogGovernanceConfig() {
     mutationFn: setLogGovernanceConfig,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['logGovernanceConfig'] })
+    },
+  })
+}
+
+// 全局出站代理。此前只在代理池弹窗里内联查询，设置页需要独立入口，
+// 抽成 hook 后两处共用同一份缓存（queryKey 与弹窗保持一致：'global-proxy'）。
+export function useGlobalProxy() {
+  return useQuery({
+    queryKey: ['global-proxy'],
+    queryFn: getGlobalProxy,
+  })
+}
+
+export function useSetGlobalProxy() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (req: SetGlobalProxyRequest) => setGlobalProxy(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['global-proxy'] })
+    },
+  })
+}
+
+// 镜像在线更新配置（GitHub Token / 无人值守自动更新）
+export function useUpdateConfig() {
+  return useQuery({
+    queryKey: ['update-config'],
+    queryFn: getUpdateConfig,
+  })
+}
+
+export function useSetUpdateConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (req: SetUpdateConfigRequest) => setUpdateConfig(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['update-config'] })
     },
   })
 }

--- a/admin-ui/src/hooks/use-url-state.ts
+++ b/admin-ui/src/hooks/use-url-state.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * 把筛选态同步进 URL hash 的查询串：`#/traces?status=error&range=60`。
+ *
+ * 为什么值得做：排查问题时最自然的动作是把当前视图甩给同事 —— "你看这个"。
+ * 筛选态只存在组件 state 里的话，链接过去是一个默认视图，对方得照着描述重设一遍
+ * 筛选条件。顺带解决刷新页面丢筛选、浏览器后退不回上一组条件。
+ *
+ * 用 `replaceState` 而非直接改 `location.hash`：
+ * - 不触发 hashchange，App 的 Tab 路由不会被误伤
+ * - 连续输入搜索词不会往历史栈里塞几十条记录
+ *
+ * 只写非默认值，URL 保持干净：默认视图的地址就是 `#/traces`。
+ */
+export function useUrlState<T extends Record<string, string>>(
+  tab: string,
+  defaults: T,
+): [T, (patch: Partial<T>) => void, () => void] {
+  const [state, setState] = useState<T>(() => readFromHash(defaults))
+
+  // 浏览器前进 / 后退时跟随 URL 回到对应筛选态
+  useEffect(() => {
+    const onHash = () => setState(readFromHash(defaults))
+    window.addEventListener('hashchange', onHash)
+    return () => window.removeEventListener('hashchange', onHash)
+    // defaults 是模块级常量，不参与依赖
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const write = useCallback(
+    (next: T) => {
+      const params = new URLSearchParams()
+      for (const [k, v] of Object.entries(next)) {
+        // 只跟默认值比较，不额外跳过空串：空串可能本身就是一个有意义的选择。
+        // 日志页「不限时间」就是 range=''，而默认是 '1440'——若把空串一并跳过，
+        // 这个选择进不了 URL，刷新后会静默弹回 24 小时。
+        if (v !== defaults[k]) params.set(k, v)
+      }
+      const qs = params.toString()
+      const url = `${window.location.pathname}${window.location.search}#/${tab}${qs ? `?${qs}` : ''}`
+      window.history.replaceState(null, '', url)
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tab],
+  )
+
+  const patch = useCallback(
+    (p: Partial<T>) => {
+      setState((prev) => {
+        const next = { ...prev, ...p }
+        write(next)
+        return next
+      })
+    },
+    [write],
+  )
+
+  const reset = useCallback(() => {
+    setState(defaults)
+    write(defaults)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [write])
+
+  return [state, patch, reset]
+}
+
+function readFromHash<T extends Record<string, string>>(defaults: T): T {
+  const hash = window.location.hash
+  const qIndex = hash.indexOf('?')
+  if (qIndex < 0) return { ...defaults }
+  const params = new URLSearchParams(hash.slice(qIndex + 1))
+  const out = { ...defaults }
+  for (const key of Object.keys(defaults)) {
+    const v = params.get(key)
+    if (v != null) out[key as keyof T] = v as T[keyof T]
+  }
+  return out
+}
+
+/** 从 hash 中取出 Tab 名，忽略查询串。App 的路由与本 hook 共用这一份解析。 */
+export function tabFromHash(): string {
+  const raw = window.location.hash.replace(/^#\/?/, '')
+  const qIndex = raw.indexOf('?')
+  return qIndex >= 0 ? raw.slice(0, qIndex) : raw
+}

--- a/admin-ui/src/index.css
+++ b/admin-ui/src/index.css
@@ -26,6 +26,13 @@
     --input: 220 13% 88%;
     --ring: 211 100% 50%;
     --radius: 0.875rem;
+
+    /* 状态色轨 —— 三个页面共用的一套异常语言。
+       amber 与 orange 分开是有信息量的：冷却会自己恢复，超额不会。 */
+    --rail-ok: 160 84% 39%;
+    --rail-warn: 38 92% 50%;
+    --rail-cool: 25 95% 53%;
+    --rail-dead: 4 100% 59%;
   }
 
   .dark {
@@ -49,6 +56,11 @@
     --border: 220 14% 22%;
     --input: 220 14% 22%;
     --ring: 211 100% 60%;
+
+    --rail-ok: 160 84% 45%;
+    --rail-warn: 38 92% 55%;
+    --rail-cool: 25 95% 58%;
+    --rail-dead: 4 90% 62%;
   }
 }
 
@@ -137,6 +149,26 @@
     box-shadow: inset 0 -1px 0 0 hsl(var(--border) / 0.7);
   }
 
+  /* 可用模型铭牌逐行入场：与图表同一条 Apple 缓动曲线 */
+  .spec-row-in {
+    animation: spec-row-in 320ms cubic-bezier(0.32, 0.72, 0, 1) both;
+  }
+  @keyframes spec-row-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .spec-row-in {
+      animation: none;
+    }
+  }
+
   /* 趋势图 range 切换时的开屏动画：fade + slight slide-up */
   .chart-range-fade {
     animation: chart-range-fade 280ms cubic-bezier(0.32, 0.72, 0, 1) both;
@@ -153,6 +185,139 @@
   }
   @media (prefers-reduced-motion: reduce) {
     .chart-range-fade {
+      animation: none;
+    }
+  }
+}
+
+/* ============================================================
+   Console 密度层
+   ------------------------------------------------------------
+   卡片是"看"的（rounded-2xl / h-10 / 舒适间距），表格是"做"的。
+   两种密度并存，不互相覆盖：本层只作用于 .console-* 作用域内，
+   避免与现有组件的 padding / radius 打架。
+   ============================================================ */
+@layer components {
+  .console-scope {
+    /* 数据列专用字族：ID / token / credit / 耗时 / 时间戳 靠它纵向对齐。
+       运维表格能否快速扫读，前提就是数字对齐。 */
+    --font-console: ui-monospace, "SF Mono", "JetBrains Mono", "Menlo",
+      "Cascadia Mono", monospace;
+  }
+
+  /* 数值 / 标识符单元格 */
+  .console-num {
+    font-family: var(--font-console);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+  }
+
+  /* 密集表格骨架 */
+  .console-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    text-align: left;
+    font-size: 12.5px;
+    line-height: 1.35;
+  }
+  .console-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    height: 30px;
+    padding: 0 10px;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--card));
+    box-shadow: inset 0 -1px 0 0 hsl(var(--border) / 0.8);
+    white-space: nowrap;
+  }
+  .console-table tbody td {
+    height: 34px;
+    padding: 0 10px;
+    box-shadow: inset 0 -1px 0 0 hsl(var(--border) / 0.4);
+    white-space: nowrap;
+  }
+  .console-table tbody tr:hover td {
+    background: hsl(var(--accent) / 0.45);
+  }
+  /* 键盘游标行（j/k 导航）—— 比 hover 更实心，两者可叠加 */
+  .console-table tbody tr[data-cursor="true"] td {
+    background: hsl(var(--accent) / 0.75);
+  }
+  .console-table tbody tr[data-selected="true"] td {
+    background: hsl(var(--primary) / 0.09);
+  }
+  .console-table tbody tr[data-selected="true"]:hover td {
+    background: hsl(var(--primary) / 0.14);
+  }
+
+  /* 3px 左侧状态色轨：异常在三个页面里都是同一个信号 */
+  .console-rail {
+    box-shadow: inset 3px 0 0 0 var(--rail, transparent);
+  }
+  .rail-ok {
+    --rail: hsl(var(--rail-ok));
+  }
+  .rail-warn {
+    --rail: hsl(var(--rail-warn));
+  }
+  .rail-cool {
+    --rail: hsl(var(--rail-cool));
+  }
+  .rail-dead {
+    --rail: hsl(var(--rail-dead));
+  }
+
+  /* 行内操作：静默时不占视觉，hover / 焦点内才显形。
+     用 opacity 而非 display，避免 hover 时列宽跳动。 */
+  .console-row-actions {
+    opacity: 0;
+    transition: opacity 120ms ease-out;
+  }
+  tr:hover .console-row-actions,
+  tr:focus-within .console-row-actions,
+  tr[data-cursor="true"] .console-row-actions {
+    opacity: 1;
+  }
+
+  /* 吸底批量栏 */
+  .console-bulkbar {
+    animation: console-bulkbar-in 200ms cubic-bezier(0.32, 0.72, 0, 1) both;
+  }
+  @keyframes console-bulkbar-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* 右侧抽屉 */
+  .console-drawer {
+    animation: console-drawer-in 240ms cubic-bezier(0.32, 0.72, 0, 1) both;
+  }
+  @keyframes console-drawer-in {
+    from {
+      transform: translateX(16px);
+      opacity: 0;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .console-bulkbar,
+    .console-drawer {
       animation: none;
     }
   }

--- a/admin-ui/src/lib/credential-metadata-style.ts
+++ b/admin-ui/src/lib/credential-metadata-style.ts
@@ -1,0 +1,61 @@
+import type { CSSProperties } from 'react'
+
+const FORBIDDEN_VALUE_PATTERN = /url|@import|expression|javascript|[<>]/i
+const BLOCKED_PROPERTIES = new Set([
+  'position',
+  'z-index',
+  'inset',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'content',
+  'display',
+  'visibility',
+  'pointer-events',
+  'transform',
+  'animation',
+  'transition',
+])
+
+export function validateMetadataCss(css: string): string | null {
+  const source = css.trim()
+  if (!source) return null
+  if (source.length > 1000) return '自定义 CSS 不能超过 1000 个字符'
+  if (FORBIDDEN_VALUE_PATTERN.test(source)) {
+    return '自定义 CSS 不允许外链、脚本表达式或 HTML 标签'
+  }
+
+  for (const declaration of source.split(';').map((item) => item.trim()).filter(Boolean)) {
+    const colon = declaration.indexOf(':')
+    if (colon <= 0 || !declaration.slice(colon + 1).trim()) {
+      return `CSS 声明格式不正确：${declaration}`
+    }
+    const property = declaration.slice(0, colon).trim().toLowerCase()
+    if (!/^(--[a-z0-9_-]+|-?[a-z][a-z0-9_-]*)$/.test(property)) {
+      return `CSS 属性名不正确：${property}`
+    }
+    if (BLOCKED_PROPERTIES.has(property)) {
+      return `不允许使用可能破坏页面布局的 CSS 属性：${property}`
+    }
+  }
+  return null
+}
+
+function toReactProperty(property: string): string {
+  if (property.startsWith('--')) return property
+  const camel = property.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase())
+  return camel.startsWith('webkit') ? `W${camel.slice(1)}` : camel
+}
+
+export function metadataCssToStyle(css?: string): CSSProperties | undefined {
+  if (!css?.trim() || validateMetadataCss(css)) return undefined
+  const style: Record<string, string> = {}
+  for (const declaration of css.split(';').map((item) => item.trim()).filter(Boolean)) {
+    const colon = declaration.indexOf(':')
+    const property = declaration.slice(0, colon).trim()
+    const value = declaration.slice(colon + 1).trim()
+    style[toReactProperty(property)] = value
+  }
+  return style as CSSProperties
+}

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -66,6 +66,8 @@ export interface CredentialStatusItem {
   provider?: string | null
   hasProfileArn: boolean
   email?: string
+  /** 后端持久化的最近一次订阅等级；封禁时仍可显示。 */
+  subscriptionTitle?: string | null
   refreshTokenHash?: string
   apiKeyHash?: string
   maskedApiKey?: string

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -26,6 +26,8 @@ export interface CredentialMetadataDisplay {
   title: string
   description?: string
   value: unknown
+  /** Schema oneOf 中匹配 value 的显示名（如 "normal" → "正常号"），无命中时为 undefined。 */
+  valueLabel?: string
 }
 
 /** 状态接口中的 metadata：字段 key 映射到其描述与当前值。 */

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -21,6 +21,16 @@ export interface CredentialMetadata {
   [key: string]: unknown
 }
 
+/** `/api/admin/credentials` 返回的单个 metadata 字段。 */
+export interface CredentialMetadataDisplay {
+  title: string
+  description?: string
+  value: unknown
+}
+
+/** 状态接口中的 metadata：字段 key 映射到其描述与当前值。 */
+export type CredentialStatusMetadata = Record<string, CredentialMetadataDisplay>
+
 export interface CredentialMetadataSchemaOption {
   const: unknown
   title: string
@@ -84,8 +94,8 @@ export interface CredentialStatusItem {
   groups?: string[]
   /** 账号来源渠道（纯备注） */
   sourceChannel?: string
-  /** 可扩展的凭据元数据 */
-  metadata: CredentialMetadata
+  /** 已关联描述与当前值的凭据 metadata。 */
+  metadata: CredentialStatusMetadata
   /** 后端缓存的最近一次余额（5 分钟内） */
   balance?: BalanceResponse
   /** 余额缓存的更新时间（Unix 秒） */

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -10,10 +10,14 @@ export interface CredentialsStatusResponse {
 }
 
 export type CredentialType = 'normal' | 'boom'
+export type CredentialSaleStatus = 'not_for_sale' | 'for_sale' | 'sold'
 
-/** 可扩展的凭据元数据；type 是固定字段，其余键由后端原样保存。 */
+/** 可扩展的凭据元数据；type 和 saleStatus 是固定字段，其余键由后端原样保存。 */
 export interface CredentialMetadata {
   type: CredentialType
+  saleStatus: CredentialSaleStatus
+  /** 人民币销售价格；未设置时不展示。 */
+  salePrice?: number
   [key: string]: unknown
 }
 
@@ -27,7 +31,10 @@ export interface CredentialMetadataFieldSchema {
   description?: string
   type: 'string' | 'number' | 'integer' | 'boolean'
   default?: unknown
+  minimum?: number
   oneOf?: CredentialMetadataSchemaOption[]
+  /** 应用于卡片字段值的安全内联 CSS 声明。 */
+  'x-css'?: string
 }
 
 export interface CredentialMetadataSchema {

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -4,7 +4,44 @@ export interface CredentialsStatusResponse {
   available: number
   /** 优先级模式下的当前优先凭据 ID；均衡模式为 0 */
   currentId: number
+  /** 描述 metadata 字段、值类型和选项的 JSON Schema */
+  metadataSchema: CredentialMetadataSchema
   credentials: CredentialStatusItem[]
+}
+
+export type CredentialType = 'normal' | 'boom'
+
+/** 可扩展的凭据元数据；type 是固定字段，其余键由后端原样保存。 */
+export interface CredentialMetadata {
+  type: CredentialType
+  [key: string]: unknown
+}
+
+export interface CredentialMetadataSchemaOption {
+  const: unknown
+  title: string
+}
+
+export interface CredentialMetadataFieldSchema {
+  title: string
+  description?: string
+  type: 'string' | 'number' | 'integer' | 'boolean'
+  default?: unknown
+  oneOf?: CredentialMetadataSchemaOption[]
+}
+
+export interface CredentialMetadataSchema {
+  $schema?: string
+  $id?: string
+  title?: string
+  type: 'object'
+  properties: Record<string, CredentialMetadataFieldSchema>
+  required?: string[]
+  additionalProperties: boolean
+}
+
+export interface CredentialMetadataSchemaConfig {
+  schema: CredentialMetadataSchema
 }
 
 // 单个凭据状态
@@ -38,6 +75,8 @@ export interface CredentialStatusItem {
   groups?: string[]
   /** 账号来源渠道（纯备注） */
   sourceChannel?: string
+  /** 可扩展的凭据元数据 */
+  metadata: CredentialMetadata
   /** 后端缓存的最近一次余额（5 分钟内） */
   balance?: BalanceResponse
   /** 余额缓存的更新时间（Unix 秒） */
@@ -141,6 +180,7 @@ export interface AddCredentialRequest {
   email?: string
   groups?: string[]
   sourceChannel?: string
+  metadata?: CredentialMetadata
 }
 
 // 添加凭据响应
@@ -161,6 +201,8 @@ export interface UpdateCredentialRequest {
   groups?: string[]
   /** 账号来源渠道（undefined 表示不修改，空串表示清除） */
   sourceChannel?: string
+  /** 整体更新 metadata；调用方应保留不认识的扩展字段 */
+  metadata?: CredentialMetadata
 }
 
 // 更新 refreshToken 请求

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -312,12 +312,13 @@ export interface AssignRoundRobinResponse {
 export interface GlobalProxyResponse {
   proxyUrl: string | null
   proxyUsername: string | null
-  proxyPassword: string | null
+  proxyPasswordSet: boolean
 }
 
 export interface SetGlobalProxyRequest {
   proxyUrl: string | null
   proxyUsername?: string | null
+  /** Omit to preserve the existing password; send null to clear it. */
   proxyPassword?: string | null
 }
 

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -637,6 +637,19 @@ export interface FailureStats {
 /** credentialId(字符串) → 失败分类计数 */
 export type FailureStatsMap = Record<string, FailureStats>
 
+// ============ 自定义模型 ============
+
+/** 单条自定义模型（与 config.json customModels 数组一一对应） */
+export interface CustomModelItem {
+  id: string
+  backendId: string
+  displayName?: string
+  contextWindow?: number
+  maxTokens?: number
+  supportsReasoning?: boolean
+  ownedBy?: string
+}
+
 // ============ 账号分组（独立实体）============
 
 export interface GroupItem {

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -544,6 +544,12 @@ export interface TraceQuery {
   /** 按账号分组名筛选（只返回 final_credential_id 属于该分组的 trace） */
   group?: string
   onlyFailed?: boolean
+  /** 时间窗口起点（Unix 秒，含）。与后端 traces.ts_epoch 同单位 */
+  startTime?: number
+  /** 时间窗口终点（Unix 秒，含） */
+  endTime?: number
+  /** 关键字模糊匹配：模型名 / traceId / 错误信息 */
+  q?: string
   limit?: number
   offset?: number
 }

--- a/admin-ui/src/types/api.ts
+++ b/admin-ui/src/types/api.ts
@@ -309,10 +309,14 @@ export interface AssignRoundRobinResponse {
 // 全局代理配置
 export interface GlobalProxyResponse {
   proxyUrl: string | null
+  proxyUsername: string | null
+  proxyPassword: string | null
 }
 
 export interface SetGlobalProxyRequest {
   proxyUrl: string | null
+  proxyUsername?: string | null
+  proxyPassword?: string | null
 }
 
 // 在线更新配置

--- a/admin-ui/vite.config.ts
+++ b/admin-ui/vite.config.ts
@@ -11,10 +11,22 @@ export default defineConfig({
     },
   },
   server: {
+    // 监听所有网卡，方便从局域网 / 其它设备访问同一个 dev server
+    host: '0.0.0.0',
+    port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        // 默认本地后端。要打线上：
+        //   KIRO_API_TARGET=https://kiro.linkof.link bun run dev
+        // 线上域名在 Cloudflare 后面，TLS 握手缺 SNI 会被直接断连
+        // （"Client network socket disconnected before secure TLS connection"），
+        // http-proxy 不会自动从 target 推导 servername，所以显式给出。
+        target: process.env.KIRO_API_TARGET || 'http://localhost:8080',
         changeOrigin: true,
+        secure: true,
+        servername: process.env.KIRO_API_TARGET
+          ? new URL(process.env.KIRO_API_TARGET).hostname
+          : undefined,
       },
     },
   },

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -31,6 +31,7 @@ use super::{
         SetUpdateConfigRequest, StartIdcLoginRequest, StartSocialLoginRequest, SuccessResponse,
         UpdateAdminKeyRequest, UpdateClientKeyRequest, UpdateCredentialRequest,
         UpdateRefreshTokenRequest,
+        SetCustomModelsRequest,
     },
     usage_stats::{Range, StatsGranularity, StatsQueryWindow},
 };
@@ -728,6 +729,24 @@ pub async fn set_global_proxy(
         .set_global_proxy(payload.proxy_url, payload.proxy_username, payload.proxy_password)
     {
         Ok(_) => Json(SuccessResponse::new("全局代理已更新")).into_response(),
+        Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
+    }
+}
+
+/// GET /api/admin/config/custom-models
+/// 获取所有自定义模型配置
+pub async fn get_custom_models(State(state): State<AdminState>) -> impl IntoResponse {
+    Json(state.service.get_custom_models())
+}
+
+/// PUT /api/admin/config/custom-models
+/// 批量替换自定义模型配置（运行时热更新 + 持久化 config.json）
+pub async fn set_custom_models(
+    State(state): State<AdminState>,
+    Json(payload): Json<SetCustomModelsRequest>,
+) -> impl IntoResponse {
+    match state.service.set_custom_models(payload) {
+        Ok(response) => Json(response).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }
 }

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -23,6 +23,7 @@ use super::{
         BatchAddProxyRequest, BatchImportEvent, BatchImportRequest, BatchImportSummary,
         ClientKeyItem, ClientKeysResponse, CompleteSocialLoginRequest, CreateClientKeyRequest,
         CreateClientKeyResponse, GlobalProxyResponse, ModelTestRequest,
+        CredentialMetadataSchemaConfig,
         SetAccountRpmLimitConfigRequest, SetAccountThrottleConfigRequest, SetDisabledRequest,
         SetGlobalProxyRequest,
         SetLoadBalancingModeRequest, SetLogGovernanceConfigRequest, SetPriorityRequest,
@@ -42,6 +43,24 @@ type CredSessionPath = (u64, String);
 pub async fn get_all_credentials(State(state): State<AdminState>) -> impl IntoResponse {
     let response = state.service.get_all_credentials();
     Json(response)
+}
+
+/// GET /api/admin/config/credential-metadata-schema
+pub async fn get_credential_metadata_schema(
+    State(state): State<AdminState>,
+) -> impl IntoResponse {
+    Json(state.service.get_credential_metadata_schema())
+}
+
+/// PUT /api/admin/config/credential-metadata-schema
+pub async fn set_credential_metadata_schema(
+    State(state): State<AdminState>,
+    Json(payload): Json<CredentialMetadataSchemaConfig>,
+) -> impl IntoResponse {
+    match state.service.set_credential_metadata_schema(payload) {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => (error.status_code(), Json(error.into_response())).into_response(),
+    }
 }
 
 /// GET /api/admin/credentials/export

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -22,7 +22,7 @@ use super::{
         AddCredentialRequest, AddProxyRequest, AssignProxyRequest, AssignRoundRobinRequest,
         BatchAddProxyRequest, BatchImportEvent, BatchImportRequest, BatchImportSummary,
         ClientKeyItem, ClientKeysResponse, CompleteSocialLoginRequest, CreateClientKeyRequest,
-        CreateClientKeyResponse, GlobalProxyResponse, ModelTestRequest,
+        CreateClientKeyResponse, ModelTestRequest,
         CredentialMetadataSchemaConfig,
         SetAccountRpmLimitConfigRequest, SetAccountThrottleConfigRequest, SetDisabledRequest,
         SetGlobalProxyRequest,
@@ -714,9 +714,7 @@ pub async fn complete_social_login(
 /// GET /api/admin/config/global-proxy
 /// 获取当前全局代理配置
 pub async fn get_global_proxy(State(state): State<AdminState>) -> impl IntoResponse {
-    Json(GlobalProxyResponse {
-        proxy_url: state.service.get_global_proxy(),
-    })
+    Json(state.service.get_global_proxy())
 }
 
 /// PUT /api/admin/config/global-proxy
@@ -725,7 +723,10 @@ pub async fn set_global_proxy(
     State(state): State<AdminState>,
     Json(payload): Json<SetGlobalProxyRequest>,
 ) -> impl IntoResponse {
-    match state.service.set_global_proxy(payload.proxy_url) {
+    match state
+        .service
+        .set_global_proxy(payload.proxy_url, payload.proxy_username, payload.proxy_password)
+    {
         Ok(_) => Json(SuccessResponse::new("全局代理已更新")).into_response(),
         Err(e) => (e.status_code(), Json(e.into_response())).into_response(),
     }

--- a/src/admin/handlers.rs
+++ b/src/admin/handlers.rs
@@ -1298,7 +1298,8 @@ pub async fn stats_by_credential(
 
 /// GET /api/admin/traces
 /// 查询请求链路追踪记录（含每跳明细）。
-/// query 参数：status / errorType / credentialId / keyId / group / model / onlyFailed / limit / offset
+/// query 参数：status / errorType / credentialId / keyId / group / model / onlyFailed /
+///            startTime / endTime（Unix 秒）/ q（关键字）/ limit / offset
 /// 返回：{ records: [...], total: N }
 pub async fn list_traces(
     State(state): State<AdminState>,
@@ -1336,6 +1337,13 @@ pub async fn list_traces(
             .map(|s| s == "true" || s == "1")
             .unwrap_or(false),
         credential_ids,
+        // startTime / endTime 为 Unix 秒，与 traces.ts_epoch 同单位
+        start_ts: params.get("startTime").and_then(|s| s.parse::<i64>().ok()),
+        end_ts: params.get("endTime").and_then(|s| s.parse::<i64>().ok()),
+        keyword: params
+            .get("q")
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
         limit: params
             .get("limit")
             .and_then(|s| s.parse::<usize>().ok())

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -16,15 +16,16 @@ use super::{
         delete_credential, delete_group, delete_proxy, disable_quota_exceeded, enable_overage_all,
         export_credentials, force_refresh_token, get_account_rpm_limit_config,
         get_account_throttle_config, get_all_credentials,
-        get_credential_balance, get_credential_models, get_current_models, get_global_proxy,
+        get_credential_balance, get_credential_metadata_schema, get_credential_models,
+        get_current_models, get_global_proxy,
         get_load_balancing_mode, get_log_governance_config, get_proxy_pool, get_self_heal_config,
         get_update_config, list_client_keys, list_groups, list_traces, poll_idc_login,
         poll_idc_relogin, poll_social_login, poll_social_relogin, pull_update_image,
         reset_all_success_count, reset_client_key_stats, reset_failure_count, reset_success_count,
         rollback_image_update, rotate_client_key, set_account_rpm_limit_config,
-        set_account_throttle_config,
-        set_client_key_disabled, set_credential_disabled, set_credential_overage,
-        set_credential_priority, set_global_proxy, set_load_balancing_mode,
+        set_account_throttle_config, set_client_key_disabled, set_credential_disabled,
+        set_credential_metadata_schema, set_credential_overage, set_credential_priority,
+        set_global_proxy, set_load_balancing_mode,
         set_log_governance_config, set_proxy_enabled, set_self_heal_config, set_update_config,
         start_idc_login, start_idc_relogin, start_social_login, start_social_relogin,
         stats_by_credential, stats_by_model, stats_overview, stats_timeseries, test_model,
@@ -121,6 +122,10 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route(
             "/config/log-governance",
             get(get_log_governance_config).put(set_log_governance_config),
+        )
+        .route(
+            "/config/credential-metadata-schema",
+            get(get_credential_metadata_schema).put(set_credential_metadata_schema),
         )
         .route(
             "/config/global-proxy",

--- a/src/admin/router.rs
+++ b/src/admin/router.rs
@@ -17,7 +17,7 @@ use super::{
         export_credentials, force_refresh_token, get_account_rpm_limit_config,
         get_account_throttle_config, get_all_credentials,
         get_credential_balance, get_credential_metadata_schema, get_credential_models,
-        get_current_models, get_global_proxy,
+        get_current_models, get_global_proxy, get_custom_models,
         get_load_balancing_mode, get_log_governance_config, get_proxy_pool, get_self_heal_config,
         get_update_config, list_client_keys, list_groups, list_traces, poll_idc_login,
         poll_idc_relogin, poll_social_login, poll_social_relogin, pull_update_image,
@@ -25,7 +25,7 @@ use super::{
         rollback_image_update, rotate_client_key, set_account_rpm_limit_config,
         set_account_throttle_config, set_client_key_disabled, set_credential_disabled,
         set_credential_metadata_schema, set_credential_overage, set_credential_priority,
-        set_global_proxy, set_load_balancing_mode,
+        set_custom_models, set_global_proxy, set_load_balancing_mode,
         set_log_governance_config, set_proxy_enabled, set_self_heal_config, set_update_config,
         start_idc_login, start_idc_relogin, start_social_login, start_social_relogin,
         stats_by_credential, stats_by_model, stats_overview, stats_timeseries, test_model,
@@ -130,6 +130,10 @@ pub fn create_admin_router(state: AdminState) -> Router {
         .route(
             "/config/global-proxy",
             get(get_global_proxy).put(set_global_proxy),
+        )
+        .route(
+            "/config/custom-models",
+            get(get_custom_models).put(set_custom_models),
         )
         .route(
             "/config/update",

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -40,7 +40,8 @@ use super::types::{
     AssignRoundRobinResponse, AvailableModelItem, AvailableModelsResponse, BalanceResponse,
     BatchAddProxyRequest, BatchImportEvent, CheckRateLimitRequest, CredentialMetadataDetail,
     CredentialStatusItem,
-    CredentialsExportResponse, CredentialsStatusResponse, EnableOverageAllResult, ExportedAccount,
+    CredentialsExportResponse, CredentialsStatusResponse, CustomModelsConfigResponse, CustomModelItem,
+    EnableOverageAllResult, ExportedAccount,
     ExportedCredentials, GitHubRateLimitInfo, ImageUpdateResponse, LoadBalancingModeResponse,
     CredentialMetadataSchemaConfig,
     LogGovernanceConfigResponse, ModelSelectionMode, ModelTestRequest, ModelTestResponse,
@@ -48,7 +49,7 @@ use super::types::{
     ProxyPoolResponse, QuotaExceededResult, SelfHealConfigResponse,
     SetAccountRpmLimitConfigRequest, SetAccountThrottleConfigRequest, SetLoadBalancingModeRequest,
     SetLogGovernanceConfigRequest,
-    SetSelfHealConfigRequest, SetUpdateConfigRequest, StartIdcLoginRequest, StartIdcLoginResponse,
+    SetSelfHealConfigRequest, SetCustomModelsRequest, SetUpdateConfigRequest, StartIdcLoginRequest, StartIdcLoginResponse,
     StartSocialLoginRequest, StartSocialLoginResponse, UpdateCheckInfo, UpdateConfigResponse,
     UpdateCredentialRequest, UpdateRefreshTokenRequest,
 };
@@ -1637,6 +1638,74 @@ impl AdminService {
             c.proxy_password = password_for_save;
         });
         Ok(())
+    }
+
+    /// 获取所有自定义模型配置。
+    pub fn get_custom_models(&self) -> CustomModelsConfigResponse {
+        let models = crate::model::custom_models::all()
+            .into_iter()
+            .map(|m| CustomModelItem {
+                id: m.id,
+                backend_id: m.backend_id,
+                display_name: m.display_name,
+                context_window: m.context_window,
+                max_tokens: m.max_tokens,
+                supports_reasoning: m.supports_reasoning,
+                owned_by: m.owned_by,
+            })
+            .collect();
+        CustomModelsConfigResponse { models }
+    }
+
+    /// 批量替换自定义模型配置（校验 → 持久化 config.json → 热更新内存注册表）。
+    pub fn set_custom_models(
+        &self,
+        req: SetCustomModelsRequest,
+    ) -> Result<CustomModelsConfigResponse, AdminServiceError> {
+        // 校验必填字段
+        for (i, m) in req.models.iter().enumerate() {
+            if m.id.trim().is_empty() {
+                return Err(AdminServiceError::InvalidCredential(format!(
+                    "第 {} 条模型的 id 不能为空",
+                    i + 1
+                )));
+            }
+            if m.backend_id.trim().is_empty() {
+                return Err(AdminServiceError::InvalidCredential(format!(
+                    "第 {} 条模型（{}）的 backend_id 不能为空",
+                    i + 1,
+                    m.id
+                )));
+            }
+        }
+
+        // 转换为 config::CustomModel 并持久化
+        let custom_models: Vec<crate::model::config::CustomModel> = req
+            .models
+            .into_iter()
+            .map(|m| crate::model::config::CustomModel {
+                id: m.id,
+                backend_id: m.backend_id,
+                display_name: m.display_name,
+                context_window: m.context_window,
+                max_tokens: m.max_tokens,
+                supports_reasoning: m.supports_reasoning,
+                owned_by: m.owned_by,
+            })
+            .collect();
+
+        let models_for_config = custom_models.clone();
+        self.update_config_file(move |c| {
+            c.custom_models = models_for_config;
+        });
+
+        // 热更新内存注册表
+        crate::model::custom_models::init(custom_models);
+
+        // 使所有已缓存的模型列表失效，确保下次查询反映最新自定义模型
+        self.token_manager.invalidate_all_model_caches();
+
+        Ok(self.get_custom_models())
     }
 
     /// 持久化新的登录API密钥（adminApiKey）到配置文件（内存中的 key 由 handler 层负责更新）

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -15,7 +15,7 @@ use crate::kiro::auth::social;
 use crate::kiro::error::UpstreamRateLimitError;
 use crate::kiro::model::available_models::ListAvailableModelsResponse;
 use crate::kiro::model::credentials::{
-    KiroCredentials, credential_metadata_schema, normalize_credential_metadata_schema,
+    CredentialMetadata, KiroCredentials, credential_metadata_schema, normalize_credential_metadata_schema,
     normalize_import_auth_method, validate_credential_metadata,
     validate_credential_metadata_schema, validate_external_idp_endpoint,
 };
@@ -37,7 +37,8 @@ use super::types::{
     AccountRpmLimitConfigResponse, AccountThrottleConfigResponse, AddCredentialRequest,
     AddCredentialResponse, AssignProxyRequest,
     AssignRoundRobinResponse, AvailableModelItem, AvailableModelsResponse, BalanceResponse,
-    BatchAddProxyRequest, BatchImportEvent, CheckRateLimitRequest, CredentialStatusItem,
+    BatchAddProxyRequest, BatchImportEvent, CheckRateLimitRequest, CredentialMetadataDetail,
+    CredentialStatusItem,
     CredentialsExportResponse, CredentialsStatusResponse, EnableOverageAllResult, ExportedAccount,
     ExportedCredentials, GitHubRateLimitInfo, ImageUpdateResponse, LoadBalancingModeResponse,
     CredentialMetadataSchemaConfig,
@@ -53,6 +54,65 @@ use super::types::{
 
 /// 余额缓存过期时间（秒），5 分钟
 const BALANCE_CACHE_TTL_SECS: i64 = 300;
+
+/// 将原始 metadata 与 schema 合并为客户端可直接消费的字段列表。
+///
+/// Schema 字段保持其配置顺序，未登记的扩展字段按 key 排序追加；旧凭据缺失的字段
+/// 使用 schema 默认值，既避免客户端重复做 join，也不会丢掉自定义 metadata。
+fn credential_metadata_details(
+    metadata: &CredentialMetadata,
+    schema: &serde_json::Value,
+) -> Vec<CredentialMetadataDetail> {
+    let values = match serde_json::to_value(metadata)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+    {
+        Some(values) => values,
+        None => return Vec::new(),
+    };
+    let properties = schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object);
+
+    let mut keys: Vec<String> = properties
+        .map(|fields| fields.keys().cloned().collect())
+        .unwrap_or_default();
+    let mut extra_keys: Vec<String> = values
+        .keys()
+        .filter(|key| !properties.is_some_and(|fields| fields.contains_key(*key)))
+        .cloned()
+        .collect();
+    extra_keys.sort();
+    keys.extend(extra_keys);
+
+    keys.into_iter()
+        .filter_map(|key| {
+            let field = properties.and_then(|fields| fields.get(&key));
+            let value = values.get(&key).cloned().or_else(|| {
+                field.and_then(|schema_field| schema_field.get("default").cloned())
+            })?;
+            let title = field
+                .and_then(|schema_field| schema_field.get("title"))
+                .and_then(serde_json::Value::as_str)
+                .filter(|title| !title.trim().is_empty())
+                .map(str::to_owned)
+                .unwrap_or_else(|| key.clone());
+            let description = field
+                .and_then(|schema_field| schema_field.get("description"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|description| !description.is_empty())
+                .map(str::to_owned);
+
+            Some(CredentialMetadataDetail {
+                key,
+                title,
+                description,
+                value,
+            })
+        })
+        .collect()
+}
 
 /// 在线检查更新结果缓存时间（秒），30 分钟。
 /// 在线检查更新结果缓存时间（秒），30 分钟。
@@ -642,6 +702,7 @@ impl AdminService {
             snapshot.current_id
         };
         let default_endpoint = self.token_manager.config().default_endpoint.clone();
+        let metadata_schema = self.credential_metadata_schema.lock().clone();
 
         // 一次性快照余额缓存，避免 N 次加锁
         let balance_snapshot: HashMap<u64, CachedBalance> = {
@@ -659,6 +720,8 @@ impl AdminService {
                     .filter(|c| (now_ts - c.cached_at) < BALANCE_CACHE_TTL_SECS as f64)
                     .map(|c| (Some(c.data.clone()), Some(c.cached_at)))
                     .unwrap_or((None, None));
+                let metadata_details =
+                    credential_metadata_details(&entry.metadata, &metadata_schema);
 
                 CredentialStatusItem {
                     id: entry.id,
@@ -686,6 +749,7 @@ impl AdminService {
                     groups: entry.groups,
                     source_channel: entry.source_channel,
                     metadata: entry.metadata,
+                    metadata_details,
                     balance,
                     balance_updated_at,
                     created_at: entry.created_at,
@@ -700,7 +764,7 @@ impl AdminService {
             total: snapshot.total,
             available: snapshot.available,
             current_id: exposed_current_id,
-            metadata_schema: self.credential_metadata_schema.lock().clone(),
+            metadata_schema,
             credentials,
         }
     }
@@ -3475,6 +3539,30 @@ mod tests {
         assert!(validate_model_id("auto").is_err());
         assert!(validate_model_id("AUTO").is_err());
         assert!(validate_model_id(&"x".repeat(257)).is_err());
+    }
+
+    #[test]
+    fn metadata_details_include_schema_description_and_current_value() {
+        let mut metadata = CredentialMetadata::default();
+        metadata
+            .extra
+            .insert("region".to_string(), serde_json::json!("us-east-1"));
+        let mut schema = credential_metadata_schema();
+        schema["properties"]["region"] = serde_json::json!({
+            "title": "区域",
+            "description": "凭据所属区域",
+            "type": "string"
+        });
+
+        let details = credential_metadata_details(&metadata, &schema);
+        let region = details
+            .iter()
+            .find(|detail| detail.key == "region")
+            .expect("应返回扩展 metadata 字段");
+
+        assert_eq!(region.title, "区域");
+        assert_eq!(region.description.as_deref(), Some("凭据所属区域"));
+        assert_eq!(region.value, serde_json::json!("us-east-1"));
     }
 
     #[tokio::test]

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -104,6 +104,21 @@ fn credential_metadata_details(
                 .map(str::trim)
                 .filter(|description| !description.is_empty())
                 .map(str::to_owned);
+            let value_label = field
+                .and_then(|schema_field| schema_field.get("oneOf"))
+                .and_then(serde_json::Value::as_array)
+                .and_then(|options| {
+                    options.iter().find_map(|opt| {
+                        let konst = opt.get("const")?;
+                        if konst == &value {
+                            opt.get("title")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_owned)
+                        } else {
+                            None
+                        }
+                    })
+                });
 
             Some((
                 key,
@@ -111,6 +126,7 @@ fn credential_metadata_details(
                     title,
                     description,
                     value,
+                    value_label,
                 },
             ))
         })

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -1,6 +1,6 @@
 //! Admin API 业务逻辑服务
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -62,13 +62,13 @@ const BALANCE_CACHE_TTL_SECS: i64 = 300;
 fn credential_metadata_details(
     metadata: &CredentialMetadata,
     schema: &serde_json::Value,
-) -> Vec<CredentialMetadataDetail> {
+) -> BTreeMap<String, CredentialMetadataDetail> {
     let values = match serde_json::to_value(metadata)
         .ok()
         .and_then(|value| value.as_object().cloned())
     {
         Some(values) => values,
-        None => return Vec::new(),
+        None => return BTreeMap::new(),
     };
     let properties = schema
         .get("properties")
@@ -104,12 +104,14 @@ fn credential_metadata_details(
                 .filter(|description| !description.is_empty())
                 .map(str::to_owned);
 
-            Some(CredentialMetadataDetail {
+            Some((
                 key,
-                title,
-                description,
-                value,
-            })
+                CredentialMetadataDetail {
+                    title,
+                    description,
+                    value,
+                },
+            ))
         })
         .collect()
 }
@@ -720,8 +722,7 @@ impl AdminService {
                     .filter(|c| (now_ts - c.cached_at) < BALANCE_CACHE_TTL_SECS as f64)
                     .map(|c| (Some(c.data.clone()), Some(c.cached_at)))
                     .unwrap_or((None, None));
-                let metadata_details =
-                    credential_metadata_details(&entry.metadata, &metadata_schema);
+                let metadata = credential_metadata_details(&entry.metadata, &metadata_schema);
 
                 CredentialStatusItem {
                     id: entry.id,
@@ -748,8 +749,7 @@ impl AdminService {
                     endpoint: entry.endpoint.unwrap_or_else(|| default_endpoint.clone()),
                     groups: entry.groups,
                     source_channel: entry.source_channel,
-                    metadata: entry.metadata,
-                    metadata_details,
+                    metadata,
                     balance,
                     balance_updated_at,
                     created_at: entry.created_at,
@@ -3555,10 +3555,7 @@ mod tests {
         });
 
         let details = credential_metadata_details(&metadata, &schema);
-        let region = details
-            .iter()
-            .find(|detail| detail.key == "region")
-            .expect("应返回扩展 metadata 字段");
+        let region = details.get("region").expect("应返回扩展 metadata 字段");
 
         assert_eq!(region.title, "区域");
         assert_eq!(region.description.as_deref(), Some("凭据所属区域"));

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -15,9 +15,9 @@ use crate::kiro::auth::social;
 use crate::kiro::error::UpstreamRateLimitError;
 use crate::kiro::model::available_models::ListAvailableModelsResponse;
 use crate::kiro::model::credentials::{
-    KiroCredentials, credential_metadata_schema, normalize_import_auth_method,
-    validate_credential_metadata, validate_credential_metadata_schema,
-    validate_external_idp_endpoint,
+    KiroCredentials, credential_metadata_schema, normalize_credential_metadata_schema,
+    normalize_import_auth_method, validate_credential_metadata,
+    validate_credential_metadata_schema, validate_external_idp_endpoint,
 };
 use crate::kiro::model::events::{Event, strip_tool_use_xml_leaks};
 use crate::kiro::model::requests::conversation::{
@@ -562,13 +562,19 @@ impl AdminService {
             .credential_metadata_schema
             .clone()
         {
-            Some(schema) => match validate_credential_metadata_schema(&schema) {
-                Ok(()) => schema,
-                Err(error) => {
-                    tracing::warn!("配置中的 credentialMetadataSchema 无效，回退内置值: {}", error);
-                    credential_metadata_schema()
+            Some(schema) => {
+                let schema = normalize_credential_metadata_schema(schema);
+                match validate_credential_metadata_schema(&schema) {
+                    Ok(()) => schema,
+                    Err(error) => {
+                        tracing::warn!(
+                            "配置中的 credentialMetadataSchema 无效，回退内置值: {}",
+                            error
+                        );
+                        credential_metadata_schema()
+                    }
                 }
-            },
+            }
             None => credential_metadata_schema(),
         };
 

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -675,6 +675,7 @@ impl AdminService {
                     api_key_hash: entry.api_key_hash,
                     masked_api_key: entry.masked_api_key,
                     email: entry.email,
+                    subscription_title: entry.subscription_title,
                     success_count: entry.success_count,
                     last_used_at: entry.last_used_at.clone(),
                     has_proxy: entry.has_proxy,

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -9,6 +9,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::admin::types::GlobalProxyResponse;
 use crate::http_client::ProxyConfig;
 use crate::kiro::auth::idc::{self, BUILDER_ID_START_URL};
 use crate::kiro::auth::social;
@@ -1571,13 +1572,23 @@ impl AdminService {
         }
     }
 
-    /// 获取全局代理 URL
-    pub fn get_global_proxy(&self) -> Option<String> {
-        self.token_manager.proxy().map(|p| p.url.clone())
+    /// 获取全局代理配置
+    pub fn get_global_proxy(&self) -> GlobalProxyResponse {
+        let proxy = self.token_manager.proxy();
+        GlobalProxyResponse {
+            proxy_url: proxy.as_ref().map(|p| p.url.clone()),
+            proxy_username: proxy.as_ref().and_then(|p| p.username.clone()),
+            proxy_password: proxy.as_ref().and_then(|p| p.password.clone()),
+        }
     }
 
-    /// 设置全局代理 URL（None 表示清除）并持久化到配置文件
-    pub fn set_global_proxy(&self, url: Option<String>) -> Result<(), AdminServiceError> {
+    /// 设置全局代理配置（None url 表示清除）并持久化到配置文件
+    pub fn set_global_proxy(
+        &self,
+        url: Option<String>,
+        username: Option<String>,
+        password: Option<String>,
+    ) -> Result<(), AdminServiceError> {
         if let Some(ref u) = url {
             let valid_prefix = u.starts_with("http://")
                 || u.starts_with("https://")
@@ -1591,12 +1602,24 @@ impl AdminService {
             }
         }
 
-        let proxy = url.as_deref().map(ProxyConfig::new);
+        let username_for_save = username.clone().filter(|s| !s.is_empty());
+        let password_for_save = password.clone().filter(|s| !s.is_empty());
+
+        let proxy = url.as_deref().map(|u| {
+            let mut cfg = ProxyConfig::new(u);
+            cfg.username = username_for_save.clone();
+            cfg.password = password_for_save.clone();
+            cfg
+        });
         self.token_manager.set_global_proxy(proxy);
 
         // 从磁盘加载最新 config 再写，避免覆盖其他字段的并发修改
         let url_for_save = url;
-        self.update_config_file(move |c| c.proxy_url = url_for_save);
+        self.update_config_file(move |c| {
+            c.proxy_url = url_for_save;
+            c.proxy_username = username_for_save;
+            c.proxy_password = password_for_save;
+        });
         Ok(())
     }
 

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -1595,7 +1595,7 @@ impl AdminService {
         GlobalProxyResponse {
             proxy_url: proxy.as_ref().map(|p| p.url.clone()),
             proxy_username: proxy.as_ref().and_then(|p| p.username.clone()),
-            proxy_password: proxy.as_ref().and_then(|p| p.password.clone()),
+            proxy_password_set: proxy.as_ref().and_then(|p| p.password.as_ref()).is_some(),
         }
     }
 
@@ -1604,23 +1604,35 @@ impl AdminService {
         &self,
         url: Option<String>,
         username: Option<String>,
-        password: Option<String>,
+        password: Option<Option<String>>,
     ) -> Result<(), AdminServiceError> {
         if let Some(ref u) = url {
-            let valid_prefix = u.starts_with("http://")
-                || u.starts_with("https://")
-                || u.starts_with("socks5://")
-                || u.starts_with("socks4://");
+            let normalized = u.to_ascii_lowercase();
+            let valid_prefix = [
+                "http://",
+                "https://",
+                "socks4://",
+                "socks4a://",
+                "socks5://",
+                "socks5h://",
+            ]
+            .iter()
+            .any(|scheme| normalized.starts_with(scheme));
             if !valid_prefix {
                 return Err(AdminServiceError::InvalidCredential(
-                    "代理 URL 格式无效，需以 http://、https://、socks5:// 或 socks4:// 开头"
+                    "代理 URL 格式无效，需以 http://、https://、socks4://、socks4a://、socks5:// 或 socks5h:// 开头"
                         .to_string(),
                 ));
             }
         }
 
         let username_for_save = username.clone().filter(|s| !s.is_empty());
-        let password_for_save = password.clone().filter(|s| !s.is_empty());
+        let current_password = self.token_manager.proxy().and_then(|proxy| proxy.password);
+        let password_for_save = match (url.as_ref(), password) {
+            (None, _) => None,
+            (Some(_), None) => current_password,
+            (Some(_), Some(value)) => value.filter(|s| !s.is_empty()),
+        };
 
         let proxy = url.as_deref().map(|u| {
             let mut cfg = ProxyConfig::new(u);
@@ -1628,15 +1640,16 @@ impl AdminService {
             cfg.password = password_for_save.clone();
             cfg
         });
-        self.token_manager.set_global_proxy(proxy);
-
-        // 从磁盘加载最新 config 再写，避免覆盖其他字段的并发修改
+        // 从磁盘加载最新 config 再写；持久化成功后才切换运行时代理，避免半更新。
         let url_for_save = url;
-        self.update_config_file(move |c| {
-            c.proxy_url = url_for_save;
-            c.proxy_username = username_for_save;
-            c.proxy_password = password_for_save;
-        });
+        self.token_manager
+            .update_config_file(move |c| {
+                c.proxy_url = url_for_save;
+                c.proxy_username = username_for_save;
+                c.proxy_password = password_for_save;
+            })
+            .map_err(|error| AdminServiceError::InternalError(error.to_string()))?;
+        self.token_manager.set_global_proxy(proxy);
         Ok(())
     }
 
@@ -1664,18 +1677,45 @@ impl AdminService {
     ) -> Result<CustomModelsConfigResponse, AdminServiceError> {
         // 校验必填字段
         for (i, m) in req.models.iter().enumerate() {
-            if m.id.trim().is_empty() {
+            let id = m.id.trim();
+            let backend_id = m.backend_id.trim();
+            if id.is_empty() || id.len() > 128 || id.chars().any(char::is_control) {
                 return Err(AdminServiceError::InvalidCredential(format!(
-                    "第 {} 条模型的 id 不能为空",
-                    i + 1
+                    "第 {} 条模型的 id 必须是 1-128 个非控制字符",
+                    i + 1,
                 )));
             }
-            if m.backend_id.trim().is_empty() {
+            if backend_id.is_empty() || backend_id.len() > 256 || backend_id.chars().any(char::is_control) {
                 return Err(AdminServiceError::InvalidCredential(format!(
-                    "第 {} 条模型（{}）的 backend_id 不能为空",
-                    i + 1,
-                    m.id
+                    "第 {} 条模型（{}）的 backend_id 必须是 1-256 个非控制字符",
+                    i + 1, id,
                 )));
+            }
+            if let Some(value) = m.context_window {
+                if !(1..=10_000_000).contains(&value) {
+                    return Err(AdminServiceError::InvalidCredential(format!(
+                        "第 {} 条模型的 contextWindow 必须在 1 到 10000000 之间",
+                        i + 1
+                    )));
+                }
+            }
+            if let Some(value) = m.max_tokens {
+                if !(1..=1_000_000).contains(&value) {
+                    return Err(AdminServiceError::InvalidCredential(format!(
+                        "第 {} 条模型的 maxTokens 必须在 1 到 1000000 之间",
+                        i + 1
+                    )));
+                }
+            }
+        }
+
+        let mut seen_ids = HashSet::new();
+        for model in &req.models {
+            let key = model.id.trim().to_ascii_lowercase();
+            if !seen_ids.insert(key) {
+                return Err(AdminServiceError::InvalidCredential(
+                    "自定义模型 id 不能重复（不区分大小写）".to_string(),
+                ));
             }
         }
 
@@ -1684,8 +1724,8 @@ impl AdminService {
             .models
             .into_iter()
             .map(|m| crate::model::config::CustomModel {
-                id: m.id,
-                backend_id: m.backend_id,
+                id: m.id.trim().to_string(),
+                backend_id: m.backend_id.trim().to_string(),
                 display_name: m.display_name,
                 context_window: m.context_window,
                 max_tokens: m.max_tokens,
@@ -3670,6 +3710,23 @@ mod tests {
         assert_eq!(region.title, "区域");
         assert_eq!(region.description.as_deref(), Some("凭据所属区域"));
         assert_eq!(region.value, serde_json::json!("us-east-1"));
+    }
+
+    #[tokio::test]
+    async fn global_proxy_response_redacts_password() {
+        let proxy = ProxyConfig::new("socks5h://127.0.0.1:1080").with_auth("user", "secret");
+        let manager = Arc::new(
+            MultiTokenManager::new(Config::default(), Vec::new(), Some(proxy), None, false)
+                .unwrap(),
+        );
+        let service = AdminService::new(manager, Vec::new());
+
+        let response = service.get_global_proxy();
+        let json = serde_json::to_value(response).unwrap();
+
+        assert_eq!(json["proxyPasswordSet"], true);
+        assert!(json.get("proxyPassword").is_none());
+        assert!(!json.to_string().contains("secret"));
     }
 
     #[tokio::test]

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -1695,9 +1695,11 @@ impl AdminService {
             .collect();
 
         let models_for_config = custom_models.clone();
-        self.update_config_file(move |c| {
-            c.custom_models = models_for_config;
-        });
+        self.token_manager
+            .update_config_file(move |c| {
+                c.custom_models = models_for_config;
+            })
+            .map_err(|error| AdminServiceError::InternalError(error.to_string()))?;
 
         // 热更新内存注册表
         crate::model::custom_models::init(custom_models);

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -15,7 +15,9 @@ use crate::kiro::auth::social;
 use crate::kiro::error::UpstreamRateLimitError;
 use crate::kiro::model::available_models::ListAvailableModelsResponse;
 use crate::kiro::model::credentials::{
-    KiroCredentials, normalize_import_auth_method, validate_external_idp_endpoint,
+    KiroCredentials, credential_metadata_schema, normalize_import_auth_method,
+    validate_credential_metadata, validate_credential_metadata_schema,
+    validate_external_idp_endpoint,
 };
 use crate::kiro::model::events::{Event, strip_tool_use_xml_leaks};
 use crate::kiro::model::requests::conversation::{
@@ -38,6 +40,7 @@ use super::types::{
     BatchAddProxyRequest, BatchImportEvent, CheckRateLimitRequest, CredentialStatusItem,
     CredentialsExportResponse, CredentialsStatusResponse, EnableOverageAllResult, ExportedAccount,
     ExportedCredentials, GitHubRateLimitInfo, ImageUpdateResponse, LoadBalancingModeResponse,
+    CredentialMetadataSchemaConfig,
     LogGovernanceConfigResponse, ModelSelectionMode, ModelTestRequest, ModelTestResponse,
     PollIdcLoginResponse, ProxyCheckAllResponse, ProxyCheckResponse, ProxyPoolEntry,
     ProxyPoolResponse, QuotaExceededResult, SelfHealConfigResponse,
@@ -222,6 +225,8 @@ pub struct AdminService {
     proxy_pool: ProxyPoolManager,
     /// 在线镜像更新运行时配置
     update_config: Mutex<RuntimeUpdateConfig>,
+    /// 凭据 metadata schema；设置页修改后即时生效。
+    credential_metadata_schema: Mutex<serde_json::Value>,
     /// 最近一次"检查更新"结果（带 TTL，用于减少 GitHub API 调用）
     update_check_cache: Mutex<Option<CachedUpdateCheck>>,
     /// 进行中的 IdC 设备授权会话
@@ -552,6 +557,20 @@ impl AdminService {
 
         let balance_cache = Self::load_balance_cache_from(&cache_path);
         let update_config = RuntimeUpdateConfig::from_config(token_manager.config());
+        let credential_metadata_schema = match token_manager
+            .config()
+            .credential_metadata_schema
+            .clone()
+        {
+            Some(schema) => match validate_credential_metadata_schema(&schema) {
+                Ok(()) => schema,
+                Err(error) => {
+                    tracing::warn!("配置中的 credentialMetadataSchema 无效，回退内置值: {}", error);
+                    credential_metadata_schema()
+                }
+            },
+            None => credential_metadata_schema(),
+        };
 
         let svc = Self {
             token_manager,
@@ -561,6 +580,7 @@ impl AdminService {
             known_endpoints: known_endpoints.into_iter().collect(),
             proxy_pool: ProxyPoolManager::new(proxy_pool_path, token_manager_tls_backend),
             update_config: Mutex::new(update_config),
+            credential_metadata_schema: Mutex::new(credential_metadata_schema),
             update_check_cache: Mutex::new(None),
             idc_sessions: Arc::new(Mutex::new(HashMap::new())),
             social_sessions: Arc::new(Mutex::new(HashMap::new())),
@@ -658,6 +678,7 @@ impl AdminService {
                     endpoint: entry.endpoint.unwrap_or_else(|| default_endpoint.clone()),
                     groups: entry.groups,
                     source_channel: entry.source_channel,
+                    metadata: entry.metadata,
                     balance,
                     balance_updated_at,
                     created_at: entry.created_at,
@@ -672,8 +693,31 @@ impl AdminService {
             total: snapshot.total,
             available: snapshot.available,
             current_id: exposed_current_id,
+            metadata_schema: self.credential_metadata_schema.lock().clone(),
             credentials,
         }
+    }
+
+    pub fn get_credential_metadata_schema(&self) -> CredentialMetadataSchemaConfig {
+        CredentialMetadataSchemaConfig {
+            schema: self.credential_metadata_schema.lock().clone(),
+        }
+    }
+
+    pub fn set_credential_metadata_schema(
+        &self,
+        req: CredentialMetadataSchemaConfig,
+    ) -> Result<CredentialMetadataSchemaConfig, AdminServiceError> {
+        validate_credential_metadata_schema(&req.schema)
+            .map_err(|error| AdminServiceError::InvalidCredential(error.to_string()))?;
+        let schema_for_save = req.schema.clone();
+        self.token_manager
+            .update_config_file(move |config| {
+                config.credential_metadata_schema = Some(schema_for_save);
+            })
+            .map_err(|error| AdminServiceError::InternalError(error.to_string()))?;
+        *self.credential_metadata_schema.lock() = req.schema;
+        Ok(self.get_credential_metadata_schema())
     }
 
     /// 导出凭据为兼容 JSON（嵌套 `Account` 格式）
@@ -1201,6 +1245,8 @@ impl AdminService {
         req: AddCredentialRequest,
         fetch_balance: bool,
     ) -> Result<AddCredentialResponse, AdminServiceError> {
+        validate_credential_metadata(&req.metadata, &self.credential_metadata_schema.lock())
+            .map_err(|error| AdminServiceError::InvalidCredential(error.to_string()))?;
         // 校验端点名：未指定则默认合法，指定则必须已注册
         if let Some(ref name) = req.endpoint {
             if !self.known_endpoints.contains(name) {
@@ -1293,6 +1339,7 @@ impl AdminService {
             endpoint: req.endpoint,
             groups: req.groups,
             source_channel: req.source_channel,
+            metadata: req.metadata,
             // 创建时间由 token_manager.add_credential 在入库时统一写入
             created_at: None,
         };
@@ -1406,6 +1453,10 @@ impl AdminService {
         id: u64,
         req: UpdateCredentialRequest,
     ) -> Result<(), AdminServiceError> {
+        if let Some(metadata) = req.metadata.as_ref() {
+            validate_credential_metadata(metadata, &self.credential_metadata_schema.lock())
+                .map_err(|error| AdminServiceError::InvalidCredential(error.to_string()))?;
+        }
         self.token_manager
             .update_credential(
                 id,
@@ -1419,6 +1470,7 @@ impl AdminService {
                 req.groups,
                 req.source_channel
                     .map(|v| if v.is_empty() { None } else { Some(v) }),
+                req.metadata,
             )
             .map_err(|e| self.classify_error(e, id))
     }
@@ -2573,6 +2625,7 @@ impl AdminService {
                 None,            // proxy_password 不修改
                 None,            // groups 不修改
                 None,            // source_channel 不修改
+                None,            // metadata 不修改
             )
             .map_err(|e| {
                 let msg = e.to_string();
@@ -2642,7 +2695,7 @@ impl AdminService {
             let url = urls[i % urls.len()].clone();
             if self
                 .token_manager
-                .update_credential(*cred_id, None, Some(Some(url)), None, None, None, None)
+                .update_credential(*cred_id, None, Some(Some(url)), None, None, None, None, None)
                 .is_ok()
             {
                 assigned += 1;

--- a/src/admin/service.rs
+++ b/src/admin/service.rs
@@ -665,8 +665,8 @@ impl AdminService {
             })
             .collect();
 
-        // 按优先级排序（数字越小优先级越高）
-        credentials.sort_by_key(|c| c.priority);
+        // 与调度器保持一致：优先级越小越靠前，同优先级按 ID 升序。
+        credentials.sort_by_key(|c| (c.priority, c.id));
 
         CredentialsStatusResponse {
             total: snapshot.total,
@@ -689,7 +689,7 @@ impl AdminService {
         if let Some(filter) = id_filter {
             credentials.retain(|c| c.id.map(|id| filter.contains(&id)).unwrap_or(false));
         }
-        credentials.sort_by_key(|c| c.priority);
+        credentials.sort_by_key(|c| (c.priority, c.id.unwrap_or(u64::MAX)));
 
         let accounts = credentials
             .into_iter()

--- a/src/admin/trace_db.rs
+++ b/src/admin/trace_db.rs
@@ -187,6 +187,12 @@ pub struct TraceQuery {
     /// 按账号分组筛选：只返回最终凭据属于这些 id 的 trace。
     /// 由 handler 层在查询前根据 group 参数转换为凭据 id 白名单填入。
     pub credential_ids: Option<Vec<u64>>,
+    /// 时间窗口起点（Unix **秒**，含）。与 `ts_epoch` 列同单位，走 `idx_traces_ts` 索引。
+    pub start_ts: Option<i64>,
+    /// 时间窗口终点（Unix **秒**，含）
+    pub end_ts: Option<i64>,
+    /// 关键字模糊匹配：模型名 / trace_id / 错误信息 的子串（大小写不敏感）
+    pub keyword: Option<String>,
     /// 返回条数上限
     pub limit: usize,
     /// 偏移量（分页用）
@@ -453,6 +459,29 @@ impl TraceStore {
         }
         if q.only_failed {
             clauses.push("final_status != 'success'".to_string());
+        }
+        // 时间窗口：与 ts_epoch 同为 Unix 秒，命中 idx_traces_ts(ts_epoch DESC)
+        if let Some(start) = q.start_ts {
+            clauses.push("ts_epoch >= ?".to_string());
+            params.push(Box::new(start));
+        }
+        if let Some(end) = q.end_ts {
+            clauses.push("ts_epoch <= ?".to_string());
+            params.push(Box::new(end));
+        }
+        // 关键字：排查时手里通常只有一个模型名、一段报错或一个 trace_id，
+        // 与其让用户先想清楚该填哪个字段，不如一个框同时匹配这三处。
+        // LIKE 无法走索引，但已被上面的时间窗口把扫描范围收窄。
+        if let Some(kw) = &q.keyword {
+            let pattern = format!("%{}%", kw.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_"));
+            clauses.push(
+                "(model LIKE ? ESCAPE '\\' OR trace_id LIKE ? ESCAPE '\\' \
+                 OR IFNULL(error_message, '') LIKE ? ESCAPE '\\')"
+                    .to_string(),
+            );
+            params.push(Box::new(pattern.clone()));
+            params.push(Box::new(pattern.clone()));
+            params.push(Box::new(pattern));
         }
         let where_sql = if clauses.is_empty() {
             String::new()
@@ -982,5 +1011,118 @@ mod tests {
         let out = truncate_snippet(&long).unwrap();
         assert!(out.ends_with("…(truncated)"));
         assert!(out.len() <= ERROR_SNIPPET_MAX + 20);
+    }
+
+    /// 指定发生时刻的样本（时间窗口筛选需要可控的 ts）
+    fn sample_at(trace_id: &str, model: &str, ago_secs: i64) -> TraceRecord {
+        let mut rec = sample(TraceSample {
+            trace_id,
+            status: "success",
+            credential_id: 5,
+            model,
+        });
+        rec.ts = (Utc::now() - chrono::Duration::seconds(ago_secs)).to_rfc3339();
+        rec
+    }
+
+    #[test]
+    fn time_window_filters_by_ts_epoch() {
+        let store = mem_store();
+        store.insert(&sample_at("recent", "m1", 60)); // 1 分钟前
+        store.insert(&sample_at("mid", "m1", 60 * 30)); // 30 分钟前
+        store.insert(&sample_at("old", "m1", 60 * 60 * 48)); // 48 小时前
+
+        let now = Utc::now().timestamp();
+        let ids = |q: &TraceQuery| {
+            let mut v: Vec<String> = store.query(q).into_iter().map(|r| r.trace_id).collect();
+            v.sort();
+            v
+        };
+
+        // 最近 15 分钟：只剩 1 分钟前那条
+        assert_eq!(
+            ids(&TraceQuery {
+                start_ts: Some(now - 15 * 60),
+                limit: 50,
+                ..Default::default()
+            }),
+            vec!["recent"]
+        );
+
+        // 最近 1 小时：含 1 分钟 + 30 分钟两条
+        assert_eq!(
+            ids(&TraceQuery {
+                start_ts: Some(now - 60 * 60),
+                limit: 50,
+                ..Default::default()
+            }),
+            vec!["mid", "recent"]
+        );
+
+        // 上界：只要 30 分钟前及更早，排除 1 分钟前那条
+        assert_eq!(
+            ids(&TraceQuery {
+                end_ts: Some(now - 10 * 60),
+                limit: 50,
+                ..Default::default()
+            }),
+            vec!["mid", "old"]
+        );
+
+        // 不带时间条件时全部返回，保证既有调用方行为不变
+        assert_eq!(
+            ids(&TraceQuery {
+                limit: 50,
+                ..Default::default()
+            })
+            .len(),
+            3
+        );
+    }
+
+    #[test]
+    fn keyword_matches_model_trace_id_and_error() {
+        let store = mem_store();
+        store.insert(&sample(TraceSample {
+            trace_id: "aaa-111",
+            status: "success",
+            credential_id: 5,
+            model: "claude-opus-4-7",
+        }));
+        store.insert(&sample(TraceSample {
+            trace_id: "bbb-222",
+            status: "error", // error_message = "blocked"
+            credential_id: 6,
+            model: "claude-sonnet-4-5",
+        }));
+
+        let ids = |kw: &str| {
+            let mut v: Vec<String> = store
+                .query(&TraceQuery {
+                    keyword: Some(kw.to_string()),
+                    limit: 50,
+                    ..Default::default()
+                })
+                .into_iter()
+                .map(|r| r.trace_id)
+                .collect();
+            v.sort();
+            v
+        };
+
+        // 命中模型名
+        assert_eq!(ids("opus"), vec!["aaa-111"]);
+        // 命中 trace_id
+        assert_eq!(ids("bbb"), vec!["bbb-222"]);
+        // 命中错误信息
+        assert_eq!(ids("blocked"), vec!["bbb-222"]);
+        // 公共子串同时命中两条
+        assert_eq!(ids("claude"), vec!["aaa-111", "bbb-222"]);
+        // 无命中
+        assert!(ids("nonexistent").is_empty());
+
+        // LIKE 元字符被转义：% 不再是通配符，不应匹配任何记录
+        assert!(ids("%").is_empty(), "% 应按字面量处理");
+        assert!(ids("_").is_empty(), "_ 应按字面量处理");
     }
 }

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -716,6 +716,10 @@ pub struct AssignProxyRequest {
 pub struct GlobalProxyResponse {
     /// 当前全局代理 URL（null 表示未配置）
     pub proxy_url: Option<String>,
+    /// 代理认证用户名
+    pub proxy_username: Option<String>,
+    /// 代理认证密码
+    pub proxy_password: Option<String>,
 }
 
 /// 设置全局代理请求
@@ -724,6 +728,12 @@ pub struct GlobalProxyResponse {
 pub struct SetGlobalProxyRequest {
     /// 代理 URL，null 表示清除全局代理
     pub proxy_url: Option<String>,
+    /// 代理认证用户名（仅 proxy_url 不为 null 时有效）
+    #[serde(default)]
+    pub proxy_username: Option<String>,
+    /// 代理认证密码（仅 proxy_url 不为 null 时有效）
+    #[serde(default)]
+    pub proxy_password: Option<String>,
 }
 
 // ============ 在线更新配置 ============

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -55,6 +55,9 @@ pub struct CredentialStatusItem {
     pub masked_api_key: Option<String>,
     /// 用户邮箱（用于前端显示）
     pub email: Option<String>,
+    /// 最近一次查询到的 Kiro 订阅等级；不依赖当前余额缓存。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_title: Option<String>,
     /// API 调用成功次数
     pub success_count: u64,
     /// 最后一次 API 调用时间（RFC3339 格式）

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -1226,3 +1226,44 @@ pub struct DeleteGroupQuery {
     #[serde(default)]
     pub force: bool,
 }
+
+// ============ 自定义模型 ============
+
+/// 自定义模型配置响应（列表）。
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomModelsConfigResponse {
+    pub models: Vec<CustomModelItem>,
+}
+
+/// 单条自定义模型条目（与 `config::CustomModel` 字段一一对应，仅用于 Admin API 序列化）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomModelItem {
+    /// 客户端请求时使用的模型名（别名）。匹配大小写不敏感。
+    pub id: String,
+    /// 映射到的 Kiro 后端模型 ID（实际下发给上游）。
+    pub backend_id: String,
+    /// `/v1/models` 展示名（可选，缺省用 `id`）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// 上下文窗口大小（可选，缺省 200000）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<i32>,
+    /// 单次响应最大 token 数（可选，缺省 64000）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<i32>,
+    /// 是否支持原生 reasoning（可选，缺省 false）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_reasoning: Option<bool>,
+    /// `/v1/models` 的 `owned_by` 字段（可选，缺省 "custom"）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owned_by: Option<String>,
+}
+
+/// 批量设置自定义模型请求（整体替换 `config.json` 中的 `customModels` 数组）。
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetCustomModelsRequest {
+    pub models: Vec<CustomModelItem>,
+}

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -722,8 +722,8 @@ pub struct GlobalProxyResponse {
     pub proxy_url: Option<String>,
     /// 代理认证用户名
     pub proxy_username: Option<String>,
-    /// 代理认证密码
-    pub proxy_password: Option<String>,
+    /// 是否已配置代理认证密码；不回显密码本身。
+    pub proxy_password_set: bool,
 }
 
 /// 设置全局代理请求
@@ -735,9 +735,10 @@ pub struct SetGlobalProxyRequest {
     /// 代理认证用户名（仅 proxy_url 不为 null 时有效）
     #[serde(default)]
     pub proxy_username: Option<String>,
-    /// 代理认证密码（仅 proxy_url 不为 null 时有效）
+    /// 代理认证密码（仅 proxy_url 不为 null 时有效）。省略表示保留现有密码，
+    /// 显式 null 表示清除密码。
     #[serde(default)]
-    pub proxy_password: Option<String>,
+    pub proxy_password: Option<Option<String>>,
 }
 
 // ============ 在线更新配置 ============

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -82,6 +82,11 @@ pub struct CredentialStatusItem {
     pub source_channel: Option<String>,
     /// 凭据扩展元数据
     pub metadata: CredentialMetadata,
+    /// 为客户端预先解析的 metadata 字段信息，包含显示文案、描述和实际值。
+    ///
+    /// 保留 `metadata` 原始对象，兼容依赖原始 key-value 结构的客户端；新客户端无需
+    /// 再自行把 `metadata` 与 `metadata_schema` 做关联。
+    pub metadata_details: Vec<CredentialMetadataDetail>,
     /// 凭据余额（从缓存中读取的最近一次结果，可能为 None）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance: Option<BalanceResponse>,
@@ -91,6 +96,21 @@ pub struct CredentialStatusItem {
     /// 凭据添加（创建）时间（RFC3339 格式）；旧凭据缺失时为 None
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
+}
+
+/// 单个凭据 metadata 字段的可展示信息。
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialMetadataDetail {
+    /// Schema 中的字段 key；自定义扩展字段保持原 key。
+    pub key: String,
+    /// 面向用户的字段名称；没有 Schema 定义时回退为 key。
+    pub title: String,
+    /// Schema 字段描述；未定义扩展字段时为 None。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// 凭据上的实际值；旧凭据缺失时可回退到 Schema 默认值。
+    pub value: serde_json::Value,
 }
 
 // ============ 操作请求 ============

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -1,6 +1,7 @@
 //! Admin API 类型定义
 
 use crate::admin::proxy_pool::ProxyHealth;
+use crate::kiro::model::credentials::CredentialMetadata;
 use serde::{Deserialize, Serialize};
 
 // ============ 凭据状态 ============
@@ -15,6 +16,8 @@ pub struct CredentialsStatusResponse {
     pub available: usize,
     /// 优先级模式下的当前优先凭据 ID；均衡模式固定为 0
     pub current_id: u64,
+    /// 凭据 metadata 的 JSON Schema
+    pub metadata_schema: serde_json::Value,
     /// 各凭据状态列表
     pub credentials: Vec<CredentialStatusItem>,
 }
@@ -74,6 +77,8 @@ pub struct CredentialStatusItem {
     /// 账号来源渠道（纯备注）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_channel: Option<String>,
+    /// 凭据扩展元数据
+    pub metadata: CredentialMetadata,
     /// 凭据余额（从缓存中读取的最近一次结果，可能为 None）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance: Option<BalanceResponse>,
@@ -197,6 +202,9 @@ pub struct AddCredentialRequest {
     /// 账号来源渠道（纯备注，可选）
     #[serde(default)]
     pub source_channel: Option<String>,
+    /// 凭据扩展元数据（默认账号类型为 normal）
+    #[serde(default)]
+    pub metadata: CredentialMetadata,
 }
 
 fn default_auth_method() -> String {
@@ -235,6 +243,9 @@ pub struct UpdateCredentialRequest {
     /// 账号来源渠道（None 表示不修改，空串表示清除）
     #[serde(default)]
     pub source_channel: Option<String>,
+    /// 凭据扩展元数据（None 表示不修改）
+    #[serde(default)]
+    pub metadata: Option<CredentialMetadata>,
 }
 
 /// 添加凭据成功响应
@@ -565,6 +576,13 @@ pub struct SetLogGovernanceConfigRequest {
     /// 用量日志保留天数，1..=365
     #[serde(default)]
     pub usage_log_retention_days: Option<u32>,
+}
+
+/// 凭据 metadata schema 配置响应/更新请求。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialMetadataSchemaConfig {
+    pub schema: serde_json::Value,
 }
 
 // ============ 代理池 ============

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -80,13 +80,8 @@ pub struct CredentialStatusItem {
     /// 账号来源渠道（纯备注）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_channel: Option<String>,
-    /// 凭据扩展元数据
-    pub metadata: CredentialMetadata,
-    /// 为客户端预先解析的 metadata 字段信息，包含显示文案、描述和实际值。
-    ///
-    /// 保留 `metadata` 原始对象，兼容依赖原始 key-value 结构的客户端；新客户端无需
-    /// 再自行把 `metadata` 与 `metadata_schema` 做关联。
-    pub metadata_details: Vec<CredentialMetadataDetail>,
+    /// 凭据 metadata；key 为字段名，值包含显示文案、描述和实际值。
+    pub metadata: std::collections::BTreeMap<String, CredentialMetadataDetail>,
     /// 凭据余额（从缓存中读取的最近一次结果，可能为 None）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance: Option<BalanceResponse>,
@@ -102,8 +97,6 @@ pub struct CredentialStatusItem {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CredentialMetadataDetail {
-    /// Schema 中的字段 key；自定义扩展字段保持原 key。
-    pub key: String,
     /// 面向用户的字段名称；没有 Schema 定义时回退为 key。
     pub title: String,
     /// Schema 字段描述；未定义扩展字段时为 None。

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -104,6 +104,10 @@ pub struct CredentialMetadataDetail {
     pub description: Option<String>,
     /// 凭据上的实际值；旧凭据缺失时可回退到 Schema 默认值。
     pub value: serde_json::Value,
+    /// Schema oneOf 中匹配 value 的显示名（如 "normal" → "正常号"）。
+    /// 未命中 oneOf 或该字段无 oneOf 时为 None，前端可回退显示 value。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_label: Option<String>,
 }
 
 // ============ 操作请求 ============

--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -286,7 +286,7 @@ pub fn map_model(model: &str) -> Option<String> {
 
     // 自定义模型表优先（大小写不敏感精确匹配），可新增或覆盖内置映射。
     if let Some(custom) = crate::model::custom_models::lookup(model) {
-        return Some(custom.backend_id.clone());
+        return Some(custom.backend_id);
     }
 
     normalize_claude_model(model).or_else(|| Some(model.to_string()))

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -541,7 +541,7 @@ fn aggregate_available_models_with_custom(
 }
 
 fn aggregate_available_models(upstream_models: Vec<UpstreamModel>) -> Vec<Model> {
-    aggregate_available_models_with_custom(upstream_models, crate::model::custom_models::all())
+    aggregate_available_models_with_custom(upstream_models, &crate::model::custom_models::all())
 }
 
 /// GET /v1/models

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -385,8 +385,9 @@ impl CredentialsConfig {
                 vec![cred]
             }
             CredentialsConfig::Multiple(mut creds) => {
-                // 按优先级排序（数字越小优先级越高）
-                creds.sort_by_key(|c| c.priority);
+                // 与运行时调度保持一致：优先级越小越靠前，同优先级按 ID 升序。
+                // 没有 ID 的旧格式凭据保持在已有 ID 之后，后续由管理器统一分配。
+                creds.sort_by_key(|c| (c.priority, c.id.unwrap_or(u64::MAX)));
                 for cred in &mut creds {
                     cred.canonicalize_auth_method();
                 }
@@ -822,6 +823,24 @@ mod tests {
         assert_eq!(list[0].refresh_token, Some("t2".to_string())); // priority 0
         assert_eq!(list[1].refresh_token, Some("t3".to_string())); // priority 1
         assert_eq!(list[2].refresh_token, Some("t1".to_string())); // priority 2
+    }
+
+    #[test]
+    fn test_credentials_config_equal_priority_sorting_uses_id() {
+        let json = r#"[
+            {"id": 3, "refreshToken": "t3", "priority": 0},
+            {"id": 1, "refreshToken": "t1", "priority": 0},
+            {"id": 2, "refreshToken": "t2", "priority": 0}
+        ]"#;
+        let config: CredentialsConfig = serde_json::from_str(json).unwrap();
+        let list = config.into_sorted_credentials();
+
+        assert_eq!(
+            list.iter()
+                .filter_map(|credential| credential.id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
     }
 
     // ============ Region 字段测试 ============

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -4,6 +4,7 @@
 //! 支持单凭据和多凭据配置格式
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -14,6 +15,205 @@ pub const BUILDER_ID_PROFILE_ARN: &str =
     "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX";
 pub const SOCIAL_PROFILE_ARN: &str =
     "arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK";
+
+/// 凭据账号类型，仅用于运营标记，不参与调度。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CredentialType {
+    /// 正常账号
+    #[default]
+    Normal,
+    /// 炸弹账号
+    Boom,
+}
+
+/// 凭据扩展元数据。
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialMetadata {
+    /// 账号类型；旧凭据缺少该字段时默认为 normal。
+    #[serde(default, rename = "type")]
+    pub kind: CredentialType,
+
+    /// 预留扩展字段。未知键在读取、修改和持久化过程中原样保留。
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+/// 返回凭据 metadata 的标准 JSON Schema。
+///
+/// `additionalProperties: true` 保证 metadata 可扩展；已登记字段则由 properties
+/// 描述 key、值类型、默认值、可选值和 UI 文案。
+pub fn credential_metadata_schema() -> serde_json::Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://kiro.rs/schemas/credential-metadata.json",
+        "title": "凭据元数据",
+        "type": "object",
+        "properties": {
+            "type": {
+                "title": "账号类型",
+                "description": "账号运营分类，仅用于标记，不参与调度。",
+                "type": "string",
+                "default": "normal",
+                "oneOf": [
+                    { "const": "normal", "title": "正常号" },
+                    { "const": "boom", "title": "炸弹号" }
+                ]
+            }
+        },
+        "required": ["type"],
+        "additionalProperties": true
+    })
+}
+
+/// 校验设置页提交的凭据 metadata schema。
+pub fn validate_credential_metadata_schema(schema: &serde_json::Value) -> anyhow::Result<()> {
+    let object = schema
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("metadata schema 必须是 JSON 对象"))?;
+    if object.get("type").and_then(|v| v.as_str()) != Some("object") {
+        anyhow::bail!("metadata schema 的 type 必须是 object");
+    }
+    if object.get("additionalProperties").and_then(|v| v.as_bool()) != Some(true) {
+        anyhow::bail!("metadata schema 必须允许 additionalProperties");
+    }
+    let properties = object
+        .get("properties")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow::anyhow!("metadata schema 缺少 properties 对象"))?;
+    if properties.len() > 100 {
+        anyhow::bail!("metadata schema 最多允许 100 个字段");
+    }
+    let type_field = properties
+        .get("type")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow::anyhow!("metadata schema 必须包含 type 字段"))?;
+    if type_field.get("type").and_then(|v| v.as_str()) != Some("string")
+        || type_field.get("default").and_then(|v| v.as_str()) != Some("normal")
+    {
+        anyhow::bail!("metadata.type 必须是 string，默认值必须是 normal");
+    }
+    let type_values: Vec<&str> = type_field
+        .get("oneOf")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("const").and_then(|v| v.as_str()))
+        .collect();
+    if type_values.len() != 2
+        || !type_values.contains(&"normal")
+        || !type_values.contains(&"boom")
+    {
+        anyhow::bail!("metadata.type 只能描述 normal 和 boom 两个可选值");
+    }
+    for (key, field) in properties {
+        if key.trim().is_empty() || key.len() > 64 {
+            anyhow::bail!("metadata 字段 key 不能为空且不能超过 64 字符");
+        }
+        let value_type = field.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if !matches!(value_type, "string" | "number" | "integer" | "boolean") {
+            anyhow::bail!("metadata.{} 使用了不支持的值类型", key);
+        }
+        if field
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+            .is_none()
+        {
+            anyhow::bail!("metadata.{} 缺少显示名称 title", key);
+        }
+        let value_matches_type = |value: &serde_json::Value| match value_type {
+            "string" => value.is_string(),
+            "number" => value.is_number(),
+            "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+            "boolean" => value.is_boolean(),
+            _ => false,
+        };
+        if let Some(default) = field.get("default") {
+            if !value_matches_type(default) {
+                anyhow::bail!("metadata.{} 的默认值类型不正确", key);
+            }
+        }
+        if let Some(options) = field.get("oneOf") {
+            let options = options
+                .as_array()
+                .filter(|options| !options.is_empty() && options.len() <= 100)
+                .ok_or_else(|| anyhow::anyhow!("metadata.{} 的 oneOf 必须是 1 到 100 项", key))?;
+            let mut seen = std::collections::HashSet::new();
+            for option in options {
+                let constant = option
+                    .get("const")
+                    .ok_or_else(|| anyhow::anyhow!("metadata.{} 的枚举项缺少 const", key))?;
+                if !value_matches_type(constant) {
+                    anyhow::bail!("metadata.{} 的枚举值类型不正确", key);
+                }
+                if option
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|title| !title.is_empty())
+                    .is_none()
+                {
+                    anyhow::bail!("metadata.{} 的枚举项缺少 title", key);
+                }
+                if !seen.insert(constant.to_string()) {
+                    anyhow::bail!("metadata.{} 存在重复枚举值", key);
+                }
+            }
+            if let Some(default) = field.get("default") {
+                if !options.iter().any(|option| option.get("const") == Some(default)) {
+                    anyhow::bail!("metadata.{} 的默认值不在 oneOf 中", key);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// 按当前 schema 校验 metadata 中已登记字段；额外字段由 additionalProperties 放行。
+pub fn validate_credential_metadata(
+    metadata: &CredentialMetadata,
+    schema: &serde_json::Value,
+) -> anyhow::Result<()> {
+    validate_credential_metadata_schema(schema)?;
+    let value = serde_json::to_value(metadata)?;
+    let values = value.as_object().expect("CredentialMetadata 必须序列化为对象");
+    let properties = schema["properties"]
+        .as_object()
+        .expect("schema 已完成 properties 校验");
+    for key in schema["required"].as_array().into_iter().flatten() {
+        if let Some(key) = key.as_str() {
+            if !values.contains_key(key) {
+                anyhow::bail!("metadata 缺少必填字段 {}", key);
+            }
+        }
+    }
+    for (key, field) in properties {
+        let Some(actual) = values.get(key) else { continue };
+        let valid_type = match field.get("type").and_then(|v| v.as_str()) {
+            Some("string") => actual.is_string(),
+            Some("number") => actual.is_number(),
+            Some("integer") => actual.as_i64().is_some() || actual.as_u64().is_some(),
+            Some("boolean") => actual.is_boolean(),
+            _ => false,
+        };
+        if !valid_type {
+            anyhow::bail!("metadata.{} 的值类型不符合 schema", key);
+        }
+        if let Some(options) = field.get("oneOf").and_then(|v| v.as_array()) {
+            let matches = options
+                .iter()
+                .filter_map(|option| option.get("const"))
+                .any(|expected| expected == actual);
+            if !matches {
+                anyhow::bail!("metadata.{} 的值不在 schema 可选项中", key);
+            }
+        }
+    }
+    Ok(())
+}
 
 /// Kiro OAuth 凭证
 ///
@@ -177,6 +377,10 @@ pub struct KiroCredentials {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_channel: Option<String>,
 
+    /// 凭据扩展元数据。旧配置缺失时自动补为 `{ "type": "normal" }`。
+    #[serde(default)]
+    pub metadata: CredentialMetadata,
+
     /// 凭据添加（创建）时间（RFC3339 格式）
     ///
     /// 由 `add_credential` 在首次入库时写入，此后随凭据一起持久化。
@@ -244,6 +448,7 @@ impl std::fmt::Debug for KiroCredentials {
             .field("endpoint", &self.endpoint)
             .field("groups", &self.groups)
             .field("source_channel", &self.source_channel)
+            .field("metadata", &self.metadata)
             .field("created_at", &self.created_at)
             .finish()
     }
@@ -618,6 +823,72 @@ mod tests {
     }
 
     #[test]
+    fn test_metadata_defaults_to_normal_for_legacy_credentials() {
+        let creds = KiroCredentials::from_json(r#"{ "refreshToken": "legacy" }"#).unwrap();
+
+        assert_eq!(creds.metadata.kind, CredentialType::Normal);
+        assert!(creds.metadata.extra.is_empty());
+        let serialized = creds.to_pretty_json().unwrap();
+        assert!(serialized.contains("\"type\": \"normal\""));
+    }
+
+    #[test]
+    fn test_metadata_boom_and_extension_fields_roundtrip() {
+        let json = r#"{
+            "refreshToken": "test",
+            "metadata": {
+                "type": "boom",
+                "supplier": "vendor-a",
+                "labels": ["risk", "manual"]
+            }
+        }"#;
+
+        let creds = KiroCredentials::from_json(json).unwrap();
+        assert_eq!(creds.metadata.kind, CredentialType::Boom);
+        assert_eq!(
+            creds.metadata.extra.get("supplier"),
+            Some(&serde_json::Value::String("vendor-a".to_string()))
+        );
+
+        let serialized = creds.to_pretty_json().unwrap();
+        let reparsed = KiroCredentials::from_json(&serialized).unwrap();
+        assert_eq!(reparsed.metadata, creds.metadata);
+    }
+
+    #[test]
+    fn test_metadata_rejects_unknown_credential_type() {
+        let result = KiroCredentials::from_json(
+            r#"{ "refreshToken": "test", "metadata": { "type": "other" } }"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_metadata_schema_describes_type_and_allows_extensions() {
+        let schema = credential_metadata_schema();
+
+        assert_eq!(schema["properties"]["type"]["default"], "normal");
+        assert_eq!(schema["properties"]["type"]["oneOf"][1]["const"], "boom");
+        assert_eq!(schema["additionalProperties"], true);
+    }
+
+    #[test]
+    fn test_metadata_values_are_validated_by_schema() {
+        let mut metadata = CredentialMetadata::default();
+        metadata.extra.insert("score".to_string(), serde_json::json!(3));
+        let mut schema = credential_metadata_schema();
+        schema["properties"]["score"] = serde_json::json!({
+            "title": "评分",
+            "type": "integer"
+        });
+        assert!(validate_credential_metadata(&metadata, &schema).is_ok());
+
+        metadata.extra.insert("score".to_string(), serde_json::json!("3"));
+        assert!(validate_credential_metadata(&metadata, &schema).is_err());
+    }
+
+    #[test]
     fn test_from_json_with_unknown_keys() {
         let json = r#"{
             "accessToken": "test_token",
@@ -664,6 +935,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            metadata: CredentialMetadata::default(),
             created_at: None,
         };
 
@@ -673,6 +945,7 @@ mod tests {
         assert!(!json.contains("refreshToken"));
         // priority 为 0 时不序列化
         assert!(!json.contains("priority"));
+        assert!(json.contains("\"type\": \"normal\""));
     }
 
     #[test]
@@ -907,6 +1180,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            metadata: CredentialMetadata::default(),
             created_at: None,
         };
 
@@ -951,6 +1225,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            metadata: CredentialMetadata::default(),
             created_at: None,
         };
 
@@ -1078,6 +1353,7 @@ mod tests {
             endpoint: None,
             groups: vec![],
             source_channel: None,
+            metadata: CredentialMetadata::default(),
             created_at: None,
         };
 

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -827,6 +827,7 @@ impl KiroCredentials {
     pub fn effective_proxy(&self, global_proxy: Option<&ProxyConfig>) -> Option<ProxyConfig> {
         match self.proxy_url.as_deref() {
             Some(url) if url.eq_ignore_ascii_case(Self::PROXY_DIRECT) => None,
+            Some(url) if url.trim().is_empty() => global_proxy.cloned(),
             Some(url) => {
                 let mut proxy = ProxyConfig::new(url);
                 if let (Some(username), Some(password)) =

--- a/src/kiro/model/credentials.rs
+++ b/src/kiro/model/credentials.rs
@@ -27,6 +27,19 @@ pub enum CredentialType {
     Boom,
 }
 
+/// 凭据账号在售状态，仅用于运营管理，不参与调度。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialSaleStatus {
+    /// 非卖品
+    #[default]
+    NotForSale,
+    /// 在售
+    ForSale,
+    /// 已售
+    Sold,
+}
+
 /// 凭据扩展元数据。
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -34,6 +47,10 @@ pub struct CredentialMetadata {
     /// 账号类型；旧凭据缺少该字段时默认为 normal。
     #[serde(default, rename = "type")]
     pub kind: CredentialType,
+
+    /// 账号在售状态；旧凭据缺少该字段时默认为 not_for_sale。
+    #[serde(default)]
+    pub sale_status: CredentialSaleStatus,
 
     /// 预留扩展字段。未知键在读取、修改和持久化过程中原样保留。
     #[serde(flatten)]
@@ -60,11 +77,123 @@ pub fn credential_metadata_schema() -> serde_json::Value {
                     { "const": "normal", "title": "正常号" },
                     { "const": "boom", "title": "炸弹号" }
                 ]
+            },
+            "saleStatus": {
+                "title": "在售状态",
+                "description": "账号运营销售状态，仅用于标记，不参与调度。",
+                "type": "string",
+                "default": "not_for_sale",
+                "oneOf": [
+                    { "const": "not_for_sale", "title": "非卖品" },
+                    { "const": "for_sale", "title": "在售" },
+                    { "const": "sold", "title": "已售" }
+                ]
+            },
+            "salePrice": {
+                "title": "销售价格（CNY）",
+                "description": "账号销售价格，单位为人民币；未设置时不在卡片显示。",
+                "type": "number",
+                "minimum": 0
             }
         },
-        "required": ["type"],
+        "required": ["type", "saleStatus"],
         "additionalProperties": true
     })
+}
+
+/// 给旧版自定义 Schema 补齐新增的内置字段，同时保留用户定义的扩展字段和样式。
+pub fn normalize_credential_metadata_schema(mut schema: serde_json::Value) -> serde_json::Value {
+    let builtin = credential_metadata_schema();
+    let Some(object) = schema.as_object_mut() else {
+        return schema;
+    };
+    if let Some(properties) = object.get_mut("properties").and_then(|v| v.as_object_mut()) {
+        let builtin_properties = builtin["properties"]
+            .as_object()
+            .expect("内置 metadata schema properties 必须是对象");
+        for key in ["type", "saleStatus", "salePrice"] {
+            if !properties.contains_key(key) {
+                properties.insert(key.to_string(), builtin_properties[key].clone());
+            }
+        }
+    }
+    if let Some(required) = object.get_mut("required").and_then(|v| v.as_array_mut()) {
+        for key in ["type", "saleStatus"] {
+            if !required.iter().any(|value| value.as_str() == Some(key)) {
+                required.push(serde_json::Value::String(key.to_string()));
+            }
+        }
+    }
+    schema
+}
+
+/// 校验 JSON Schema 字段上的 `x-css` UI 扩展。
+///
+/// 允许普通内联声明，但拒绝外链、脚本表达式以及可能让内容脱离卡片边界的布局属性。
+fn validate_metadata_field_css(key: &str, field: &serde_json::Value) -> anyhow::Result<()> {
+    let Some(css) = field.get("x-css") else {
+        return Ok(());
+    };
+    let css = css
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("metadata.{} 的 x-css 必须是字符串", key))?
+        .trim();
+    if css.len() > 1000 {
+        anyhow::bail!("metadata.{} 的 x-css 不能超过 1000 个字符", key);
+    }
+    let lower = css.to_ascii_lowercase();
+    if ["url", "@import", "expression", "javascript", "<", ">"]
+        .iter()
+        .any(|token| lower.contains(token))
+    {
+        anyhow::bail!("metadata.{} 的 x-css 包含不安全内容", key);
+    }
+
+    const BLOCKED_PROPERTIES: &[&str] = &[
+        "position",
+        "z-index",
+        "inset",
+        "top",
+        "right",
+        "bottom",
+        "left",
+        "content",
+        "display",
+        "visibility",
+        "pointer-events",
+        "transform",
+        "animation",
+        "transition",
+    ];
+    for declaration in css.split(';').map(str::trim).filter(|item| !item.is_empty()) {
+        let (property, value) = declaration
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("metadata.{} 的 x-css 声明格式不正确", key))?;
+        let property = property.trim().to_ascii_lowercase();
+        if value.trim().is_empty() {
+            anyhow::bail!("metadata.{} 的 x-css 声明缺少值", key);
+        }
+        let property_body = property.trim_start_matches('-');
+        if property_body.is_empty()
+            || !property_body
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphabetic())
+            || !property
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+        {
+            anyhow::bail!("metadata.{} 的 x-css 属性名不正确", key);
+        }
+        if BLOCKED_PROPERTIES.contains(&property.as_str()) {
+            anyhow::bail!(
+                "metadata.{} 的 x-css 不允许使用布局属性 {}",
+                key,
+                property
+            );
+        }
+    }
+    Ok(())
 }
 
 /// 校验设置页提交的凭据 metadata schema。
@@ -107,7 +236,58 @@ pub fn validate_credential_metadata_schema(schema: &serde_json::Value) -> anyhow
     {
         anyhow::bail!("metadata.type 只能描述 normal 和 boom 两个可选值");
     }
+    let sale_status_field = properties
+        .get("saleStatus")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow::anyhow!("metadata schema 必须包含 saleStatus 字段"))?;
+    if sale_status_field.get("type").and_then(|v| v.as_str()) != Some("string")
+        || sale_status_field.get("default").and_then(|v| v.as_str()) != Some("not_for_sale")
+    {
+        anyhow::bail!("metadata.saleStatus 必须是 string，默认值必须是 not_for_sale");
+    }
+    let sale_status_values: Vec<&str> = sale_status_field
+        .get("oneOf")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("const").and_then(|v| v.as_str()))
+        .collect();
+    if sale_status_values.len() != 3
+        || !sale_status_values.contains(&"not_for_sale")
+        || !sale_status_values.contains(&"for_sale")
+        || !sale_status_values.contains(&"sold")
+    {
+        anyhow::bail!(
+            "metadata.saleStatus 只能描述 not_for_sale、for_sale 和 sold 三个可选值"
+        );
+    }
+    let sale_price_field = properties
+        .get("salePrice")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow::anyhow!("metadata schema 必须包含 salePrice 字段"))?;
+    if sale_price_field.get("type").and_then(|v| v.as_str()) != Some("number")
+        || sale_price_field.get("minimum").and_then(|v| v.as_f64()) != Some(0.0)
+        || sale_price_field.contains_key("default")
+    {
+        anyhow::bail!("metadata.salePrice 必须是无默认值且最小值为 0 的 number");
+    }
+    let required = object
+        .get("required")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow::anyhow!("metadata schema 缺少 required 数组"))?;
+    for key in ["type", "saleStatus"] {
+        if !required.iter().any(|value| value.as_str() == Some(key)) {
+            anyhow::bail!("metadata schema 的 required 必须包含 {}", key);
+        }
+    }
+    if required
+        .iter()
+        .any(|value| value.as_str() == Some("salePrice"))
+    {
+        anyhow::bail!("metadata.salePrice 必须是可选字段");
+    }
     for (key, field) in properties {
+        validate_metadata_field_css(key, field)?;
         if key.trim().is_empty() || key.len() > 64 {
             anyhow::bail!("metadata 字段 key 不能为空且不能超过 64 字符");
         }
@@ -201,6 +381,14 @@ pub fn validate_credential_metadata(
         };
         if !valid_type {
             anyhow::bail!("metadata.{} 的值类型不符合 schema", key);
+        }
+        if let Some(minimum) = field.get("minimum").and_then(|value| value.as_f64()) {
+            if actual
+                .as_f64()
+                .is_some_and(|value| value < minimum)
+            {
+                anyhow::bail!("metadata.{} 的值不能小于 {}", key, minimum);
+            }
         }
         if let Some(options) = field.get("oneOf").and_then(|v| v.as_array()) {
             let matches = options
@@ -827,9 +1015,11 @@ mod tests {
         let creds = KiroCredentials::from_json(r#"{ "refreshToken": "legacy" }"#).unwrap();
 
         assert_eq!(creds.metadata.kind, CredentialType::Normal);
+        assert_eq!(creds.metadata.sale_status, CredentialSaleStatus::NotForSale);
         assert!(creds.metadata.extra.is_empty());
         let serialized = creds.to_pretty_json().unwrap();
         assert!(serialized.contains("\"type\": \"normal\""));
+        assert!(serialized.contains("\"saleStatus\": \"not_for_sale\""));
     }
 
     #[test]
@@ -838,6 +1028,7 @@ mod tests {
             "refreshToken": "test",
             "metadata": {
                 "type": "boom",
+                "saleStatus": "for_sale",
                 "supplier": "vendor-a",
                 "labels": ["risk", "manual"]
             }
@@ -845,6 +1036,7 @@ mod tests {
 
         let creds = KiroCredentials::from_json(json).unwrap();
         assert_eq!(creds.metadata.kind, CredentialType::Boom);
+        assert_eq!(creds.metadata.sale_status, CredentialSaleStatus::ForSale);
         assert_eq!(
             creds.metadata.extra.get("supplier"),
             Some(&serde_json::Value::String("vendor-a".to_string()))
@@ -865,12 +1057,83 @@ mod tests {
     }
 
     #[test]
+    fn test_metadata_rejects_unknown_sale_status() {
+        let result = KiroCredentials::from_json(
+            r#"{ "refreshToken": "test", "metadata": { "type": "normal", "saleStatus": "unknown" } }"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_metadata_schema_describes_type_and_allows_extensions() {
         let schema = credential_metadata_schema();
 
         assert_eq!(schema["properties"]["type"]["default"], "normal");
         assert_eq!(schema["properties"]["type"]["oneOf"][1]["const"], "boom");
+        assert_eq!(
+            schema["properties"]["saleStatus"]["default"],
+            "not_for_sale"
+        );
+        assert_eq!(
+            schema["properties"]["saleStatus"]["oneOf"][1]["const"],
+            "for_sale"
+        );
+        assert_eq!(schema["properties"]["salePrice"]["type"], "number");
+        assert_eq!(schema["properties"]["salePrice"]["minimum"], 0);
         assert_eq!(schema["additionalProperties"], true);
+    }
+
+    #[test]
+    fn test_old_metadata_schema_is_normalized_without_losing_extensions() {
+        let mut schema = credential_metadata_schema();
+        schema["properties"]
+            .as_object_mut()
+            .unwrap()
+            .remove("saleStatus");
+        schema["properties"]
+            .as_object_mut()
+            .unwrap()
+            .remove("salePrice");
+        schema["required"] = serde_json::json!(["type"]);
+        schema["properties"]["supplier"] = serde_json::json!({
+            "title": "供应商",
+            "type": "string",
+            "x-css": "color: #b45309"
+        });
+
+        let normalized = normalize_credential_metadata_schema(schema);
+
+        assert_eq!(
+            normalized["properties"]["saleStatus"]["default"],
+            "not_for_sale"
+        );
+        assert_eq!(normalized["properties"]["salePrice"]["minimum"], 0);
+        assert_eq!(
+            normalized["properties"]["supplier"]["x-css"],
+            "color: #b45309"
+        );
+        assert!(normalized["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "saleStatus"));
+        assert!(validate_credential_metadata_schema(&normalized).is_ok());
+    }
+
+    #[test]
+    fn test_metadata_schema_validates_safe_custom_css() {
+        let mut schema = credential_metadata_schema();
+        schema["properties"]["type"]["x-css"] =
+            serde_json::json!("color: #b45309; background-color: #fffbeb; font-weight: 600");
+        assert!(validate_credential_metadata_schema(&schema).is_ok());
+
+        schema["properties"]["type"]["x-css"] =
+            serde_json::json!("background-image: url(https://example.com/track)");
+        assert!(validate_credential_metadata_schema(&schema).is_err());
+
+        schema["properties"]["type"]["x-css"] = serde_json::json!("position: fixed");
+        assert!(validate_credential_metadata_schema(&schema).is_err());
     }
 
     #[test]
@@ -885,6 +1148,12 @@ mod tests {
         assert!(validate_credential_metadata(&metadata, &schema).is_ok());
 
         metadata.extra.insert("score".to_string(), serde_json::json!("3"));
+        assert!(validate_credential_metadata(&metadata, &schema).is_err());
+
+        metadata.extra.remove("score");
+        metadata
+            .extra
+            .insert("salePrice".to_string(), serde_json::json!(-0.01));
         assert!(validate_credential_metadata(&metadata, &schema).is_err());
     }
 

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -493,6 +493,17 @@ impl KiroProvider {
                         Some(&e.to_string()),
                         attempt_start,
                     );
+                    // 凭据专属代理故障时，跳过该凭据换下一个。
+                    let has_own_proxy = ctx
+                        .credentials
+                        .proxy_url
+                        .as_deref()
+                        .is_some_and(|u| !u.trim().is_empty());
+                    if has_own_proxy {
+                        tracing::warn!("凭据 #{} 有专属代理且 MCP 请求失败，跳过该凭据", ctx.id);
+                        self.token_manager
+                            .report_failure_for_request(ctx.id, None, group);
+                    }
                     last_error = Some(e.into());
                     if attempt + 1 < max_retries {
                         sleep(Self::retry_delay(attempt)).await;
@@ -815,8 +826,19 @@ impl KiroProvider {
                         sink, attempt, ctx.id, endpoint_name, None,
                         outcome::NETWORK_ERROR, Some(&e.to_string()), attempt_start,
                     );
-                    // 网络错误通常是上游/链路瞬态问题，不应导致"禁用凭据"或"切换凭据"
-                    // （否则一段时间网络抖动会把所有凭据都误禁用，需要重启才能恢复）
+                    // 凭据专属代理故障时，重试同一凭据无意义，应跳过该凭据换下一个。
+                    // 没有专属代理时（直连或仅全局代理），切换凭据不解决问题，保持重试。
+                    let has_own_proxy = ctx.credentials.proxy_url.as_deref()
+                        .map_or(false, |u| !u.trim().is_empty());
+                    if has_own_proxy {
+                        tracing::warn!(
+                            "凭据 #{} 有专属代理且网络请求失败，跳过该凭据",
+                            ctx.id
+                        );
+                        self.token_manager
+                            .report_failure_for_request(ctx.id, model.as_deref(), group);
+                    }
+
                     last_error = Some(e.into());
                     if attempt + 1 < max_retries {
                         sleep(Self::retry_delay(attempt)).await;

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -6570,6 +6570,7 @@ mod tests {
         .unwrap();
         let metadata = crate::kiro::model::credentials::CredentialMetadata {
             kind: crate::kiro::model::credentials::CredentialType::Boom,
+            sale_status: crate::kiro::model::credentials::CredentialSaleStatus::ForSale,
             extra: std::collections::BTreeMap::from([(
                 "supplier".to_string(),
                 serde_json::Value::String("vendor-a".to_string()),
@@ -6584,6 +6585,10 @@ mod tests {
         assert_eq!(
             snapshot.entries[0].metadata.kind,
             crate::kiro::model::credentials::CredentialType::Boom
+        );
+        assert_eq!(
+            snapshot.entries[0].metadata.sale_status,
+            crate::kiro::model::credentials::CredentialSaleStatus::ForSale
         );
         assert_eq!(
             snapshot.entries[0].metadata.extra.get("supplier"),

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1369,7 +1369,7 @@ impl MultiTokenManager {
         let initial_id = entries
             .iter()
             .filter(|e| !e.disabled)
-            .min_by_key(|e| e.credentials.priority)
+            .min_by_key(|e| (e.credentials.priority, e.id))
             .map(|e| e.id)
             .unwrap_or(0);
 
@@ -1898,17 +1898,22 @@ impl MultiTokenManager {
                 // 平局时按优先级排序（数字越小优先级越高）
                 let (entry, _) = available.iter().min_by_key(|(e, support)| {
                     let discovery_rank = usize::from(*support != CachedModelSupport::Confirmed);
-                    (discovery_rank, e.success_count, e.credentials.priority)
+                    (
+                        discovery_rank,
+                        e.success_count,
+                        e.credentials.priority,
+                        e.id,
+                    )
                 })?;
 
                 Some((entry.id, entry.credentials.clone()))
             }
             _ => {
-                // priority 模式（默认）：选择优先级最高的
-                let (entry, _) = available.iter().min_by_key(|(e, support)| {
-                    let discovery_rank = usize::from(*support != CachedModelSupport::Confirmed);
-                    (discovery_rank, e.credentials.priority)
-                })?;
+                // priority 模式（默认）：严格选择数字最小的有效凭据。
+                // 同优先级按 ID 升序固定顺序，保证后端调度与前端预览一致。
+                let (entry, _) = available
+                    .iter()
+                    .min_by_key(|(e, _)| (e.credentials.priority, e.id))?;
                 Some((entry.id, entry.credentials.clone()))
             }
         }
@@ -1960,71 +1965,38 @@ impl MultiTokenManager {
             let (id, credentials, is_balanced) = {
                 let is_balanced = self.load_balancing_mode.lock().as_str() == "balanced";
 
-                // balanced 模式：每次请求都重新均衡选择，不固定 current_id
-                // priority 模式：优先使用 current_id 指向的凭据
-                let current_hit = if is_balanced {
-                    None
+                // 两种模式都按当前请求重新选择。priority 模式不能复用 current_id，
+                // 否则高优先级凭据从 RPM/冷却恢复后无法在下一次请求立即回切。
+                let mut best = self.select_next_credential(model, group);
+
+                // 没有可用凭据：如果是"自动禁用导致全灭"，做一次受控自愈
+                // （受冷却间隔与连续轮数上限约束，避免持续 403 死循环）。
+                if best.is_none() && self.try_self_heal(model, group) {
+                    best = self.select_next_credential(model, group);
+                }
+
+                let (id, credentials) = if let Some((new_id, new_creds)) = best {
+                    if update_current {
+                        let mut current_id = self.current_id.lock();
+                        *current_id = new_id;
+                    }
+                    (new_id, new_creds)
                 } else {
                     let entries = self.entries.lock();
-                    let current_id = *self.current_id.lock();
-                    let now = Instant::now();
-                    let confirmed_available = entries.iter().any(|e| {
-                        !e.disabled
-                            && !e.throttled_until.map(|t| t > now).unwrap_or(false)
-                            && !self.rpm_exceeded(e, now)
-                            && credential_matches_request(&e.credentials, model, group)
-                            && self.cached_model_support(e.id, model)
-                                == CachedModelSupport::Confirmed
-                    });
-                    entries
-                        .iter()
-                        .find(|e| {
-                            let model_support = self.cached_model_support(e.id, model);
-                            e.id == current_id
-                                && !e.disabled
-                                && !e.throttled_until.map(|t| t > now).unwrap_or(false)
-                                && !self.rpm_exceeded(e, now)
-                                && credential_matches_request(&e.credentials, model, group)
-                                && model_support != CachedModelSupport::Unsupported
-                                && (!confirmed_available
-                                    || model_support == CachedModelSupport::Confirmed)
-                        })
-                        .map(|e| (e.id, e.credentials.clone()))
-                };
-
-                let (id, credentials) = if let Some(hit) = current_hit {
-                    hit
-                } else {
-                    // 当前凭据不可用或 balanced 模式，根据负载均衡策略选择
-                    let mut best = self.select_next_credential(model, group);
-
-                    // 没有可用凭据：如果是"自动禁用导致全灭"，做一次受控自愈
-                    // （受冷却间隔与连续轮数上限约束，避免持续 403 死循环）。
-                    if best.is_none() && self.try_self_heal(model, group) {
-                        best = self.select_next_credential(model, group);
+                    // RPM 打满（而非全部禁用）时回 429 并带 Retry-After，
+                    // 让调用方知道这是限流而不是凭据耗尽。
+                    if let Some(retry_after) =
+                        self.rpm_retry_after_secs(&entries, model, group, Instant::now())
+                    {
+                        return Err(
+                            UpstreamRateLimitError::new(Some(retry_after.to_string())).into()
+                        );
                     }
-
-                    if let Some((new_id, new_creds)) = best {
-                        if update_current {
-                            let mut current_id = self.current_id.lock();
-                            *current_id = new_id;
-                        }
-                        (new_id, new_creds)
-                    } else {
-                        let entries = self.entries.lock();
-                        if let Some(retry_after) =
-                            self.rpm_retry_after_secs(&entries, model, group, Instant::now())
-                        {
-                            return Err(
-                                UpstreamRateLimitError::new(Some(retry_after.to_string())).into()
-                            );
-                        }
-                        // 注意：必须在 bail! 之前计算 available_count，
-                        // 因为 available_count() 会尝试获取 entries 锁，
-                        // 而此时我们已经持有该锁，会导致死锁
-                        let available = entries.iter().filter(|e| !e.disabled).count();
-                        anyhow::bail!("所有凭据均已禁用（{}/{}）", available, total);
-                    }
+                    // 注意：必须在 bail! 之前计算 available_count，
+                    // 因为 available_count() 会尝试获取 entries 锁，
+                    // 而此时我们已经持有该锁，会导致死锁
+                    let available = entries.iter().filter(|e| !e.disabled).count();
+                    anyhow::bail!("所有凭据均已禁用（{}/{}）", available, total);
                 };
 
                 (id, credentials, is_balanced)
@@ -2093,7 +2065,7 @@ impl MultiTokenManager {
         if let Some(best) = entries
             .iter()
             .filter(|e| !e.disabled)
-            .min_by_key(|e| e.credentials.priority)
+            .min_by_key(|e| (e.credentials.priority, e.id))
         {
             if best.id != *current_id {
                 tracing::info!(
@@ -2581,7 +2553,7 @@ impl MultiTokenManager {
                     .filter(|entry| {
                         self.entry_available_for_request(entry, model, group, Instant::now())
                     })
-                    .min_by_key(|e| e.credentials.priority)
+                    .min_by_key(|e| (e.credentials.priority, e.id))
                 {
                     *current_id = next.id;
                     tracing::info!(
@@ -2656,7 +2628,7 @@ impl MultiTokenManager {
                 .filter(|entry| {
                     self.entry_available_for_request(entry, model, group, Instant::now())
                 })
-                .min_by_key(|e| e.credentials.priority)
+                .min_by_key(|e| (e.credentials.priority, e.id))
             {
                 *current_id = next.id;
                 tracing::info!(
@@ -2824,7 +2796,7 @@ impl MultiTokenManager {
                 .filter(|entry| {
                     self.entry_available_for_request(entry, model, group, Instant::now())
                 })
-                .min_by_key(|e| e.credentials.priority)
+                .min_by_key(|e| (e.credentials.priority, e.id))
             {
                 *current_id = next.id;
                 tracing::info!(
@@ -2890,7 +2862,7 @@ impl MultiTokenManager {
                 let has_available = if let Some(next) = entries
                     .iter()
                     .filter(|e| !e.disabled)
-                    .min_by_key(|e| e.credentials.priority)
+                    .min_by_key(|e| (e.credentials.priority, e.id))
                 {
                     *current_id = next.id;
                     tracing::info!(
@@ -2946,7 +2918,7 @@ impl MultiTokenManager {
             if let Some(next) = entries
                 .iter()
                 .filter(|e| !e.disabled)
-                .min_by_key(|e| e.credentials.priority)
+                .min_by_key(|e| (e.credentials.priority, e.id))
             {
                 *current_id = next.id;
                 tracing::info!(
@@ -2978,7 +2950,7 @@ impl MultiTokenManager {
         if let Some(next) = entries
             .iter()
             .filter(|e| !e.disabled && e.id != *current_id)
-            .min_by_key(|e| e.credentials.priority)
+            .min_by_key(|e| (e.credentials.priority, e.id))
         {
             *current_id = next.id;
             tracing::info!(
@@ -6578,7 +6550,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_model_routing_prefers_confirmed_cache_over_unknown_current() {
+    async fn test_priority_routing_prefers_priority_over_unknown_model_cache() {
         let mut confirmed = grouped_cred("confirmed", &[]);
         confirmed.priority = 10;
         let manager = MultiTokenManager::new(
@@ -6595,7 +6567,7 @@ mod tests {
             .acquire_context(Some("minimax-m2.5"), None)
             .await
             .unwrap();
-        assert_eq!(context.id, 2);
+        assert_eq!(context.id, 1);
     }
 
     #[tokio::test]
@@ -6728,6 +6700,113 @@ mod tests {
         assert!(manager.select_next_credential(None, Some("nope")).is_none());
         // 未绑定分组(None) → 可选到账号
         assert!(manager.select_next_credential(None, None).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_priority_mode_ignores_stale_current_id() {
+        let mut first = grouped_cred("first", &[]);
+        first.priority = 0;
+        let mut second = grouped_cred("second", &[]);
+        second.priority = 10;
+        let manager =
+            MultiTokenManager::new(Config::default(), vec![first, second], None, None, false)
+                .unwrap();
+
+        assert!(manager.switch_to_next());
+        assert_eq!(manager.snapshot().current_id, 2);
+
+        let context = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(context.id, 1);
+        assert_eq!(manager.snapshot().current_id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_priority_mode_selects_smallest_priority_in_request_group() {
+        let mut other_group = grouped_cred("other", &["g2"]);
+        other_group.priority = 0;
+        let mut later_in_group = grouped_cred("later", &["g1"]);
+        later_in_group.priority = 20;
+        let mut first_in_group = grouped_cred("first", &["g1"]);
+        first_in_group.priority = 10;
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![other_group, later_in_group, first_in_group],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        let context = manager.acquire_context(None, Some("g1")).await.unwrap();
+        assert_eq!(context.id, 3);
+        assert_eq!(manager.snapshot().current_id, 3);
+    }
+
+    #[tokio::test]
+    async fn test_priority_mode_falls_through_at_rpm_limit_and_switches_back() {
+        let mut config = Config::default();
+        config.account_rpm_limit_enabled = true;
+        config.account_rpm_limit = 1;
+
+        let mut first = grouped_cred("first", &[]);
+        first.priority = 0;
+        let mut second = grouped_cred("second", &[]);
+        second.priority = 10;
+        let manager = MultiTokenManager::new(config, vec![first, second], None, None, false).unwrap();
+
+        let first_context = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(first_context.id, 1);
+
+        let fallback_context = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(fallback_context.id, 2);
+
+        {
+            let mut entries = manager.entries.lock();
+            let expired = Instant::now() - StdDuration::from_secs(RPM_WINDOW_SECS + 1);
+            for timestamp in entries[0].rpm_window.iter_mut() {
+                *timestamp = expired;
+            }
+        }
+
+        let recovered_context = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(recovered_context.id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_priority_mode_switches_back_after_higher_priority_is_enabled() {
+        let mut first = grouped_cred("first", &[]);
+        first.priority = 0;
+        let mut second = grouped_cred("second", &[]);
+        second.priority = 10;
+        let manager =
+            MultiTokenManager::new(Config::default(), vec![first, second], None, None, false)
+                .unwrap();
+
+        manager.set_disabled(1, true).unwrap();
+        let fallback_context = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(fallback_context.id, 2);
+
+        manager.set_disabled(1, false).unwrap();
+        let recovered_context = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(recovered_context.id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_priority_mode_uses_id_to_break_equal_priority_ties() {
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![grouped_cred("first", &[]), grouped_cred("second", &[])],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert!(manager.switch_to_next());
+        assert_eq!(manager.snapshot().current_id, 2);
+
+        let context = manager.acquire_context(None, None).await.unwrap();
+        assert_eq!(context.id, 1);
     }
 
     #[tokio::test]

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1050,6 +1050,8 @@ pub struct CredentialEntrySnapshot {
     pub masked_api_key: Option<String>,
     /// 用户邮箱（用于前端显示）
     pub email: Option<String>,
+    /// 最近一次查询到的 Kiro 订阅等级；凭据禁用后也应保留展示。
+    pub subscription_title: Option<String>,
     /// API 调用成功次数
     pub success_count: u64,
     /// 最后一次 API 调用时间（RFC3339 格式）
@@ -3052,6 +3054,7 @@ impl MultiTokenManager {
                         None
                     },
                     email: e.credentials.email.clone(),
+                    subscription_title: e.credentials.subscription_title.clone(),
                     success_count: e.success_count,
                     last_used_at: e.last_used_at.clone(),
                     has_proxy: e.credentials.proxy_url.is_some(),

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1076,6 +1076,8 @@ pub struct CredentialEntrySnapshot {
     /// 账号来源渠道（纯备注）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_channel: Option<String>,
+    /// 凭据扩展元数据
+    pub metadata: crate::kiro::model::credentials::CredentialMetadata,
     /// 凭据添加（创建）时间（RFC3339 格式）；旧凭据缺失时为 None
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
@@ -3064,6 +3066,7 @@ impl MultiTokenManager {
                     endpoint: e.credentials.endpoint.clone(),
                     groups: e.credentials.groups.clone(),
                     source_channel: e.credentials.source_channel.clone(),
+                    metadata: e.credentials.metadata.clone(),
                     created_at: e.credentials.created_at.clone(),
                 })
                 .collect(),
@@ -3769,6 +3772,7 @@ impl MultiTokenManager {
         validated_cred.proxy_username = new_cred.proxy_username;
         validated_cred.proxy_password = new_cred.proxy_password;
         validated_cred.kiro_api_key = new_cred.kiro_api_key;
+        validated_cred.metadata = new_cred.metadata;
         // 记录添加时间：保留导入时携带的原值（如 KAM 迁移），否则以当前时间入库。
         // 此处为所有添加路径（单条添加 / 批量导入 / 登录回调）的唯一收口。
         if validated_cred.created_at.is_none() {
@@ -3841,6 +3845,7 @@ impl MultiTokenManager {
         proxy_password: Option<Option<String>>,
         groups: Option<Vec<String>>,
         source_channel: Option<Option<String>>,
+        metadata: Option<crate::kiro::model::credentials::CredentialMetadata>,
     ) -> anyhow::Result<()> {
         let invalidate_models =
             proxy_url.is_some() || proxy_username.is_some() || proxy_password.is_some();
@@ -3873,6 +3878,9 @@ impl MultiTokenManager {
             if let Some(v) = source_channel {
                 entry.credentials.source_channel =
                     v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+            }
+            if let Some(v) = metadata {
+                entry.credentials.metadata = v;
             }
         }
         if invalidate_models {
@@ -6540,12 +6548,46 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .unwrap();
 
         assert_eq!(
             manager.cached_model_support(1, Some("glm-5")),
             CachedModelSupport::Unknown
+        );
+    }
+
+    #[test]
+    fn test_update_credential_preserves_extensible_metadata() {
+        let manager = MultiTokenManager::new(
+            Config::default(),
+            vec![grouped_cred("token", &[])],
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        let metadata = crate::kiro::model::credentials::CredentialMetadata {
+            kind: crate::kiro::model::credentials::CredentialType::Boom,
+            extra: std::collections::BTreeMap::from([(
+                "supplier".to_string(),
+                serde_json::Value::String("vendor-a".to_string()),
+            )]),
+        };
+
+        manager
+            .update_credential(1, None, None, None, None, None, None, Some(metadata))
+            .unwrap();
+
+        let snapshot = manager.snapshot();
+        assert_eq!(
+            snapshot.entries[0].metadata.kind,
+            crate::kiro::model::credentials::CredentialType::Boom
+        );
+        assert_eq!(
+            snapshot.entries[0].metadata.extra.get("supplier"),
+            Some(&serde_json::Value::String("vendor-a".to_string()))
         );
     }
 

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -1517,7 +1517,7 @@ impl MultiTokenManager {
         self.model_refresh_locks.lock().remove(&id);
     }
 
-    fn invalidate_all_model_caches(&self) {
+    pub fn invalidate_all_model_caches(&self) {
         self.model_cache_epoch.fetch_add(1, Ordering::Relaxed);
         self.model_cache.lock().clear();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,14 +92,19 @@ async fn main() {
 
     let configured_api_key = config.api_key.clone().filter(|k| !k.trim().is_empty());
 
-    // 构建代理配置
-    let proxy_config = config.proxy_url.as_ref().map(|url| {
-        let mut proxy = http_client::ProxyConfig::new(url);
-        if let (Some(username), Some(password)) = (&config.proxy_username, &config.proxy_password) {
-            proxy = proxy.with_auth(username, password);
-        }
-        proxy
-    });
+    // 构建代理配置（空字符串视为未配置）
+    let proxy_config = config
+        .proxy_url
+        .as_ref()
+        .filter(|url| !url.trim().is_empty())
+        .map(|url| {
+            let mut proxy = http_client::ProxyConfig::new(url);
+            if let (Some(username), Some(password)) = (&config.proxy_username, &config.proxy_password)
+            {
+                proxy = proxy.with_auth(username, password);
+            }
+            proxy
+        });
 
     if proxy_config.is_some() {
         tracing::info!("已配置 HTTP 代理: {}", config.proxy_url.as_ref().unwrap());

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -274,6 +274,10 @@ pub struct Config {
     #[serde(default)]
     pub custom_models: Vec<CustomModel>,
 
+    /// 凭据 metadata 的 JSON Schema。未配置时使用程序内置 schema。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_metadata_schema: Option<serde_json::Value>,
+
     /// 配置文件路径（运行时元数据，不写入 JSON）
     #[serde(skip)]
     config_path: Option<PathBuf>,
@@ -423,6 +427,7 @@ impl Default for Config {
             usage_log_retention_days: default_usage_log_retention_days(),
             endpoints: HashMap::new(),
             custom_models: Vec::new(),
+            credential_metadata_schema: None,
             config_path: None,
         }
     }

--- a/src/model/custom_models.rs
+++ b/src/model/custom_models.rs
@@ -1,14 +1,15 @@
 //! 自定义模型全局注册表
 //!
-//! 启动时由 [`init`] 从 `config.custom_models` 装载一次，运行期只读。仿
-//! `crate::token` / `crate::kiro::machine_id` 的 `OnceLock` 惯例，避免把配置表
-//! 逐层透传进 `map_model` / `get_context_window_size` 等无状态自由函数。
+//! 启动时由 [`init`] 从 `config.custom_models` 装载，运行期可通过 Admin API
+//! 热更新（`RwLock` 写锁替换）。仿 `crate::token` / `crate::kiro::machine_id`
+//! 的全局单例惯例，避免把配置表逐层透传进 `map_model` /
+//! `get_context_window_size` 等无状态自由函数。
 //!
 //! 匹配规则：按模型 `id` 大小写不敏感精确匹配；找不到时自动剥离 `-thinking`
 //! 后缀再试一次（与内置 `map_model` 对 thinking 变体的处理保持一致）。
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use super::config::CustomModel;
 
@@ -20,46 +21,51 @@ struct CustomModelRegistry {
     by_id: HashMap<String, usize>,
 }
 
-static REGISTRY: OnceLock<CustomModelRegistry> = OnceLock::new();
+static REGISTRY: RwLock<Option<CustomModelRegistry>> = RwLock::new(None);
 
-/// 初始化自定义模型注册表。
+/// 初始化 / 热更新自定义模型注册表。
 ///
-/// 应在应用启动时调用一次；重复调用会被忽略（`OnceLock` 语义）。后一条同名 id
+/// 启动时调用一次，运行期可通过 Admin API 再次调用以热更新。后一条同名 id
 /// 覆盖前一条的索引，但两者都保留在 `ordered` 中（`/v1/models` 会同时展示）。
 pub fn init(models: Vec<CustomModel>) {
     let mut by_id = HashMap::with_capacity(models.len());
     for (idx, m) in models.iter().enumerate() {
         by_id.insert(m.id.to_ascii_lowercase(), idx);
     }
-    let _ = REGISTRY.set(CustomModelRegistry {
-        ordered: models,
-        by_id,
-    });
+    if let Ok(mut reg) = REGISTRY.write() {
+        *reg = Some(CustomModelRegistry {
+            ordered: models,
+            by_id,
+        });
+    }
 }
 
 /// 按模型名查找自定义模型定义。
 ///
 /// 先按大小写不敏感精确匹配；未命中且名字带 `-thinking` 后缀时，剥离后再试一次。
-pub fn lookup(model: &str) -> Option<&'static CustomModel> {
-    let reg = REGISTRY.get()?;
+pub fn lookup(model: &str) -> Option<CustomModel> {
+    let reg = REGISTRY.read().ok()?;
+    let registry = reg.as_ref()?;
     let key = model.to_ascii_lowercase();
-    if let Some(&idx) = reg.by_id.get(&key) {
-        return reg.ordered.get(idx);
-    }
-    if let Some(stripped) = key.strip_suffix("-thinking") {
-        if let Some(&idx) = reg.by_id.get(stripped) {
-            return reg.ordered.get(idx);
-        }
-    }
-    None
+    let idx = registry
+        .by_id
+        .get(&key)
+        .copied()
+        .or_else(|| {
+            key.strip_suffix("-thinking")
+                .and_then(|stripped| registry.by_id.get(stripped))
+                .copied()
+        })?;
+    registry.ordered.get(idx).cloned()
 }
 
 /// 返回所有已注册的自定义模型（保持配置文件中的原始顺序）。
-pub fn all() -> &'static [CustomModel] {
+pub fn all() -> Vec<CustomModel> {
     REGISTRY
-        .get()
-        .map(|r| r.ordered.as_slice())
-        .unwrap_or(&[])
+        .read()
+        .ok()
+        .and_then(|r| r.as_ref().map(|reg| reg.ordered.clone()))
+        .unwrap_or_default()
 }
 
 /// 是否存在 `backend_id` 等于给定值且声明支持 reasoning 的自定义模型。
@@ -67,9 +73,17 @@ pub fn all() -> &'static [CustomModel] {
 /// `map_model` 把别名映射成 backend_id 后，`model_supports_native_reasoning`
 /// 拿到的是 backend_id；这里按 backend_id 反查，让自定义模型能声明 reasoning 能力。
 pub fn backend_supports_reasoning(backend_id: &str) -> bool {
-    all()
-        .iter()
-        .any(|m| m.backend_id == backend_id && m.supports_reasoning == Some(true))
+    REGISTRY
+        .read()
+        .ok()
+        .and_then(|r| {
+            r.as_ref().map(|reg| {
+                reg.ordered
+                    .iter()
+                    .any(|m| m.backend_id == backend_id && m.supports_reasoning == Some(true))
+            })
+        })
+        .unwrap_or(false)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 背景

Admin 的凭据、设置、日志三页都是「顶栏下拉菜单 + 长表单」的形态：设置项挤在一个下拉里逐个展开，凭据页的筛选散落在多个下拉中，批量操作按钮和主操作抢同一行空间。凭据数量上来之后这套交互不够用了。

本 PR 把三页改造成运维控制台形态，并在此基础上加了凭据 metadata 可扩展 schema、自定义模型管理和代理配置增强。

## 改动

**三页改造为运维控制台**

- 设置页拆成独立分区（`dispatch` / `network` / `models` / `metadata` / `security` / `system`），每个分区有完整表单空间，顶栏只留跨页的核心操作。
- 凭据页顶部新增状态账条（StatusStrip）：把各状态的计数和筛选合到一处，点某段即只看该状态。默认落在「可用」而非全部 —— 这一屏最常做的事是调排队顺序，只有可用凭据才真的在队列里，混进禁用/超额的行会让拖出来的次序与实际调度顺序对不上。
- 批量操作移到吸底 BulkBar，与主操作分离，不再互相挤压。
- 抽出可复用组件：`data-table`、`detail-drawer`、`priority-preview`、`time-range`、`setting-row`、`credential-label`、`rail`。
- 搜索框加快捷键：`/` 或 `Cmd/Ctrl+K` 聚焦，`Esc` 清空并失焦。
- 日志页接入 `trace_db` 查询，支持按时间窗与条件筛选；新增 `use-url-state` 让筛选状态可分享。

**凭据 metadata 可扩展 schema**

- 后端定义 metadata schema：字段的类型、描述、枚举值（`oneOf`）和默认值都由 schema 描述，接口返回字段详情，前端不再维护第二套映射表。
- 卡片在 metadata 缺显式键时降级读取 schema 默认值，「未设置」与「取默认值」的展示一致。
- 设置页新增 metadata 分区，可视化增删自定义字段，改动实时预览并刷新全局缓存。
- 内置基础字段模板 `type` / `saleStatus` / `salePrice`，默认值 `personal` / `not_for_sale` / 无，与后端 schema 校验区间一致。

**自定义模型管理与代理增强**

- 设置页支持增删改自定义模型映射，按厂商分 Tab 展示。
- 凭据编辑对话框 Tab 化，字段按用途分组。
- 全局代理支持单独配置认证用户名和密码，不必再拼进 URL。
- 专属代理不可用时自动切换到下一个凭据；异常代理在列表中标红。

## 与上游改动的两处取舍

本分支从 07-30 分叉，期间上游合了若干 PR。有两处需要说明：

**1. PR #56 的「按状态隐藏」多选下拉被状态账条取代。** 两者解决同一问题：#56 用多选做减法（隐藏这些状态），账条用单选做加法（只看这个状态）并顺带展示计数。保留两套会在同一页出现两个语义相反的状态筛选器，因此移除了 `StatusKey` / `STATUS_OPTIONS` / `credentialHasStatus`，代码里留了注释说明来由。**#56 的字段排序能力完整保留**（`sortField` / `sortDir` / 拖拽互斥），那部分与账条正交。

如果希望保留多选隐藏的语义，可以把账条改成多选，或作为「高级筛选」与账条并存 —— 按你的偏好调整。

**2. 上游 `f4d9d7d` 对 `topbar-tools.tsx` 的移动端修复。** 该 commit 抽了 `useSelfHealPanelState` hook 并给紧凑菜单加了滚动约束。本 PR 把这个文件从 1125 行拆到 294 行（设置内容搬进设置页各分区），那个 hook 重构随之失效，但**滚动约束已原样移到精简后的菜单上**（`max-h-[calc(100dvh-4.5rem)]` / `max-w-[calc(100dvw-1rem)]` / `overflow-y-auto` / `overscroll-contain`），移动端行为没有退化。

另外 `token_manager.rs` 里，本分支的「严格按优先级选择有效凭据」与上游 `da4829d` 的 RPM enforce 有重叠：解析时保留了上游的 RPM retry-after 返回 429 的逻辑，只是把「复用 current_id」改成每次按优先级重选（否则高优先级凭据从 RPM/冷却恢复后无法立即回切）。

## 验证

- `cargo check` 通过，`cargo test` **657 passed / 0 failed**（上游基线 642，本 PR 新增 15 个）
- `admin-ui`: `tsc -b` 类型检查通过，`vite build` 构建成功
- CHANGELOG 未改动，`Cargo.toml` 版本号跟随上游，发版节奏交由维护者决定

## 关于 PR 体积

54 文件 / +8487 / -2474，其中 **24 个是新增文件**（拆出来的分区与复用组件），审查成本主要在改动的 30 个文件上。26 个 commit 里有若干纯样式微调（metadata 设置页布局迭代过几轮），如果希望历史更清爽，直接 squash merge 即可 —— 我这边不依赖这些中间 commit。

如果更倾向拆成多个小 PR，可行的切法是先合「三页改造」（约 30 文件），再把 metadata / 自定义模型 / 代理作为后续 PR。代价是后者的 diff 在前者合并前会带上前者的全部改动，需要串行等待。按你的偏好，我可以重新拆。
