### PR TITLE
fix(kiro): 用量类接口携带真实 profileArn，修复 Enterprise/IdC 403

### DIFF
--- a/src/kiro/kiro_version.rs
+++ b/src/kiro/kiro_version.rs
@@ -8,9 +8,7 @@
 //! - 获取失败时调用方回退到 `config.kiro_version`，不阻塞启动。
 //!
 //! 注意：用量类 REST 接口（getUsageLimits / ListAvailableModels / setUserPreference）
-//! 不使用这里的「最新版本」——新版 IDE 对这些接口强制要求 profileArn，对 Enterprise/IdC
-//! 账号会失败。那几个接口固定使用 [`USAGE_API_KIRO_VERSION`]：该版本无需 profileArn
-//! 即可返回订阅与用量。
+//! 不使用这里的「最新版本」，而是固定使用 [`USAGE_API_KIRO_VERSION`]，见该常量的说明。
 
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -29,7 +27,11 @@ const METADATA_URL: &str =
     "https://prod.download.desktop.kiro.dev/stable/metadata-linux-x64-stable.json";
 
 /// 用量类接口（getUsageLimits / ListAvailableModels / setUserPreference）固定使用的
-/// Kiro IDE 版本：该版本下上游无需 profileArn 即可返回数据，Enterprise/IdC 账号同样可用。
+/// Kiro IDE 版本，避免 IDE 版本漂移影响用量查询。
+///
+/// 该版本号只影响 User-Agent，不决定是否需要 profileArn：这些接口对
+/// Enterprise / IdC 账号始终要求真实 profileArn（缺失时 0.9.2 报 403、新版报
+/// 400 `Invalid profileArn.`），带上后两个版本返回的数据一致。
 pub const USAGE_API_KIRO_VERSION: &str = "0.9.2";
 
 static LATEST_VERSION: OnceLock<RwLock<Option<String>>> = OnceLock::new();

--- a/src/kiro/token_manager.rs
+++ b/src/kiro/token_manager.rs
@@ -470,17 +470,46 @@ fn rest_api_region_candidates(sso_region: &str) -> [&'static str; 2] {
     }
 }
 
-fn usage_limits_url(host: &str, _credentials: &KiroCredentials) -> String {
-    // Kiro 0.9.2 accepts these REST calls without profileArn. A resolved ARN is
-    // only for the streaming endpoint and makes this legacy request malformed.
+fn profile_arn_query(profile_arn: Option<&str>) -> String {
+    match profile_arn {
+        Some(arn) => format!("&profileArn={}", urlencoding::encode(arn)),
+        None => String::new(),
+    }
+}
+
+/// 用量类接口的 403 回退候选：每个区域端点先带真实 profileArn 试，再退回不带。
+///
+/// Enterprise / IdC 账号缺 profileArn 会被上游拒（`403 User is not authorized
+/// to make this call.`）；BuilderID 占位符已由 `effective_profile_arn` 过滤，
+/// 这类账号只有「不带」一种形态，行为与加此参数前一致。
+fn usage_api_attempts<'a>(
+    credentials: &'a KiroCredentials,
+    candidates: &[&'static str],
+) -> Vec<(&'static str, Option<&'a str>)> {
+    let mut attempts = Vec::with_capacity(candidates.len() * 2);
+    for region in candidates {
+        if let Some(arn) = credentials.effective_profile_arn() {
+            attempts.push((*region, Some(arn)));
+        }
+        attempts.push((*region, None));
+    }
+    attempts
+}
+
+fn usage_limits_url(host: &str, profile_arn: Option<&str>) -> String {
     format!(
-        "https://{}/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true",
-        host
+        "https://{}/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true{}",
+        host,
+        profile_arn_query(profile_arn)
     )
 }
 
-fn available_models_url(host: &str, _credentials: &KiroCredentials) -> String {
-    format!("https://{}/ListAvailableModels?origin=AI_EDITOR", host)
+fn available_models_url(host: &str, profile_arn: Option<&str>) -> String {
+    format!(
+        "https://{}/ListAvailableModels?origin=AI_EDITOR{}",
+        host,
+        profile_arn_query(profile_arn)
+    )
 }
 
 /// 获取使用额度信息
@@ -512,10 +541,12 @@ pub(crate) async fn get_usage_limits(
 
     let client = build_client(proxy, 60, config.tls_backend)?;
 
+    let attempts = usage_api_attempts(credentials, &candidates);
+
     let mut last_error: Option<String> = None;
-    for (idx, region) in candidates.iter().enumerate() {
+    for (idx, (region, profile_arn)) in attempts.iter().enumerate() {
         let host = format!("q.{}.amazonaws.com", region);
-        let url = usage_limits_url(&host, credentials);
+        let url = usage_limits_url(&host, *profile_arn);
 
         let mut request = client
             .get(&url)
@@ -546,12 +577,12 @@ pub(crate) async fn get_usage_limits(
             return Err(error.into());
         }
 
-        // 403 且仍有备用端点时，尝试下一个区域端点（Enterprise/IdC 跨区兼容）
-        if status.as_u16() == 403 && idx + 1 < candidates.len() {
+        // 403 时依次回退：带 profileArn → 不带 → 备用区域端点
+        if status.as_u16() == 403 && idx + 1 < attempts.len() {
             tracing::debug!(
-                "getUsageLimits 在 {} 返回 403，尝试备用端点 {}",
+                "getUsageLimits 在 {} 返回 403（profileArn={}），尝试下一候选",
                 region,
-                candidates[idx + 1]
+                profile_arn.is_some()
             );
             last_error = Some(format!("{} {}", status, body_text));
             continue;
@@ -605,10 +636,12 @@ pub(crate) async fn get_available_models(
 
     let client = build_client(proxy, 60, config.tls_backend)?;
 
+    let attempts = usage_api_attempts(credentials, &candidates);
+
     let mut last_error: Option<String> = None;
-    for (idx, region) in candidates.iter().enumerate() {
+    for (idx, (region, profile_arn)) in attempts.iter().enumerate() {
         let host = format!("q.{}.amazonaws.com", region);
-        let url = available_models_url(&host, credentials);
+        let url = available_models_url(&host, *profile_arn);
 
         let mut request = client
             .get(&url)
@@ -639,12 +672,12 @@ pub(crate) async fn get_available_models(
             return Err(error.into());
         }
 
-        // 403 且仍有备用端点时，尝试下一个区域端点（Enterprise/IdC 跨区兼容）
-        if status.as_u16() == 403 && idx + 1 < candidates.len() {
+        // 403 时依次回退：带 profileArn → 不带 → 备用区域端点
+        if status.as_u16() == 403 && idx + 1 < attempts.len() {
             tracing::debug!(
-                "ListAvailableModels 在 {} 返回 403，尝试备用端点 {}",
+                "ListAvailableModels 在 {} 返回 403（profileArn={}），尝试下一候选",
                 region,
-                candidates[idx + 1]
+                profile_arn.is_some()
             );
             last_error = Some(format!("{} {}", status, body_text));
             continue;
@@ -1570,7 +1603,17 @@ impl MultiTokenManager {
         let generation = self.model_cache_generation(id);
         let epoch = self.model_cache_epoch.load(Ordering::Relaxed);
         let _permit = self.model_refresh_semaphore.acquire().await?;
-        let (token, credentials) = self.prepare_request_token(id).await?;
+        let (token, mut credentials) = self.prepare_request_token(id).await?;
+
+        // 同 get_usage_limits_for：先解析回填真实 profileArn。
+        match self.resolve_profile_arn_for(id, &token).await {
+            Ok(Some(arn)) => credentials.profile_arn = Some(arn),
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!("凭据 #{} 查询模型列表前解析 profileArn 失败: {}", id, error)
+            }
+        }
+
         let global_proxy = self.proxy.lock().clone();
         let effective_proxy = credentials.effective_proxy(global_proxy.as_ref());
         let response =
@@ -3399,7 +3442,7 @@ impl MultiTokenManager {
             }
         };
 
-        let credentials = {
+        let mut credentials = {
             let entries = self.entries.lock();
             entries
                 .iter()
@@ -3407,6 +3450,16 @@ impl MultiTokenManager {
                 .map(|e| e.credentials.clone())
                 .ok_or_else(|| anyhow::anyhow!("凭据不存在: {}", id))?
         };
+
+        // Enterprise / IdC 账号必须带真实 profileArn，先解析回填；
+        // 失败不阻断查询，由 get_usage_limits 内部按候选表回退。
+        match self.resolve_profile_arn_for(id, &token).await {
+            Ok(Some(arn)) => credentials.profile_arn = Some(arn),
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!("凭据 #{} 查询用量前解析 profileArn 失败: {}", id, error)
+            }
+        }
 
         let global_proxy = self.proxy.lock().clone();
         let effective_proxy = credentials.effective_proxy(global_proxy.as_ref());
@@ -6081,7 +6134,9 @@ mod tests {
     }
 
     #[test]
-    fn test_usage_rest_urls_omit_resolved_profile_arn() {
+    fn test_usage_rest_urls_carry_resolved_profile_arn() {
+        // Enterprise / IdC：真实 ARN 必须以 URL 编码形式出现在查询串里，
+        // 否则上游返回 403 "User is not authorized to make this call."
         let credentials = KiroCredentials {
             profile_arn: Some(
                 "arn:aws:codewhisperer:us-east-1:123456789012:profile/REAL123".to_string(),
@@ -6089,13 +6144,60 @@ mod tests {
             ..Default::default()
         };
         let host = "q.us-east-1.amazonaws.com";
+        let encoded =
+            "arn%3Aaws%3Acodewhisperer%3Aus-east-1%3A123456789012%3Aprofile%2FREAL123";
 
+        let arn = credentials.effective_profile_arn();
         assert_eq!(
-            usage_limits_url(host, &credentials),
+            usage_limits_url(host, arn),
+            format!(
+                "https://q.us-east-1.amazonaws.com/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true&profileArn={}",
+                encoded
+            )
+        );
+        assert_eq!(
+            available_models_url(host, arn),
+            format!(
+                "https://q.us-east-1.amazonaws.com/ListAvailableModels?origin=AI_EDITOR&profileArn={}",
+                encoded
+            )
+        );
+
+        // 每个区域端点先试带 ARN，403 时回退到不带
+        assert_eq!(
+            usage_api_attempts(&credentials, &["us-east-1", "eu-central-1"]),
+            vec![
+                ("us-east-1", arn),
+                ("us-east-1", None),
+                ("eu-central-1", arn),
+                ("eu-central-1", None),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_usage_rest_urls_omit_builder_id_placeholder() {
+        // BuilderID 占位符不发送：这些账号沿用不带 profileArn 的老式请求
+        use crate::kiro::model::credentials::BUILDER_ID_PROFILE_ARN;
+
+        let credentials = KiroCredentials {
+            profile_arn: Some(BUILDER_ID_PROFILE_ARN.to_string()),
+            ..Default::default()
+        };
+        let host = "q.us-east-1.amazonaws.com";
+
+        // 占位符被过滤，只剩「不带 ARN」一种形态：与加此参数前的行为一致
+        assert_eq!(credentials.effective_profile_arn(), None);
+        assert_eq!(
+            usage_api_attempts(&credentials, &["us-east-1", "eu-central-1"]),
+            vec![("us-east-1", None), ("eu-central-1", None)]
+        );
+        assert_eq!(
+            usage_limits_url(host, None),
             "https://q.us-east-1.amazonaws.com/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true"
         );
         assert_eq!(
-            available_models_url(host, &credentials),
+            available_models_url(host, None),
             "https://q.us-east-1.amazonaws.com/ListAvailableModels?origin=AI_EDITOR"
         );
     }


### PR DESCRIPTION
## 问题

Enterprise / IAM Identity Center (IdC) 账号刷新余额和可用模型时固定失败，但同一账号的对话请求完全正常：

```
WARN kiro_rs::admin::error: Admin 上游服务请求失败
error=权限不足，无法获取使用额度: 403 Forbidden
{"message":"User is not authorized to make this call.","reason":null}
```

## 根因

`getUsageLimits` / `ListAvailableModels` 一直不发送 `profileArn`。流式聊天之所以正常，是因为 `provider.rs` 在请求前会调用 `resolve_profile_arn_for` 解析真实 ARN，而用量类接口没有这一步。

原注释断言「Kiro 0.9.2 无需 profileArn，带上反而使请求格式错误」，该前提对 Enterprise/IdC 账号已不成立，估计是 AWS 侧有过调整。实测（IdC 账号）：

| 接口 | 不带 ARN | 带 ARN |
|---|---|---|
| `getUsageLimits` | 403 `User is not authorized to make this call.` | 200 |
| `ListAvailableModels` | 403 同上 | 200 |

另外确认版本号只影响 User-Agent、不决定是否需要 ARN：`0.9.2` 缺 ARN 报 403，最新版 `1.0.337` 缺 ARN 报 400 `Invalid profileArn.`；带上 ARN 两版本均 200 且 `usageBreakdownList` 等关键字段一致。因此 `USAGE_API_KIRO_VERSION` 保持不变，仅订正其失实注释。

## 改动

- `usage_limits_url` / `available_models_url` 改为接收 `Option<&str>`，以 URL 编码追加 `&profileArn=…`
- 新增 `usage_api_attempts`：把「区域端点 × ARN 形态」摊平成一维候选表，每个区域先带真实 ARN 试、再退回不带。请求循环仍是原来的单层结构，只是候选表从 `candidates` 换成 `attempts`
- `get_usage_limits_for` / `refresh_model_cache_for` 在请求前调用 `resolve_profile_arn_for`，使新导入、尚无 ARN 的 IdC 凭据自动解析并回填

## 兼容性

`effective_profile_arn` 本就过滤 BuilderID 占位符，这类账号的候选表只有「不带 ARN」一种形态，行为与改动前完全一致。此外带 ARN 若仍被拒会自动退回不带 ARN 的老式请求 —— 手头没有 BuilderID / Social 账号可实测，故取这个保守策略兜底。

## 验证

- `cargo test` 667/667 通过；改写了原本断言缺陷行为的 `test_usage_rest_urls_omit_resolved_profile_arn`，另加占位符不外发的用例
- release 二进制以隔离配置实跑：删除凭据 `profileArn` 后启动，日志显示「已解析并回填真实 profileArn」，余额后台刷新成功、余额与模型接口均返回正常数据，全程无 403
