### PR TITLE
fix(compact): 修复 compact 报错及兼容性问题

### DIFF
--- a/src/anthropic/converter.rs
+++ b/src/anthropic/converter.rs
@@ -572,11 +572,23 @@ pub struct ConversionResult {
     pub additional_model_request_fields: Option<AdditionalModelRequestFields>,
 }
 
+/// Internal conversion purpose. Clients cannot select this directly; the
+/// Responses adapter uses `Compact` only after validating a terminal
+/// `compaction_trigger` item.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConversionPurpose {
+    Generate,
+    Compact,
+}
+
+const COMPACTION_HISTORY_TOOL_NAME: &str = "kiro_compaction_history_tool";
+
 /// 转换错误
 #[derive(Debug)]
 pub enum ConversionError {
     InvalidModel(String),
     EmptyMessages,
+    InvalidMessageSequence(String),
     /// Claude Code 工具无法映射到 Kiro 内置工具（如 Read.pages 无对应、内置缺 schema）。
     UnsupportedToolMapping(String),
 }
@@ -586,6 +598,9 @@ impl std::fmt::Display for ConversionError {
         match self {
             ConversionError::InvalidModel(reason) => write!(f, "无效模型 ID: {}", reason),
             ConversionError::EmptyMessages => write!(f, "消息列表为空"),
+            ConversionError::InvalidMessageSequence(reason) => {
+                write!(f, "消息序列无效: {}", reason)
+            }
             ConversionError::UnsupportedToolMapping(reason) => {
                 write!(f, "工具映射不支持: {}", reason)
             }
@@ -667,6 +682,29 @@ fn create_placeholder_tool(name: &str) -> Tool {
     }
 }
 
+fn create_compaction_history_tool() -> Tool {
+    Tool {
+        tool_specification: ToolSpecification {
+            name: COMPACTION_HISTORY_TOOL_NAME.to_string(),
+            description: "Inert placeholder for structured tool calls in compacted history. Do not call it."
+                .to_string(),
+            input_schema: InputSchema::from_json(serde_json::json!({
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": true
+            })),
+        },
+    }
+}
+
+fn sorted_ids(ids: &std::collections::HashSet<String>) -> Vec<String> {
+    let mut ids = ids.iter().cloned().collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
 /// 将 Anthropic 请求转换为 Kiro 请求
 /// 便捷入口（测试用）：默认按 ClaudeCode 模式转换。
 #[cfg(test)]
@@ -677,6 +715,18 @@ pub fn convert_request(req: &MessagesRequest) -> Result<ConversionResult, Conver
 pub fn convert_request_with_mode(
     req: &MessagesRequest,
     tool_compatibility_mode: ToolCompatibilityMode,
+) -> Result<ConversionResult, ConversionError> {
+    convert_request_with_purpose(
+        req,
+        tool_compatibility_mode,
+        ConversionPurpose::Generate,
+    )
+}
+
+pub(crate) fn convert_request_with_purpose(
+    req: &MessagesRequest,
+    tool_compatibility_mode: ToolCompatibilityMode,
+    purpose: ConversionPurpose,
 ) -> Result<ConversionResult, ConversionError> {
     // 1. 映射模型
     let model_id = map_model(&req.model).ok_or_else(|| {
@@ -725,14 +775,22 @@ pub fn convert_request_with_mode(
 
     // 6. 转换工具定义（超长名称自动缩短并记录映射；ClaudeCode 模式做内置工具适配）
     let mut tool_name_map = HashMap::new();
-    let mut tools = convert_tools(&req.tools, &mut tool_name_map, tool_compatibility_mode)?;
+    let mut tools = if purpose == ConversionPurpose::Compact {
+        Vec::new()
+    } else {
+        convert_tools(&req.tools, &mut tool_name_map, tool_compatibility_mode)?
+    };
 
     // 收集本次请求声明的所有工具名（原始 client 名），供 `<invoke>` 容错的工具表校验。
-    let mut known_tool_names: std::collections::HashSet<String> = req
-        .tools
-        .as_ref()
-        .map(|ts| ts.iter().map(|t| t.name.clone()).collect())
-        .unwrap_or_default();
+    let mut known_tool_names: std::collections::HashSet<String> =
+        if purpose == ConversionPurpose::Compact {
+            std::collections::HashSet::new()
+        } else {
+            req.tools
+                .as_ref()
+                .map(|ts| ts.iter().map(|t| t.name.clone()).collect())
+                .unwrap_or_default()
+        };
     // 建议3 修复：超长工具名（>63）会被 shorten 成短名发给上游，模型回吐的也是短名。
     // tool_name_map 的 key 正是这些短名，一并加入，避免「超长名工具的合法 invoke 被漏捞」。
     for short in tool_name_map.keys() {
@@ -746,16 +804,22 @@ pub fn convert_request_with_mode(
         &model_id,
         &mut tool_name_map,
         tool_compatibility_mode,
+        purpose,
     )?;
 
     // 8. 验证并过滤 tool_use/tool_result 配对
     // 移除孤立的 tool_result（没有对应的 tool_use）
     // 同时返回孤立的 tool_use_id 集合，用于后续清理
-    let (validated_tool_results, orphaned_tool_use_ids) =
-        validate_tool_pairing(&history, &tool_results);
-
-    // 9. 从历史中移除孤立的 tool_use（Kiro API 要求 tool_use 必须有对应的 tool_result）
-    remove_orphaned_tool_uses(&mut history, &orphaned_tool_use_ids);
+    let validated_tool_results = if purpose == ConversionPurpose::Compact {
+        validate_compaction_tool_sequence(&history, &tool_results)?;
+        tool_results.clone()
+    } else {
+        let (validated_tool_results, orphaned_tool_use_ids) =
+            validate_tool_pairing(&history, &tool_results);
+        // Generate keeps its existing compatibility behavior.
+        remove_orphaned_tool_uses(&mut history, &orphaned_tool_use_ids);
+        validated_tool_results
+    };
 
     // 10. 收集历史中使用的工具名称，为缺失的工具生成占位符定义
     // Kiro API 要求：历史消息中引用的工具必须在 tools 列表中有定义
@@ -766,9 +830,16 @@ pub fn convert_request_with_mode(
         .map(|t| t.tool_specification.name.to_lowercase())
         .collect();
 
-    for tool_name in history_tool_names {
-        if !existing_tool_names.contains(&tool_name.to_lowercase()) {
-            tools.push(create_placeholder_tool(&tool_name));
+    if purpose == ConversionPurpose::Compact {
+        if !history_tool_names.is_empty() {
+            tools.push(create_compaction_history_tool());
+            known_tool_names.insert(COMPACTION_HISTORY_TOOL_NAME.to_string());
+        }
+    } else {
+        for tool_name in history_tool_names {
+            if !existing_tool_names.contains(&tool_name.to_lowercase()) {
+                tools.push(create_placeholder_tool(&tool_name));
+            }
         }
     }
 
@@ -1060,6 +1131,66 @@ fn validate_tool_pairing(
     }
 
     (filtered_results, unpaired_tool_use_ids)
+}
+
+fn validate_compaction_tool_sequence(
+    history: &[Message],
+    current_tool_results: &[ToolResult],
+) -> Result<(), ConversionError> {
+    let mut pending = std::collections::HashSet::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for message in history {
+        match message {
+            Message::Assistant(assistant) => {
+                for tool_use in assistant
+                    .assistant_response_message
+                    .tool_uses
+                    .iter()
+                    .flatten()
+                {
+                    if !seen.insert(tool_use.tool_use_id.clone()) {
+                        return Err(ConversionError::InvalidMessageSequence(format!(
+                            "duplicate tool_use id in compaction history: {}",
+                            tool_use.tool_use_id
+                        )));
+                    }
+                    pending.insert(tool_use.tool_use_id.clone());
+                }
+            }
+            Message::User(user) => {
+                for result in &user
+                    .user_input_message
+                    .user_input_message_context
+                    .tool_results
+                {
+                    if !pending.remove(&result.tool_use_id) {
+                        return Err(ConversionError::InvalidMessageSequence(format!(
+                            "tool_result has no pending tool_use in compaction history: {}",
+                            result.tool_use_id
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    for result in current_tool_results {
+        if !pending.remove(&result.tool_use_id) {
+            return Err(ConversionError::InvalidMessageSequence(format!(
+                "current tool_result has no pending tool_use in compaction history: {}",
+                result.tool_use_id
+            )));
+        }
+    }
+
+    if !pending.is_empty() {
+        return Err(ConversionError::InvalidMessageSequence(format!(
+            "compaction history contains tool_use without tool_result: {}",
+            sorted_ids(&pending).join(", ")
+        )));
+    }
+    Ok(())
 }
 
 /// 从历史消息中移除孤立的 tool_use
@@ -1612,7 +1743,14 @@ fn has_thinking_tags(content: &str) -> bool {
 ///   注意：该切片与 `req.messages` 可能不同（prefill 时会截断末尾的 assistant 消息），
 ///   调用方应始终使用此参数而非 `req.messages`。
 /// * `model_id` - 已映射的 Kiro 模型 ID
-fn build_history(req: &MessagesRequest, messages: &[super::types::Message], model_id: &str, tool_name_map: &mut HashMap<String, String>, mode: ToolCompatibilityMode) -> Result<Vec<Message>, ConversionError> {
+fn build_history(
+    req: &MessagesRequest,
+    messages: &[super::types::Message],
+    model_id: &str,
+    tool_name_map: &mut HashMap<String, String>,
+    mode: ToolCompatibilityMode,
+    purpose: ConversionPurpose,
+) -> Result<Vec<Message>, ConversionError> {
     let mut history = Vec::new();
 
     // 生成thinking前缀（如果需要）
@@ -1674,7 +1812,8 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
         if msg.role == "user" {
             // 先处理累积的 assistant 消息
             if !assistant_buffer.is_empty() {
-                let merged = merge_assistant_messages(&assistant_buffer, tool_name_map, mode)?;
+                let merged =
+                    merge_assistant_messages(&assistant_buffer, tool_name_map, mode, purpose)?;
                 history.push(Message::Assistant(merged));
                 assistant_buffer.clear();
             }
@@ -1693,7 +1832,7 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
 
     // 处理末尾累积的 assistant 消息
     if !assistant_buffer.is_empty() {
-        let merged = merge_assistant_messages(&assistant_buffer, tool_name_map, mode)?;
+        let merged = merge_assistant_messages(&assistant_buffer, tool_name_map, mode, purpose)?;
         history.push(Message::Assistant(merged));
     }
 
@@ -1702,9 +1841,14 @@ fn build_history(req: &MessagesRequest, messages: &[super::types::Message], mode
         let merged_user = merge_user_messages(&user_buffer, model_id, &mut image_dedup)?;
         history.push(Message::User(merged_user));
 
-        // 自动配对一个 "OK" 的 assistant 响应
-        let auto_assistant = HistoryAssistantMessage::new("OK");
-        history.push(Message::Assistant(auto_assistant));
+        if purpose == ConversionPurpose::Compact {
+            return Err(ConversionError::InvalidMessageSequence(
+                "compaction would move an unanswered user message into history".to_string(),
+            ));
+        }
+
+        // Generate preserves the legacy compatibility pair.
+        history.push(Message::Assistant(HistoryAssistantMessage::new("OK")));
     }
 
     Ok(history)
@@ -1754,6 +1898,7 @@ fn convert_assistant_message(
     msg: &super::types::Message,
     tool_name_map: &mut HashMap<String, String>,
     mode: ToolCompatibilityMode,
+    purpose: ConversionPurpose,
 ) -> Result<HistoryAssistantMessage, ConversionError> {
     let mut thinking_content = String::new();
     let mut text_content = String::new();
@@ -1780,9 +1925,20 @@ fn convert_assistant_message(
                         "tool_use" => {
                             if let (Some(id), Some(name)) = (block.id, block.name) {
                                 let input = block.input.unwrap_or(serde_json::json!({}));
-                                let mapped_name =
-                                    map_client_tool_name_to_kiro(&name, tool_name_map, mode);
-                                let input = map_tool_input_to_kiro(&name, input, mode)?;
+                                let (mapped_name, input) = if purpose
+                                    == ConversionPurpose::Compact
+                                {
+                                    (COMPACTION_HISTORY_TOOL_NAME.to_string(), input)
+                                } else {
+                                    (
+                                        map_client_tool_name_to_kiro(
+                                            &name,
+                                            tool_name_map,
+                                            mode,
+                                        ),
+                                        map_tool_input_to_kiro(&name, input, mode)?,
+                                    )
+                                };
                                 tool_uses
                                     .push(ToolUseEntry::new(id, mapped_name).with_input(input));
                             }
@@ -1829,17 +1985,18 @@ fn merge_assistant_messages(
     messages: &[&super::types::Message],
     tool_name_map: &mut HashMap<String, String>,
     mode: ToolCompatibilityMode,
+    purpose: ConversionPurpose,
 ) -> Result<HistoryAssistantMessage, ConversionError> {
     assert!(!messages.is_empty());
     if messages.len() == 1 {
-        return convert_assistant_message(messages[0], tool_name_map, mode);
+        return convert_assistant_message(messages[0], tool_name_map, mode, purpose);
     }
 
     let mut all_tool_uses: Vec<ToolUseEntry> = Vec::new();
     let mut content_parts: Vec<String> = Vec::new();
 
     for msg in messages {
-        let converted = convert_assistant_message(msg, tool_name_map, mode)?;
+        let converted = convert_assistant_message(msg, tool_name_map, mode, purpose)?;
         let am = converted.assistant_response_message;
         if !am.content.trim().is_empty() {
             content_parts.push(am.content);
@@ -3307,7 +3464,13 @@ mod tests {
             ]),
         };
 
-        let result = convert_assistant_message(&msg, &mut HashMap::new(), ToolCompatibilityMode::Raw).expect("应该成功转换");
+        let result = convert_assistant_message(
+            &msg,
+            &mut HashMap::new(),
+            ToolCompatibilityMode::Raw,
+            ConversionPurpose::Generate,
+        )
+        .expect("应该成功转换");
 
         // 验证 content 不为空（使用占位符）
         assert!(
@@ -3342,7 +3505,13 @@ mod tests {
             ]),
         };
 
-        let result = convert_assistant_message(&msg, &mut HashMap::new(), ToolCompatibilityMode::Raw).expect("应该成功转换");
+        let result = convert_assistant_message(
+            &msg,
+            &mut HashMap::new(),
+            ToolCompatibilityMode::Raw,
+            ConversionPurpose::Generate,
+        )
+        .expect("应该成功转换");
 
         // 验证 content 使用原始文本（不是占位符）
         assert_eq!(
@@ -3455,7 +3624,13 @@ mod tests {
         };
 
         let messages: Vec<&AnthropicMessage> = vec![&msg1, &msg2];
-        let result = merge_assistant_messages(&messages, &mut HashMap::new(), ToolCompatibilityMode::Raw).expect("合并应成功");
+        let result = merge_assistant_messages(
+            &messages,
+            &mut HashMap::new(),
+            ToolCompatibilityMode::Raw,
+            ConversionPurpose::Generate,
+        )
+        .expect("合并应成功");
 
         let content = &result.assistant_response_message.content;
         assert!(content.contains("<thinking>"), "应包含 thinking 标签");

--- a/src/anthropic/handlers.rs
+++ b/src/anthropic/handlers.rs
@@ -315,6 +315,21 @@ fn count_image_budget(payload: &super::types::MessagesRequest) -> ImageBudget {
 
 /// 将 KiroProvider 错误映射为 HTTP 响应
 pub(super) fn map_provider_error(err: Error) -> Response {
+    if err
+        .downcast_ref::<crate::kiro::error::UpstreamContextOverflowError>()
+        .is_some()
+    {
+        tracing::warn!(error = %err, "上游拒绝请求：上下文窗口已满（不应重试）");
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "invalid_request_error",
+                "Context window is full. Reduce conversation history, system prompt, or tools.",
+            )),
+        )
+            .into_response();
+    }
+
     if let Some(rate_limit) = err.downcast_ref::<crate::kiro::error::UpstreamRateLimitError>() {
         tracing::warn!(error = %err, "上游限流（映射为 429）");
         let mut response = (
@@ -721,6 +736,10 @@ pub async fn post_messages(
                 ConversionError::EmptyMessages => {
                     ("invalid_request_error", "消息列表为空".to_string())
                 }
+                ConversionError::InvalidMessageSequence(reason) => (
+                    "invalid_request_error",
+                    format!("消息序列无效: {}", reason),
+                ),
                 ConversionError::UnsupportedToolMapping(reason) => (
                     "invalid_request_error",
                     format!("工具映射不支持: {}", reason),
@@ -1147,6 +1166,26 @@ fn stream_trace_usage(ctx: &StreamContext) -> TraceUsage {
 
 use super::converter::get_context_window_size;
 
+pub(crate) enum NonStreamExecutionError {
+    Provider(Error),
+    Response(Response),
+}
+
+pub(crate) fn new_non_stream_request_tracer(
+    state: &AppState,
+    key_ctx: KeyContext,
+    model: String,
+) -> std::sync::Arc<RequestTracer> {
+    std::sync::Arc::new(RequestTracer::new(
+        state,
+        RequestTraceOptions {
+            key_ctx,
+            model,
+            is_stream: false,
+        },
+    ))
+}
+
 /// 处理非流式请求
 async fn handle_non_stream_request(
     provider: std::sync::Arc<crate::kiro::provider::KiroProvider>,
@@ -1163,6 +1202,38 @@ async fn handle_non_stream_request(
     tracer: std::sync::Arc<RequestTracer>,
     group: Option<String>,
 ) -> Response {
+    match execute_non_stream_request(
+        provider,
+        request_body,
+        model,
+        input_tokens,
+        thinking_enabled,
+        tool_name_map,
+        hook,
+        cache_usage,
+        tracer,
+        group,
+    )
+    .await
+    {
+        Ok(response_body) => (StatusCode::OK, Json(response_body)).into_response(),
+        Err(NonStreamExecutionError::Provider(error)) => map_provider_error(error),
+        Err(NonStreamExecutionError::Response(response)) => response,
+    }
+}
+
+pub(crate) async fn execute_non_stream_request(
+    provider: std::sync::Arc<crate::kiro::provider::KiroProvider>,
+    request_body: &str,
+    model: &str,
+    input_tokens: i32,
+    thinking_enabled: bool,
+    tool_name_map: std::collections::HashMap<String, String>,
+    hook: UsageRecordHook,
+    cache_usage: super::cache_metering::CacheUsage,
+    tracer: std::sync::Arc<RequestTracer>,
+    group: Option<String>,
+) -> Result<serde_json::Value, NonStreamExecutionError> {
     // 调用 Kiro API（支持多凭据故障转移）
     let call_result = match provider
         .call_api(request_body, Some(tracer.as_ref()), group.as_deref())
@@ -1178,7 +1249,7 @@ async fn handle_non_stream_request(
                 None,
                 TraceUsage::zero(),
             );
-            return map_provider_error(e);
+            return Err(NonStreamExecutionError::Provider(e));
         }
     };
     let response = call_result.response;
@@ -1197,14 +1268,16 @@ async fn handle_non_stream_request(
                 None,
                 TraceUsage::zero(),
             );
-            return (
-                StatusCode::BAD_GATEWAY,
-                Json(ErrorResponse::new(
-                    "api_error",
-                    format!("读取响应失败: {}", e),
-                )),
-            )
-                .into_response();
+            return Err(NonStreamExecutionError::Response(
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(ErrorResponse::new(
+                        "api_error",
+                        format!("读取响应失败: {}", e),
+                    )),
+                )
+                    .into_response(),
+            ));
         }
     };
 
@@ -1386,11 +1459,13 @@ async fn handle_non_stream_request(
                 TraceUsage::zero(),
             );
         }
-        return (
-            StatusCode::BAD_GATEWAY,
-            Json(ErrorResponse::new("upstream_tool_json_error", message)),
-        )
-            .into_response();
+        return Err(NonStreamExecutionError::Response(
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse::new("upstream_tool_json_error", message)),
+            )
+                .into_response(),
+        ));
     }
 
     // 确定 stop_reason
@@ -1473,7 +1548,7 @@ async fn handle_non_stream_request(
             },
         },
     );
-    (StatusCode::OK, Json(response_body)).into_response()
+    Ok(response_body)
 }
 
 fn build_non_stream_content(
@@ -1710,6 +1785,10 @@ pub async fn post_messages_cc(
                 ConversionError::EmptyMessages => {
                     ("invalid_request_error", "消息列表为空".to_string())
                 }
+                ConversionError::InvalidMessageSequence(reason) => (
+                    "invalid_request_error",
+                    format!("消息序列无效: {}", reason),
+                ),
                 ConversionError::UnsupportedToolMapping(reason) => (
                     "invalid_request_error",
                     format!("工具映射不支持: {}", reason),
@@ -2281,6 +2360,21 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         assert!(resp.headers().get(header::RETRY_AFTER).is_none());
+    }
+
+    #[tokio::test]
+    async fn typed_context_overflow_maps_to_stable_400() {
+        let resp = map_provider_error(crate::kiro::error::UpstreamContextOverflowError.into());
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Context window is full"));
     }
 
     #[tokio::test]

--- a/src/anthropic/openai.rs
+++ b/src/anthropic/openai.rs
@@ -433,6 +433,9 @@ pub(super) struct ParsedResponse {
     pub(super) model: String,
     pub(super) text: String,
     pub(super) tool_calls: Vec<Value>, // OpenAI tool_calls
+    /// Anthropic/Kiro 的原始停止原因。`finish_reason` 是面向 OpenAI
+    /// completion 兼容层的归一化值，不能用于区分输出耗尽和上下文溢出。
+    pub(super) upstream_stop_reason: String,
     pub(super) finish_reason: String,
     pub(super) prompt_tokens: i64,
     pub(super) cached_tokens: i64,
@@ -570,6 +573,7 @@ pub(super) fn parse_anthropic_message(anthropic: &Value, model: &str) -> ParsedR
         model: model.to_string(),
         text,
         tool_calls,
+        upstream_stop_reason: stop_reason.to_string(),
         finish_reason,
         prompt_tokens,
         cached_tokens,
@@ -846,6 +850,7 @@ mod tests {
             model: "gpt-5.6-sol".to_string(),
             text: "hi".to_string(),
             tool_calls: Vec::new(),
+            upstream_stop_reason: "end_turn".to_string(),
             finish_reason: "stop".to_string(),
             prompt_tokens: 7,
             cached_tokens: 0,
@@ -952,6 +957,20 @@ mod tests {
         assert_eq!(p.prompt_tokens, 14);
         assert_eq!(p.cached_tokens, 7);
         assert_eq!(p.completion_tokens, 5);
+    }
+
+    #[test]
+    fn parse_anthropic_message_preserves_upstream_stop_reason() {
+        for reason in ["max_tokens", "model_context_window_exceeded"] {
+            let anthropic = json!({
+                "content": [{"type": "text", "text": "partial"}],
+                "stop_reason": reason,
+                "usage": {"input_tokens": 3, "output_tokens": 5}
+            });
+            let parsed = parse_anthropic_message(&anthropic, "gpt-5.6-sol");
+            assert_eq!(parsed.upstream_stop_reason, reason);
+            assert_eq!(parsed.finish_reason, "length");
+        }
     }
 
     #[test]

--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -57,6 +57,9 @@ use super::types::{
     Message, MessagesRequest, Metadata, OutputConfig, SystemMessage, Thinking, Tool,
 };
 
+#[path = "responses_compaction.rs"]
+mod compaction;
+
 /// 读取内部响应体时的上限（64MB，与请求体上限对齐）
 const MAX_INNER_BODY: usize = 64 * 1024 * 1024;
 
@@ -112,7 +115,7 @@ fn flat_tool_name(namespace: Option<&str>, name: &str) -> String {
 
 // ============================ 请求类型 ============================
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ResponsesRequest {
     pub model: String,
     #[serde(default)]
@@ -142,7 +145,7 @@ fn default_parallel_tool_calls() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ReasoningConfig {
     #[serde(default)]
     pub effort: Option<String>,
@@ -194,6 +197,16 @@ pub async fn post_responses(
     headers: HeaderMap,
     Json(req): Json<ResponsesRequest>,
 ) -> Response {
+    let operation = match compaction::classify(&req.input) {
+        Ok(operation) => operation,
+        Err(message) => {
+            return responses_error(StatusCode::BAD_REQUEST, "invalid_request_error", &message);
+        }
+    };
+    if operation == compaction::Operation::RemoteCompact {
+        return compaction::handle(state, key_ctx, headers, req).await;
+    }
+
     let want_stream = req.stream;
     let model = req.model.clone();
     let response_config = ResponsesResponseConfig::from_request(&req);
@@ -678,8 +691,21 @@ fn translate_input_item(
             });
             push_merged(merged, "user", vec![block]);
         }
-        // 推理项 / 已完成的搜索展示项 / 压缩项：对 Anthropic 请求无意义，忽略
-        "reasoning" | "web_search_call" | "compaction" => {}
+        // 本代理生成的 compaction 项可还原为上一窗口的摘要；其它服务生成的
+        // opaque payload 无法解释，保持忽略。compaction_trigger 已由 handler 消费。
+        "compaction" => {
+            if let Some(summary) = item
+                .get("encrypted_content")
+                .and_then(Value::as_str)
+                .and_then(compaction::decode_payload)
+            {
+                system.push(SystemMessage {
+                    text: compaction::restored_context(&summary),
+                    cache_control: None,
+                });
+            }
+        }
+        "reasoning" | "web_search_call" | "compaction_trigger" => {}
         // "message" 或未标注 type 但带 role 的项
         _ => {
             let role = item.get("role").and_then(|v| v.as_str());
@@ -823,7 +849,6 @@ fn new_ctc_id() -> String {
 fn new_rs_id() -> String {
     format!("rs_{}", Uuid::new_v4().to_string().replace('-', ""))
 }
-
 /// 从自由文本工具的 arguments JSON 里解出原始 input 字符串。
 ///
 /// 回退链：`{"input": <string>}` → 单字段字符串对象 → 原样返回 arguments。
@@ -2123,6 +2148,26 @@ mod tests {
     }
 
     #[test]
+    fn compaction_payload_round_trips_into_system_context() {
+        let summary = "implemented parser; next run integration tests";
+        let payload = compaction::encode_payload(summary);
+        let req = req_with(
+            json!([]),
+            json!([
+                {
+                    "id": "cmp_1",
+                    "type": "compaction",
+                    "encrypted_content": payload
+                },
+                { "type": "message", "role": "user", "content": "continue" }
+            ]),
+        );
+        let (anthropic, _) = responses_to_anthropic(req, None).unwrap();
+        let system = anthropic.system.unwrap();
+        assert!(system.iter().any(|part| part.text.contains(summary)));
+    }
+
+    #[test]
     fn responses_body_session_metadata_is_forwarded() {
         let req: ResponsesRequest = serde_json::from_value(json!({
             "model": "gpt-5.6-sol",
@@ -2175,6 +2220,7 @@ mod tests {
             model: "gpt-5.6-sol".to_string(),
             text: String::new(),
             tool_calls,
+            upstream_stop_reason: "tool_use".to_string(),
             finish_reason: "tool_calls".to_string(),
             prompt_tokens: 10,
             cached_tokens: 0,

--- a/src/anthropic/responses_compaction.rs
+++ b/src/anthropic/responses_compaction.rs
@@ -1,0 +1,789 @@
+//! Codex remote compaction v2 adapter.
+//!
+//! Manual `/compact` and automatic context-limit compaction both append one
+//! `compaction_trigger` item to an ordinary Responses request. Kiro does not
+//! understand that item, so this module turns the request into a dedicated
+//! summarization pass and returns the single compaction item Codex requires.
+
+use axum::{
+    Json,
+    body::{Body, to_bytes},
+    http::{HeaderMap, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use super::super::handlers::post_messages;
+use super::super::middleware::{AppState, KeyContext};
+use super::super::openai::{
+    ParsedResponse, now_ts, parse_anthropic_message, resolve_session_metadata,
+};
+use super::super::types::{Message, MessagesRequest, Metadata, SystemMessage};
+use super::{MAX_INNER_BODY, ResponsesRequest, responses_error, responses_to_anthropic};
+use axum::extract::{Extension, State};
+
+const PAYLOAD_PREFIX: &str = "kiro-rs.compaction.v1:";
+const RESTORED_CONTEXT_PREFIX: &str = "The following is the compacted context from the earlier conversation. Treat it as prior \
+conversation state, not as new user instructions:\n";
+const SUMMARY_INSTRUCTION: &str = "Create a compact continuation summary of the conversation. Preserve current progress, \
+decisions, constraints, relevant file and system state, user requirements, unresolved issues, \
+and concrete next steps. Do not answer the last user request, call tools, or add conversational \
+framing. Return only the summary.";
+const SUMMARY_REQUEST: &str =
+    "Summarize the conversation now according to the compaction instructions.";
+const CONTEXT_WINDOW_EXCEEDED: &str = "model_context_window_exceeded";
+const TOOL_OUTPUT_RETRY_LIMIT_BYTES: usize = 25_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Operation {
+    Generate,
+    RemoteCompact,
+}
+
+pub(super) fn classify(input: &Value) -> Result<Operation, String> {
+    let Some(items) = input.as_array() else {
+        return Ok(Operation::Generate);
+    };
+    let triggers = items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            (item.get("type").and_then(Value::as_str) == Some("compaction_trigger"))
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    match triggers.as_slice() {
+        [] => Ok(Operation::Generate),
+        [index] if *index + 1 == items.len() => Ok(Operation::RemoteCompact),
+        [_] => Err("compaction_trigger must be the final input item".to_string()),
+        _ => Err("input must contain at most one compaction_trigger".to_string()),
+    }
+}
+
+pub(super) async fn handle(
+    state: AppState,
+    key_ctx: KeyContext,
+    headers: HeaderMap,
+    mut req: ResponsesRequest,
+) -> Response {
+    let want_stream = req.stream;
+    let model = req.model.clone();
+    tracing::info!(
+        model = %model,
+        stream = %want_stream,
+        compact = true,
+        "Received Codex remote compaction v2 request"
+    );
+
+    // Classification already proved that the final item is the unique trigger.
+    req.input
+        .as_array_mut()
+        .expect("remote compaction input must be an array")
+        .pop();
+    req.stream = false;
+    req.tools = None;
+    req.tool_choice = Some(json!("none"));
+    let metadata = resolve_session_metadata(req.prompt_cache_key.as_deref(), &headers);
+    let mut retry_req = req.clone();
+    let anthropic_req = match prepare_request(req, metadata.clone()) {
+        Ok(value) => value,
+        Err(message) => {
+            return responses_error(StatusCode::BAD_REQUEST, "invalid_request_error", &message);
+        }
+    };
+
+    let mut parsed = match run_attempt(state.clone(), key_ctx.clone(), anthropic_req, &model).await
+    {
+        Ok(parsed) => parsed,
+        Err(response) => return response,
+    };
+
+    if parsed.upstream_stop_reason == CONTEXT_WINDOW_EXCEEDED {
+        let stats = truncate_large_tool_outputs(&mut retry_req.input);
+        if stats.items > 0 {
+            tracing::warn!(
+                model = %model,
+                truncated_tool_outputs = stats.items,
+                removed_bytes = stats.removed_bytes,
+                "Kiro compaction exceeded the context window; retrying with bounded tool outputs"
+            );
+            let retry = match prepare_request(retry_req, metadata) {
+                Ok(value) => value,
+                Err(message) => {
+                    return responses_error(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request_error",
+                        &message,
+                    );
+                }
+            };
+            parsed = match run_attempt(state, key_ctx, retry, &model).await {
+                Ok(parsed) => parsed,
+                Err(response) => return response,
+            };
+        } else {
+            tracing::warn!(
+                model = %model,
+                "Kiro compaction exceeded the context window and had no oversized tool outputs to reduce"
+            );
+        }
+    }
+
+    let outcome = validate(parsed);
+    if want_stream {
+        render_stream(outcome, &model)
+    } else {
+        render_json(outcome, &model)
+    }
+}
+
+fn prepare_request(
+    req: ResponsesRequest,
+    metadata: Option<Metadata>,
+) -> Result<MessagesRequest, String> {
+    let (mut anthropic_req, _) = responses_to_anthropic(req, metadata)?;
+    anthropic_req.stream = false;
+    anthropic_req.tools = None;
+    anthropic_req.tool_choice = None;
+    append_summary_request(&mut anthropic_req);
+    anthropic_req
+        .system
+        .get_or_insert_with(Vec::new)
+        .push(SystemMessage {
+            text: SUMMARY_INSTRUCTION.to_string(),
+            cache_control: None,
+        });
+    Ok(anthropic_req)
+}
+
+async fn run_attempt(
+    state: AppState,
+    key_ctx: KeyContext,
+    anthropic_req: MessagesRequest,
+    model: &str,
+) -> Result<ParsedResponse, Response> {
+    let inner = post_messages(State(state), Extension(key_ctx), Json(anthropic_req)).await;
+    let status = inner.status();
+    let body = match to_bytes(inner.into_body(), MAX_INNER_BODY).await {
+        Ok(body) => body,
+        Err(error) => {
+            return Err(responses_error(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("failed to read compaction response: {error}"),
+            ));
+        }
+    };
+    if !status.is_success() {
+        return Err(Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap());
+    }
+    let anthropic: Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(error) => {
+            return Err(responses_error(
+                StatusCode::BAD_GATEWAY,
+                "api_error",
+                &format!("failed to parse compaction response: {error}"),
+            ));
+        }
+    };
+    let parsed = parse_anthropic_message(&anthropic, &model);
+    tracing::info!(
+        model = %model,
+        stop_reason = %parsed.upstream_stop_reason,
+        input_tokens = parsed.prompt_tokens,
+        output_tokens = parsed.completion_tokens,
+        "Kiro compaction attempt finished"
+    );
+    Ok(parsed)
+}
+
+/// A Kiro compaction pass is a fresh user turn over the history being
+/// summarized. Always append it so an assistant reply, an unanswered user
+/// message, or a tool result can never become the active generation turn.
+fn append_summary_request(req: &mut MessagesRequest) {
+    req.messages.push(Message {
+        role: "user".to_string(),
+        content: json!([{
+            "type": "text",
+            "text": SUMMARY_REQUEST,
+        }]),
+    });
+}
+
+#[derive(Default)]
+struct TruncationStats {
+    items: usize,
+    removed_bytes: usize,
+}
+
+/// Applies Kiro's aggressive compaction bound only after a confirmed context
+/// overflow. The Responses item and call id remain intact, so tool pairing is
+/// preserved when the retry is translated back to Kiro history.
+fn truncate_large_tool_outputs(input: &mut Value) -> TruncationStats {
+    let mut stats = TruncationStats::default();
+    let Some(items) = input.as_array_mut() else {
+        return stats;
+    };
+    for item in items {
+        let item_type = item.get("type").and_then(Value::as_str);
+        if !matches!(
+            item_type,
+            Some("function_call_output" | "custom_tool_call_output")
+        ) {
+            continue;
+        }
+        let Some(output) = item.get_mut("output") else {
+            continue;
+        };
+        let text = super::stringify_output(Some(output));
+        if text.len() <= TOOL_OUTPUT_RETRY_LIMIT_BYTES {
+            continue;
+        }
+        let original_bytes = text.len();
+        let truncated = truncate_middle(&text, TOOL_OUTPUT_RETRY_LIMIT_BYTES);
+        stats.items += 1;
+        stats.removed_bytes += original_bytes.saturating_sub(truncated.len());
+        *output = Value::String(truncated);
+    }
+    stats
+}
+
+fn truncate_middle(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let marker = format!(
+        "\n[... tool output truncated for compaction retry; original size: {} bytes ...]\n",
+        text.len()
+    );
+    if marker.len() >= max_bytes {
+        let mut end = max_bytes.min(marker.len());
+        while end > 0 && !marker.is_char_boundary(end) {
+            end -= 1;
+        }
+        return marker[..end].to_string();
+    }
+    let content_budget = max_bytes.saturating_sub(marker.len());
+    let head_budget = content_budget * 3 / 4;
+    let tail_budget = content_budget.saturating_sub(head_budget);
+
+    let mut head_end = head_budget.min(text.len());
+    while head_end > 0 && !text.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    let mut tail_start = text.len().saturating_sub(tail_budget);
+    while tail_start < text.len() && !text.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+
+    let mut result = String::with_capacity(max_bytes);
+    result.push_str(&text[..head_end]);
+    result.push_str(&marker);
+    result.push_str(&text[tail_start..]);
+    result
+}
+
+enum Outcome {
+    Complete {
+        item: Value,
+        usage: Value,
+    },
+    Incomplete {
+        usage: Value,
+    },
+    Failed {
+        code: &'static str,
+        message: String,
+        usage: Value,
+    },
+}
+
+fn validate(parsed: ParsedResponse) -> Outcome {
+    let usage = usage(&parsed);
+    match parsed.upstream_stop_reason.as_str() {
+        "max_tokens" => return Outcome::Incomplete { usage },
+        CONTEXT_WINDOW_EXCEEDED => {
+            return Outcome::Failed {
+                code: "context_length_exceeded",
+                message: "upstream context window exceeded after compaction recovery".to_string(),
+                usage,
+            };
+        }
+        _ => {}
+    }
+    if !parsed.tool_calls.is_empty() {
+        return Outcome::Failed {
+            code: "compaction_error",
+            message: "upstream returned a tool call instead of a compaction summary".to_string(),
+            usage,
+        };
+    }
+    let summary = parsed.text.trim();
+    if summary.is_empty() {
+        return Outcome::Failed {
+            code: "compaction_error",
+            message: "upstream completed without a compaction summary".to_string(),
+            usage,
+        };
+    }
+    Outcome::Complete {
+        item: json!({
+            "id": new_compaction_id(),
+            "type": "compaction",
+            "encrypted_content": encode_payload(summary),
+        }),
+        usage,
+    }
+}
+
+fn usage(parsed: &ParsedResponse) -> Value {
+    json!({
+        "input_tokens": parsed.prompt_tokens,
+        "input_tokens_details": { "cached_tokens": parsed.cached_tokens },
+        "output_tokens": parsed.completion_tokens,
+        "output_tokens_details": { "reasoning_tokens": 0 },
+        "total_tokens": parsed.prompt_tokens.saturating_add(parsed.completion_tokens),
+    })
+}
+
+fn response_object(id: &str, model: &str, status: &str, output: Vec<Value>, usage: Value) -> Value {
+    let mut response = json!({
+        "id": id,
+        "object": "response",
+        "created_at": now_ts(),
+        "status": status,
+        "model": model,
+        "output": output,
+        "usage": usage,
+    });
+    if status == "incomplete" {
+        response["incomplete_details"] = json!({ "reason": "max_output_tokens" });
+    }
+    response
+}
+
+fn render_json(outcome: Outcome, model: &str) -> Response {
+    let id = new_response_id();
+    let response = match outcome {
+        Outcome::Complete { item, usage } => {
+            response_object(&id, model, "completed", vec![item], usage)
+        }
+        Outcome::Incomplete { usage } => {
+            response_object(&id, model, "incomplete", Vec::new(), usage)
+        }
+        Outcome::Failed {
+            code,
+            message,
+            usage,
+        } => {
+            let mut response = response_object(&id, model, "failed", Vec::new(), usage);
+            response["error"] = json!({ "code": code, "message": message });
+            response
+        }
+    };
+    (StatusCode::OK, Json(response)).into_response()
+}
+
+fn render_stream(outcome: Outcome, model: &str) -> Response {
+    let id = new_response_id();
+    let created_at = now_ts();
+    let mut sequence = 0_i64;
+    let mut body = String::new();
+    let mut emit = |event: &str, mut payload: Value| {
+        payload["type"] = json!(event);
+        payload["sequence_number"] = json!(sequence);
+        sequence += 1;
+        body.push_str(&format!("event: {event}\ndata: {payload}\n\n"));
+    };
+    let initial = json!({
+        "id": id, "object": "response", "created_at": created_at,
+        "status": "in_progress", "model": model, "output": [],
+    });
+    emit("response.created", json!({ "response": initial.clone() }));
+    emit("response.in_progress", json!({ "response": initial }));
+    match outcome {
+        Outcome::Complete { item, usage } => {
+            emit(
+                "response.output_item.added",
+                json!({ "output_index": 0, "item": item.clone() }),
+            );
+            emit(
+                "response.output_item.done",
+                json!({ "output_index": 0, "item": item.clone() }),
+            );
+            emit(
+                "response.completed",
+                json!({ "response": response_object(&id, model, "completed", vec![item], usage) }),
+            );
+        }
+        Outcome::Incomplete { usage } => emit(
+            "response.incomplete",
+            json!({ "response": response_object(&id, model, "incomplete", Vec::new(), usage) }),
+        ),
+        Outcome::Failed {
+            code,
+            message,
+            usage,
+        } => {
+            let mut response = response_object(&id, model, "failed", Vec::new(), usage);
+            response["error"] = json!({ "code": code, "message": message });
+            emit("response.failed", json!({ "response": response }));
+        }
+    }
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .header(header::CONNECTION, "keep-alive")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+fn new_response_id() -> String {
+    format!("resp_{}", Uuid::new_v4().simple())
+}
+
+fn new_compaction_id() -> String {
+    format!("cmp_{}", Uuid::new_v4().simple())
+}
+
+pub(super) fn encode_payload(summary: &str) -> String {
+    format!("{PAYLOAD_PREFIX}{summary}")
+}
+
+pub(super) fn decode_payload(payload: &str) -> Option<String> {
+    payload
+        .strip_prefix(PAYLOAD_PREFIX)
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+}
+
+pub(super) fn restored_context(summary: &str) -> String {
+    format!("{RESTORED_CONTEXT_PREFIX}{summary}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::converter::convert_request;
+    use super::*;
+
+    fn parsed(text: &str, upstream_stop_reason: &str) -> ParsedResponse {
+        let finish_reason = match upstream_stop_reason {
+            "max_tokens" | CONTEXT_WINDOW_EXCEEDED => "length",
+            "tool_use" => "tool_calls",
+            _ => "stop",
+        };
+        ParsedResponse {
+            model: "gpt-5.6-sol".to_string(),
+            text: text.to_string(),
+            tool_calls: Vec::new(),
+            upstream_stop_reason: upstream_stop_reason.to_string(),
+            finish_reason: finish_reason.to_string(),
+            prompt_tokens: 10,
+            cached_tokens: 2,
+            completion_tokens: 4,
+            thinking: String::new(),
+            web_searches: Vec::new(),
+            credit_usage: None,
+            credit_unit: None,
+            credit_unit_plural: None,
+        }
+    }
+
+    #[test]
+    fn trigger_must_be_unique_and_final() {
+        assert_eq!(
+            classify(&json!([{ "type": "compaction_trigger" }])).unwrap(),
+            Operation::RemoteCompact
+        );
+        assert!(classify(&json!([{ "type": "compaction_trigger" }, { "role": "user" }])).is_err());
+        assert!(
+            classify(&json!([{ "type": "compaction_trigger" }, { "type": "compaction_trigger" }]))
+                .is_err()
+        );
+        assert_eq!(
+            classify(&json!([{ "role": "user" }])).unwrap(),
+            Operation::Generate
+        );
+    }
+
+    #[test]
+    fn checkpoint_marker_without_trigger_stays_on_message_path() {
+        let request: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "instructions": "You are performing a CONTEXT CHECKPOINT COMPACTION.",
+            "input": [{ "role": "user", "content": "history" }]
+        }))
+        .unwrap();
+
+        assert_eq!(classify(&request.input).unwrap(), Operation::Generate);
+        let (anthropic, _) = responses_to_anthropic(request, None).unwrap();
+        assert!(
+            anthropic
+                .system
+                .unwrap()
+                .iter()
+                .any(|part| part.text.contains("CONTEXT CHECKPOINT COMPACTION"))
+        );
+    }
+
+    fn compact_request(input: Value) -> ResponsesRequest {
+        serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "input": input,
+        }))
+        .unwrap()
+    }
+
+    fn translate_compact_input(mut request: ResponsesRequest) -> MessagesRequest {
+        assert_eq!(classify(&request.input).unwrap(), Operation::RemoteCompact);
+        request.input.as_array_mut().unwrap().pop();
+        responses_to_anthropic(request, None).unwrap().0
+    }
+
+    #[test]
+    fn assistant_ended_history_is_preserved_behind_summary_turn() {
+        const FINAL_ASSISTANT_MARKER: &str = "FINAL_ASSISTANT_STATE_9f13";
+        let mut request = translate_compact_input(compact_request(json!([
+            { "type": "message", "role": "user", "content": "do the work" },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": FINAL_ASSISTANT_MARKER
+            },
+            { "type": "compaction_trigger" }
+        ])));
+
+        append_summary_request(&mut request);
+        let converted = convert_request(&request).unwrap();
+
+        assert_eq!(
+            converted
+                .conversation_state
+                .current_message
+                .user_input_message
+                .content,
+            SUMMARY_REQUEST
+        );
+        assert!(converted.conversation_state.history.iter().any(|message| {
+            matches!(
+                message,
+                crate::kiro::model::requests::conversation::Message::Assistant(assistant)
+                    if assistant.assistant_response_message.content.contains(FINAL_ASSISTANT_MARKER)
+            )
+        }));
+    }
+
+    #[test]
+    fn user_ended_history_is_preserved_behind_summary_turn() {
+        const FINAL_USER_MARKER: &str = "FINAL_USER_REQUEST_61b8";
+        let mut request = translate_compact_input(compact_request(json!([
+            { "type": "message", "role": "user", "content": "initial request" },
+            { "type": "message", "role": "assistant", "content": "previous reply" },
+            {
+                "type": "message",
+                "role": "user",
+                "content": FINAL_USER_MARKER
+            },
+            { "type": "compaction_trigger" }
+        ])));
+
+        append_summary_request(&mut request);
+        let converted = convert_request(&request).unwrap();
+        assert_eq!(
+            converted
+                .conversation_state
+                .current_message
+                .user_input_message
+                .content,
+            SUMMARY_REQUEST
+        );
+        assert!(converted.conversation_state.history.iter().any(|message| {
+            matches!(
+                message,
+                crate::kiro::model::requests::conversation::Message::User(user)
+                    if user.user_input_message.content.contains(FINAL_USER_MARKER)
+            )
+        }));
+    }
+
+    #[test]
+    fn tool_result_ended_history_is_not_the_active_compaction_turn() {
+        const TOOL_RESULT_MARKER: &str = "TOOL_RESULT_STATE_70c4";
+        let mut request = translate_compact_input(compact_request(json!([
+            { "type": "message", "role": "user", "content": "run the command" },
+            {
+                "type": "function_call",
+                "call_id": "call_70c4",
+                "name": "shell",
+                "arguments": "{\"command\":\"cargo test\"}"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_70c4",
+                "output": TOOL_RESULT_MARKER
+            },
+            { "type": "compaction_trigger" }
+        ])));
+
+        append_summary_request(&mut request);
+        let converted = convert_request(&request).unwrap();
+        let current = &converted
+            .conversation_state
+            .current_message
+            .user_input_message;
+
+        assert_eq!(current.content, SUMMARY_REQUEST);
+        assert!(
+            current.user_input_message_context.tool_results.is_empty(),
+            "historical tool results must not drive the compaction turn"
+        );
+        assert!(converted.conversation_state.history.iter().any(|message| {
+            matches!(
+                message,
+                crate::kiro::model::requests::conversation::Message::User(user)
+                    if user
+                        .user_input_message
+                        .user_input_message_context
+                        .tool_results
+                        .iter()
+                        .any(|result| {
+                            result.tool_use_id == "call_70c4"
+                                && result.content.iter().any(|content| {
+                                    content.get("text").and_then(Value::as_str)
+                                        == Some(TOOL_RESULT_MARKER)
+                                })
+                        })
+            )
+        }));
+    }
+
+    #[test]
+    fn completed_summary_emits_exactly_one_compaction_item() {
+        let response = render_stream(validate(parsed("handoff", "end_turn")), "gpt-5.6-sol");
+        let body =
+            futures::executor::block_on(to_bytes(response.into_body(), 1024 * 1024)).unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert_eq!(body.matches("event: response.output_item.done").count(), 1);
+        assert!(body.contains("\"type\":\"compaction\""));
+        assert!(!body.contains("\"type\":\"message\""));
+        assert!(body.contains("event: response.completed"));
+    }
+
+    #[test]
+    fn truncated_or_empty_summary_never_emits_compaction_item() {
+        let incomplete = render_stream(validate(parsed("partial", "max_tokens")), "gpt-5.6-sol");
+        let incomplete =
+            futures::executor::block_on(to_bytes(incomplete.into_body(), 1024 * 1024)).unwrap();
+        let incomplete = String::from_utf8(incomplete.to_vec()).unwrap();
+        assert!(incomplete.contains("event: response.incomplete"));
+        assert!(!incomplete.contains("\"type\":\"compaction\""));
+
+        let failed = render_stream(validate(parsed("   ", "end_turn")), "gpt-5.6-sol");
+        let failed =
+            futures::executor::block_on(to_bytes(failed.into_body(), 1024 * 1024)).unwrap();
+        let failed = String::from_utf8(failed.to_vec()).unwrap();
+        assert!(failed.contains("event: response.failed"));
+        assert!(!failed.contains("\"type\":\"compaction\""));
+    }
+
+    #[test]
+    fn context_overflow_is_not_reported_as_max_output_tokens() {
+        let response = render_stream(
+            validate(parsed("partial", CONTEXT_WINDOW_EXCEEDED)),
+            "gpt-5.6-sol",
+        );
+        let body =
+            futures::executor::block_on(to_bytes(response.into_body(), 1024 * 1024)).unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body.contains("event: response.failed"));
+        assert!(body.contains("\"code\":\"context_length_exceeded\""));
+        assert!(!body.contains("event: response.incomplete"));
+        assert!(!body.contains("max_output_tokens"));
+        assert!(!body.contains("\"type\":\"compaction\""));
+    }
+
+    #[test]
+    fn retry_truncation_preserves_tool_item_pairing_and_summary_turn() {
+        let large_output = format!(
+            "BEGIN:{}:END",
+            "x".repeat(TOOL_OUTPUT_RETRY_LIMIT_BYTES + 1000)
+        );
+        let mut request = compact_request(json!([
+            { "type": "message", "role": "user", "content": "run it" },
+            {
+                "type": "function_call",
+                "call_id": "call_large",
+                "name": "shell",
+                "arguments": "{\"command\":\"build\"}"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_large",
+                "output": large_output
+            },
+            { "type": "message", "role": "user", "content": "small history stays intact" },
+            { "type": "compaction_trigger" }
+        ]));
+        request.input.as_array_mut().unwrap().pop();
+
+        let stats = truncate_large_tool_outputs(&mut request.input);
+        assert_eq!(stats.items, 1);
+        assert!(stats.removed_bytes > 0);
+        let items = request.input.as_array().unwrap();
+        let output_item = &items[2];
+        assert_eq!(output_item["type"], "function_call_output");
+        assert_eq!(output_item["call_id"], "call_large");
+        let output = output_item["output"].as_str().unwrap();
+        assert!(output.len() <= TOOL_OUTPUT_RETRY_LIMIT_BYTES);
+        assert!(output.starts_with("BEGIN:"));
+        assert!(output.ends_with(":END"));
+        assert!(output.contains("tool output truncated for compaction retry"));
+        assert_eq!(items[3]["content"], "small history stays intact");
+
+        let mut anthropic = responses_to_anthropic(request, None).unwrap().0;
+        append_summary_request(&mut anthropic);
+        let converted = convert_request(&anthropic).unwrap();
+        assert_eq!(
+            converted
+                .conversation_state
+                .current_message
+                .user_input_message
+                .content,
+            SUMMARY_REQUEST
+        );
+        assert!(converted.conversation_state.history.iter().any(|message| {
+            matches!(
+                message,
+                crate::kiro::model::requests::conversation::Message::User(user)
+                    if user
+                        .user_input_message
+                        .user_input_message_context
+                        .tool_results
+                        .iter()
+                        .any(|result| result.tool_use_id == "call_large")
+            )
+        }));
+    }
+
+    #[test]
+    fn retry_truncation_is_utf8_safe() {
+        let text = "测".repeat(10_000);
+        let truncated = truncate_middle(&text, 1000);
+        assert!(truncated.len() <= 1000);
+        assert!(truncated.contains("tool output truncated for compaction retry"));
+    }
+
+    #[test]
+    fn payload_round_trips() {
+        let payload = encode_payload("summary");
+        assert_eq!(decode_payload(&payload).as_deref(), Some("summary"));
+    }
+}

--- a/src/anthropic/responses_compaction.rs
+++ b/src/anthropic/responses_compaction.rs
@@ -5,23 +5,31 @@
 //! understand that item, so this module turns the request into a dedicated
 //! summarization pass and returns the single compaction item Codex requires.
 
+#[cfg(test)]
+use axum::body::to_bytes;
 use axum::{
     Json,
-    body::{Body, to_bytes},
+    body::Body,
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use super::super::handlers::post_messages;
+use crate::kiro::model::requests::kiro::KiroRequest;
+use crate::token;
+
+use super::super::converter::{ConversionPurpose, convert_request_with_purpose};
+use super::super::handlers::{
+    NonStreamExecutionError, UsageRecordHook, execute_non_stream_request, map_provider_error,
+    new_non_stream_request_tracer,
+};
 use super::super::middleware::{AppState, KeyContext};
 use super::super::openai::{
     ParsedResponse, now_ts, parse_anthropic_message, resolve_session_metadata,
 };
 use super::super::types::{Message, MessagesRequest, Metadata, SystemMessage};
-use super::{MAX_INNER_BODY, ResponsesRequest, responses_error, responses_to_anthropic};
-use axum::extract::{Extension, State};
+use super::{ResponsesRequest, responses_error, responses_to_anthropic};
 
 const PAYLOAD_PREFIX: &str = "kiro-rs.compaction.v1:";
 const RESTORED_CONTEXT_PREFIX: &str = "The following is the compacted context from the earlier conversation. Treat it as prior \
@@ -32,8 +40,11 @@ and concrete next steps. Do not answer the last user request, call tools, or add
 framing. Return only the summary.";
 const SUMMARY_REQUEST: &str =
     "Summarize the conversation now according to the compaction instructions.";
+const CANCELLED_TOOL_RESULT: &str =
+    "Tool execution was interrupted before compaction and produced no result.";
 const CONTEXT_WINDOW_EXCEEDED: &str = "model_context_window_exceeded";
-const TOOL_OUTPUT_RETRY_LIMIT_BYTES: usize = 25_000;
+const TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES: usize = 25_000;
+const TOOL_OUTPUT_RETRY_MIN_BYTES: usize = 1_024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum Operation {
@@ -93,19 +104,30 @@ pub(super) async fn handle(
         }
     };
 
-    let mut parsed = match run_attempt(state.clone(), key_ctx.clone(), anthropic_req, &model).await
-    {
-        Ok(parsed) => parsed,
-        Err(response) => return response,
-    };
+    let first_attempt =
+        match run_attempt(state.clone(), key_ctx.clone(), anthropic_req, &model).await {
+            Ok(parsed) => Some(parsed),
+            Err(AttemptError::ContextOverflow) => None,
+            Err(AttemptError::Response(response)) => return response,
+        };
+    let mut accumulated_usage = CompactionUsage::default();
+    if let Some(parsed) = &first_attempt {
+        accumulated_usage.add(parsed);
+    }
+    let context_overflow = first_attempt
+        .as_ref()
+        .is_none_or(|parsed| parsed.upstream_stop_reason == CONTEXT_WINDOW_EXCEEDED);
+    let mut final_parsed = first_attempt;
 
-    if parsed.upstream_stop_reason == CONTEXT_WINDOW_EXCEEDED {
-        let stats = truncate_large_tool_outputs(&mut retry_req.input);
+    if context_overflow {
+        let stats = bound_tool_outputs_for_retry(&mut retry_req.input);
         if stats.items > 0 {
             tracing::warn!(
                 model = %model,
                 truncated_tool_outputs = stats.items,
                 removed_bytes = stats.removed_bytes,
+                original_tool_output_bytes = stats.original_bytes,
+                retained_tool_output_bytes = stats.retained_bytes,
                 "Kiro compaction exceeded the context window; retrying with bounded tool outputs"
             );
             let retry = match prepare_request(retry_req, metadata) {
@@ -118,9 +140,13 @@ pub(super) async fn handle(
                     );
                 }
             };
-            parsed = match run_attempt(state, key_ctx, retry, &model).await {
-                Ok(parsed) => parsed,
-                Err(response) => return response,
+            final_parsed = match run_attempt(state, key_ctx, retry, &model).await {
+                Ok(parsed) => {
+                    accumulated_usage.add(&parsed);
+                    Some(parsed)
+                }
+                Err(AttemptError::ContextOverflow) => None,
+                Err(AttemptError::Response(response)) => return response,
             };
         } else {
             tracing::warn!(
@@ -130,7 +156,11 @@ pub(super) async fn handle(
         }
     }
 
-    let outcome = validate(parsed);
+    let usage = accumulated_usage.into_json();
+    let outcome = match final_parsed {
+        Some(parsed) => validate(parsed, usage),
+        None => context_overflow_outcome(usage),
+    };
     if want_stream {
         render_stream(outcome, &model)
     } else {
@@ -146,7 +176,7 @@ fn prepare_request(
     anthropic_req.stream = false;
     anthropic_req.tools = None;
     anthropic_req.tool_choice = None;
-    append_summary_request(&mut anthropic_req);
+    prepare_summary_turn(&mut anthropic_req)?;
     anthropic_req
         .system
         .get_or_insert_with(Vec::new)
@@ -157,42 +187,97 @@ fn prepare_request(
     Ok(anthropic_req)
 }
 
+enum AttemptError {
+    ContextOverflow,
+    Response(Response),
+}
+
 async fn run_attempt(
     state: AppState,
     key_ctx: KeyContext,
     anthropic_req: MessagesRequest,
     model: &str,
-) -> Result<ParsedResponse, Response> {
-    let inner = post_messages(State(state), Extension(key_ctx), Json(anthropic_req)).await;
-    let status = inner.status();
-    let body = match to_bytes(inner.into_body(), MAX_INNER_BODY).await {
-        Ok(body) => body,
-        Err(error) => {
-            return Err(responses_error(
-                StatusCode::BAD_GATEWAY,
-                "api_error",
-                &format!("failed to read compaction response: {error}"),
-            ));
+) -> Result<ParsedResponse, AttemptError> {
+    let provider = match &state.kiro_provider {
+        Some(provider) => provider.clone(),
+        None => {
+            return Err(AttemptError::Response(responses_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "service_unavailable",
+                "Kiro API provider not configured",
+            )));
         }
     };
-    if !status.is_success() {
-        return Err(Response::builder()
-            .status(status)
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(body))
-            .unwrap());
-    }
-    let anthropic: Value = match serde_json::from_slice(&body) {
-        Ok(value) => value,
-        Err(error) => {
-            return Err(responses_error(
-                StatusCode::BAD_GATEWAY,
-                "api_error",
-                &format!("failed to parse compaction response: {error}"),
-            ));
-        }
+
+    let conversion = convert_request_with_purpose(
+        &anthropic_req,
+        state.tool_compatibility_mode,
+        ConversionPurpose::Compact,
+    )
+    .map_err(|error| {
+        AttemptError::Response(responses_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            &error.to_string(),
+        ))
+    })?;
+    let kiro_request = KiroRequest {
+        conversation_state: conversion.conversation_state,
+        profile_arn: None,
+        additional_model_request_fields: conversion.additional_model_request_fields,
     };
-    let parsed = parse_anthropic_message(&anthropic, &model);
+    let request_body = serde_json::to_string(&kiro_request).map_err(|error| {
+        AttemptError::Response(responses_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+            &format!("failed to serialize compaction request: {error}"),
+        ))
+    })?;
+    tracing::debug!("Kiro compaction request body: {}", request_body);
+
+    let input_tokens = token::count_all_tokens(
+        anthropic_req.model.clone(),
+        anthropic_req.system.clone(),
+        anthropic_req.messages.clone(),
+        anthropic_req.tools.clone(),
+    ) as i32;
+    let hook = UsageRecordHook::from_state(&state, key_ctx.key_id, model.to_string());
+    let cache_usage = state
+        .cache_meter
+        .as_ref()
+        .map(|cache| {
+            super::super::cache_metering::compute_cache_usage(cache, &anthropic_req, key_ctx.key_id)
+        })
+        .unwrap_or_default();
+    let tracer = new_non_stream_request_tracer(&state, key_ctx.clone(), model.to_string());
+    let anthropic = execute_non_stream_request(
+        provider,
+        &request_body,
+        model,
+        input_tokens,
+        false,
+        conversion.tool_name_map,
+        hook,
+        cache_usage,
+        tracer,
+        key_ctx.group.clone(),
+    )
+    .await
+    .map_err(|error| match error {
+        NonStreamExecutionError::Provider(error)
+            if error
+                .downcast_ref::<crate::kiro::error::UpstreamContextOverflowError>()
+                .is_some() =>
+        {
+            AttemptError::ContextOverflow
+        }
+        NonStreamExecutionError::Provider(error) => {
+            AttemptError::Response(map_provider_error(error))
+        }
+        NonStreamExecutionError::Response(response) => AttemptError::Response(response),
+    })?;
+
+    let parsed = parse_anthropic_message(&anthropic, model);
     tracing::info!(
         model = %model,
         stop_reason = %parsed.upstream_stop_reason,
@@ -203,54 +288,174 @@ async fn run_attempt(
     Ok(parsed)
 }
 
-/// A Kiro compaction pass is a fresh user turn over the history being
-/// summarized. Always append it so an assistant reply, an unanswered user
-/// message, or a tool result can never become the active generation turn.
-fn append_summary_request(req: &mut MessagesRequest) {
-    req.messages.push(Message {
-        role: "user".to_string(),
-        content: json!([{
-            "type": "text",
-            "text": SUMMARY_REQUEST,
-        }]),
-    });
+/// Keep the last real turn as Kiro's current message whenever it is already a
+/// user turn. Only assistant-ended history needs a synthetic user turn because
+/// Kiro cannot generate from an assistant prefill.
+fn prepare_summary_turn(req: &mut MessagesRequest) -> Result<(), String> {
+    let tool_names = historical_tool_names(&req.messages);
+    let last = req
+        .messages
+        .last_mut()
+        .ok_or_else(|| "compaction input must contain at least one message".to_string())?;
+
+    match last.role.as_str() {
+        "user" => append_text_block(&mut last.content, SUMMARY_REQUEST)?,
+        "assistant" => {
+            let cancelled = terminal_tool_uses(&last.content)
+                .into_iter()
+                .map(|(id, _)| {
+                    json!({
+                        "type": "tool_result",
+                        "tool_use_id": id,
+                        "content": CANCELLED_TOOL_RESULT,
+                        "is_error": true,
+                    })
+                })
+                .chain(std::iter::once(json!({
+                    "type": "text",
+                    "text": SUMMARY_REQUEST,
+                })))
+                .collect::<Vec<_>>();
+            req.messages.push(Message {
+                role: "user".to_string(),
+                content: Value::Array(cancelled),
+            });
+        }
+        role => return Err(format!("unsupported final compaction message role: {role}")),
+    }
+
+    if !tool_names.is_empty() {
+        let mapping = serde_json::to_string(&tool_names)
+            .map_err(|error| format!("failed to serialize historical tool mapping: {error}"))?;
+        req.system
+            .get_or_insert_with(Vec::new)
+            .push(SystemMessage {
+                text: format!(
+                    "Historical tool calls are represented by an inert placeholder in the upstream request. The original call_id to tool-name mapping is: {mapping}"
+                ),
+                cache_control: None,
+            });
+    }
+    Ok(())
+}
+
+fn append_text_block(content: &mut Value, text: &str) -> Result<(), String> {
+    match content {
+        Value::Array(blocks) => blocks.push(json!({ "type": "text", "text": text })),
+        Value::String(existing) => {
+            let existing = std::mem::take(existing);
+            *content = json!([
+                { "type": "text", "text": existing },
+                { "type": "text", "text": text }
+            ]);
+        }
+        _ => return Err("final user message has unsupported content".to_string()),
+    }
+    Ok(())
+}
+
+fn terminal_tool_uses(content: &Value) -> Vec<(String, String)> {
+    content
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
+        .filter_map(|block| {
+            Some((
+                block.get("id")?.as_str()?.to_string(),
+                block.get("name")?.as_str()?.to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn historical_tool_names(messages: &[Message]) -> std::collections::BTreeMap<String, String> {
+    messages
+        .iter()
+        .filter(|message| message.role == "assistant")
+        .flat_map(|message| terminal_tool_uses(&message.content))
+        .collect()
 }
 
 #[derive(Default)]
 struct TruncationStats {
     items: usize,
     removed_bytes: usize,
+    original_bytes: usize,
+    retained_bytes: usize,
 }
 
 /// Applies Kiro's aggressive compaction bound only after a confirmed context
 /// overflow. The Responses item and call id remain intact, so tool pairing is
 /// preserved when the retry is translated back to Kiro history.
-fn truncate_large_tool_outputs(input: &mut Value) -> TruncationStats {
+fn bound_tool_outputs_for_retry(input: &mut Value) -> TruncationStats {
     let mut stats = TruncationStats::default();
     let Some(items) = input.as_array_mut() else {
         return stats;
     };
-    for item in items {
-        let item_type = item.get("type").and_then(Value::as_str);
-        if !matches!(
-            item_type,
-            Some("function_call_output" | "custom_tool_call_output")
-        ) {
-            continue;
-        }
-        let Some(output) = item.get_mut("output") else {
-            continue;
-        };
-        let text = super::stringify_output(Some(output));
-        if text.len() <= TOOL_OUTPUT_RETRY_LIMIT_BYTES {
-            continue;
-        }
-        let original_bytes = text.len();
-        let truncated = truncate_middle(&text, TOOL_OUTPUT_RETRY_LIMIT_BYTES);
-        stats.items += 1;
-        stats.removed_bytes += original_bytes.saturating_sub(truncated.len());
-        *output = Value::String(truncated);
+
+    let outputs = items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            let item_type = item.get("type").and_then(Value::as_str);
+            if !matches!(
+                item_type,
+                Some("function_call_output" | "custom_tool_call_output")
+            ) {
+                return None;
+            }
+            let output = item.get("output")?;
+            let text = match output {
+                Value::String(text) => text.clone(),
+                structured => structured.to_string(),
+            };
+            Some((index, text))
+        })
+        .collect::<Vec<_>>();
+
+    stats.original_bytes = outputs.iter().map(|(_, text)| text.len()).sum();
+    stats.retained_bytes = stats.original_bytes;
+    if stats.original_bytes <= TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES || outputs.is_empty() {
+        return stats;
     }
+
+    // Every result retains at least an equal floor. Any remaining excess is
+    // removed oldest-first, which leaves the newest results intact whenever
+    // the aggregate budget allows it.
+    let per_item_floor =
+        TOOL_OUTPUT_RETRY_MIN_BYTES.min(TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES / outputs.len());
+    let mut excess = stats
+        .original_bytes
+        .saturating_sub(TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES);
+
+    for (index, text) in outputs {
+        if excess == 0 {
+            break;
+        }
+        let minimum = per_item_floor.min(text.len());
+        let removed = excess.min(text.len().saturating_sub(minimum));
+        if removed == 0 {
+            continue;
+        }
+        let target = text.len().saturating_sub(removed);
+        let truncated = truncate_middle(&text, target);
+        let actual_removed = text.len().saturating_sub(truncated.len());
+        if actual_removed == 0 {
+            continue;
+        }
+        if let Some(output) = items[index].get_mut("output") {
+            *output = Value::String(truncated);
+        }
+        stats.items += 1;
+        stats.removed_bytes = stats.removed_bytes.saturating_add(actual_removed);
+        stats.retained_bytes = stats.retained_bytes.saturating_sub(actual_removed);
+        excess = excess.saturating_sub(actual_removed);
+    }
+
+    // `truncate_middle` never exceeds its target, so this can only fail if a
+    // future output representation stops being mutable in place.
+    debug_assert!(stats.retained_bytes <= TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES);
     stats
 }
 
@@ -304,17 +509,87 @@ enum Outcome {
     },
 }
 
-fn validate(parsed: ParsedResponse) -> Outcome {
-    let usage = usage(&parsed);
+#[derive(Default)]
+struct CompactionUsage {
+    input_tokens: i64,
+    cached_tokens: i64,
+    output_tokens: i64,
+    credit_usage: Option<f64>,
+    credit_unit: Option<String>,
+    credit_unit_plural: Option<String>,
+    credit_units_consistent: bool,
+}
+
+impl CompactionUsage {
+    fn add(&mut self, parsed: &ParsedResponse) {
+        self.input_tokens = self
+            .input_tokens
+            .saturating_add(parsed.prompt_tokens.max(0));
+        self.cached_tokens = self
+            .cached_tokens
+            .saturating_add(parsed.cached_tokens.max(0));
+        self.output_tokens = self
+            .output_tokens
+            .saturating_add(parsed.completion_tokens.max(0));
+
+        let Some(credit_usage) = parsed.credit_usage else {
+            return;
+        };
+        if self.credit_usage.is_none() {
+            self.credit_units_consistent = true;
+            self.credit_unit = parsed.credit_unit.clone();
+            self.credit_unit_plural = parsed.credit_unit_plural.clone();
+        } else if option_strings_conflict(&self.credit_unit, &parsed.credit_unit)
+            || option_strings_conflict(&self.credit_unit_plural, &parsed.credit_unit_plural)
+        {
+            self.credit_units_consistent = false;
+            tracing::warn!(
+                previous_unit = ?self.credit_unit,
+                retry_unit = ?parsed.credit_unit,
+                "compaction retry returned inconsistent credit units; omitting credit metadata"
+            );
+        } else {
+            if self.credit_unit.is_none() {
+                self.credit_unit = parsed.credit_unit.clone();
+            }
+            if self.credit_unit_plural.is_none() {
+                self.credit_unit_plural = parsed.credit_unit_plural.clone();
+            }
+        }
+        self.credit_usage = Some(self.credit_usage.unwrap_or(0.0).max(0.0) + credit_usage.max(0.0));
+    }
+
+    fn into_json(self) -> Value {
+        let mut usage = json!({
+            "input_tokens": self.input_tokens,
+            "input_tokens_details": { "cached_tokens": self.cached_tokens },
+            "output_tokens": self.output_tokens,
+            "output_tokens_details": { "reasoning_tokens": 0 },
+            "total_tokens": self.input_tokens.saturating_add(self.output_tokens),
+        });
+        if self.credit_units_consistent {
+            if let Some(credit_usage) = self.credit_usage {
+                usage["credit_usage"] = json!(credit_usage);
+            }
+            if let Some(credit_unit) = self.credit_unit {
+                usage["credit_unit"] = json!(credit_unit);
+            }
+            if let Some(credit_unit_plural) = self.credit_unit_plural {
+                usage["credit_unit_plural"] = json!(credit_unit_plural);
+            }
+        }
+        usage
+    }
+}
+
+fn option_strings_conflict(left: &Option<String>, right: &Option<String>) -> bool {
+    matches!((left, right), (Some(left), Some(right)) if left != right)
+}
+
+fn validate(parsed: ParsedResponse, usage: Value) -> Outcome {
     match parsed.upstream_stop_reason.as_str() {
         "max_tokens" => return Outcome::Incomplete { usage },
-        CONTEXT_WINDOW_EXCEEDED => {
-            return Outcome::Failed {
-                code: "context_length_exceeded",
-                message: "upstream context window exceeded after compaction recovery".to_string(),
-                usage,
-            };
-        }
+        CONTEXT_WINDOW_EXCEEDED => return context_overflow_outcome(usage),
         _ => {}
     }
     if !parsed.tool_calls.is_empty() {
@@ -342,14 +617,12 @@ fn validate(parsed: ParsedResponse) -> Outcome {
     }
 }
 
-fn usage(parsed: &ParsedResponse) -> Value {
-    json!({
-        "input_tokens": parsed.prompt_tokens,
-        "input_tokens_details": { "cached_tokens": parsed.cached_tokens },
-        "output_tokens": parsed.completion_tokens,
-        "output_tokens_details": { "reasoning_tokens": 0 },
-        "total_tokens": parsed.prompt_tokens.saturating_add(parsed.completion_tokens),
-    })
+fn context_overflow_outcome(usage: Value) -> Outcome {
+    Outcome::Failed {
+        code: "context_length_exceeded",
+        message: "upstream context window exceeded after compaction recovery".to_string(),
+        usage,
+    }
 }
 
 fn response_object(id: &str, model: &str, status: &str, output: Vec<Value>, usage: Value) -> Value {
@@ -470,8 +743,20 @@ pub(super) fn restored_context(summary: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::converter::convert_request;
     use super::*;
+
+    fn convert_compact(
+        request: &MessagesRequest,
+    ) -> Result<
+        super::super::super::converter::ConversionResult,
+        super::super::super::converter::ConversionError,
+    > {
+        convert_request_with_purpose(
+            request,
+            crate::model::config::ToolCompatibilityMode::ClaudeCode,
+            ConversionPurpose::Compact,
+        )
+    }
 
     fn parsed(text: &str, upstream_stop_reason: &str) -> ParsedResponse {
         let finish_reason = match upstream_stop_reason {
@@ -494,6 +779,12 @@ mod tests {
             credit_unit: None,
             credit_unit_plural: None,
         }
+    }
+
+    fn validated(parsed: ParsedResponse) -> Outcome {
+        let mut usage = CompactionUsage::default();
+        usage.add(&parsed);
+        validate(parsed, usage.into_json())
     }
 
     #[test]
@@ -560,8 +851,8 @@ mod tests {
             { "type": "compaction_trigger" }
         ])));
 
-        append_summary_request(&mut request);
-        let converted = convert_request(&request).unwrap();
+        prepare_summary_turn(&mut request).unwrap();
+        let converted = convert_compact(&request).unwrap();
 
         assert_eq!(
             converted
@@ -594,21 +885,26 @@ mod tests {
             { "type": "compaction_trigger" }
         ])));
 
-        append_summary_request(&mut request);
-        let converted = convert_request(&request).unwrap();
-        assert_eq!(
-            converted
-                .conversation_state
-                .current_message
-                .user_input_message
-                .content,
-            SUMMARY_REQUEST
-        );
-        assert!(converted.conversation_state.history.iter().any(|message| {
+        prepare_summary_turn(&mut request).unwrap();
+        let converted = convert_compact(&request).unwrap();
+        let current = &converted
+            .conversation_state
+            .current_message
+            .user_input_message;
+        assert!(current.content.contains(FINAL_USER_MARKER));
+        assert!(current.content.contains(SUMMARY_REQUEST));
+        assert!(!converted.conversation_state.history.iter().any(|message| {
             matches!(
                 message,
                 crate::kiro::model::requests::conversation::Message::User(user)
                     if user.user_input_message.content.contains(FINAL_USER_MARKER)
+            )
+        }));
+        assert!(!converted.conversation_state.history.iter().any(|message| {
+            matches!(
+                message,
+                crate::kiro::model::requests::conversation::Message::Assistant(assistant)
+                    if assistant.assistant_response_message.content == "OK"
             )
         }));
     }
@@ -632,41 +928,148 @@ mod tests {
             { "type": "compaction_trigger" }
         ])));
 
-        append_summary_request(&mut request);
-        let converted = convert_request(&request).unwrap();
+        prepare_summary_turn(&mut request).unwrap();
+        let converted = convert_compact(&request).unwrap();
         let current = &converted
             .conversation_state
             .current_message
             .user_input_message;
 
-        assert_eq!(current.content, SUMMARY_REQUEST);
+        assert!(current.content.contains(SUMMARY_REQUEST));
         assert!(
-            current.user_input_message_context.tool_results.is_empty(),
-            "historical tool results must not drive the compaction turn"
+            current
+                .user_input_message_context
+                .tool_results
+                .iter()
+                .any(|result| {
+                    result.tool_use_id == "call_70c4"
+                        && result.content.iter().any(|content| {
+                            content.get("text").and_then(Value::as_str) == Some(TOOL_RESULT_MARKER)
+                        })
+                })
         );
-        assert!(converted.conversation_state.history.iter().any(|message| {
+        assert!(!converted.conversation_state.history.iter().any(|message| {
             matches!(
                 message,
                 crate::kiro::model::requests::conversation::Message::User(user)
-                    if user
-                        .user_input_message
-                        .user_input_message_context
-                        .tool_results
-                        .iter()
-                        .any(|result| {
-                            result.tool_use_id == "call_70c4"
-                                && result.content.iter().any(|content| {
-                                    content.get("text").and_then(Value::as_str)
-                                        == Some(TOOL_RESULT_MARKER)
-                                })
-                        })
+                    if user.user_input_message.user_input_message_context.tool_results.iter()
+                        .any(|result| result.tool_use_id == "call_70c4")
             )
         }));
+        let assistant_tool = converted
+            .conversation_state
+            .history
+            .iter()
+            .find_map(|message| match message {
+                crate::kiro::model::requests::conversation::Message::Assistant(assistant) => {
+                    assistant.assistant_response_message.tool_uses.as_ref()
+                }
+                _ => None,
+            })
+            .and_then(|uses| uses.first())
+            .unwrap();
+        assert_eq!(assistant_tool.name, "kiro_compaction_history_tool");
+        let tools = &current.user_input_message_context.tools;
+        assert_eq!(tools.len(), 1);
+        assert_eq!(
+            tools[0].tool_specification.name,
+            "kiro_compaction_history_tool"
+        );
+        assert_ne!(tools[0].tool_specification.name, "shell");
+    }
+
+    #[test]
+    fn unfinished_terminal_tool_call_gets_explicit_cancelled_result() {
+        let mut request = translate_compact_input(compact_request(json!([
+            { "type": "message", "role": "user", "content": "run it" },
+            {
+                "type": "function_call",
+                "call_id": "call_pending",
+                "name": "exec",
+                "arguments": "{\"command\":\"pwd\",\"timeout\":1000}"
+            },
+            { "type": "compaction_trigger" }
+        ])));
+
+        prepare_summary_turn(&mut request).unwrap();
+        assert!(
+            request
+                .system
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|part| { part.text.contains("call_pending") && part.text.contains("exec") })
+        );
+
+        let converted = convert_compact(&request).unwrap();
+        let current = &converted
+            .conversation_state
+            .current_message
+            .user_input_message;
+        let cancelled = current
+            .user_input_message_context
+            .tool_results
+            .iter()
+            .find(|result| result.tool_use_id == "call_pending")
+            .unwrap();
+        assert_eq!(cancelled.status.as_deref(), Some("error"));
+        assert!(cancelled.content.iter().any(|part| {
+            part.get("text")
+                .and_then(Value::as_str)
+                .is_some_and(|text| text.contains("interrupted before compaction"))
+        }));
+
+        let historical_use = converted
+            .conversation_state
+            .history
+            .iter()
+            .find_map(|message| match message {
+                crate::kiro::model::requests::conversation::Message::Assistant(assistant) => {
+                    assistant.assistant_response_message.tool_uses.as_ref()
+                }
+                _ => None,
+            })
+            .and_then(|uses| uses.first())
+            .unwrap();
+        assert_eq!(historical_use.tool_use_id, "call_pending");
+        assert_eq!(historical_use.name, "kiro_compaction_history_tool");
+        assert_eq!(historical_use.input["command"], "pwd");
+        assert_eq!(historical_use.input["timeout"], 1000);
+    }
+
+    #[test]
+    fn compact_rejects_orphaned_current_tool_result() {
+        let request = MessagesRequest {
+            model: "gpt-5.6-sol".to_string(),
+            max_tokens: 1024,
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: json!([
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "missing_call",
+                        "content": "output"
+                    },
+                    { "type": "text", "text": SUMMARY_REQUEST }
+                ]),
+            }],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            metadata: None,
+            thinking: None,
+            output_config: None,
+        };
+        assert!(matches!(
+            convert_compact(&request),
+            Err(super::super::super::converter::ConversionError::InvalidMessageSequence(_))
+        ));
     }
 
     #[test]
     fn completed_summary_emits_exactly_one_compaction_item() {
-        let response = render_stream(validate(parsed("handoff", "end_turn")), "gpt-5.6-sol");
+        let response = render_stream(validated(parsed("handoff", "end_turn")), "gpt-5.6-sol");
         let body =
             futures::executor::block_on(to_bytes(response.into_body(), 1024 * 1024)).unwrap();
         let body = String::from_utf8(body.to_vec()).unwrap();
@@ -678,14 +1081,14 @@ mod tests {
 
     #[test]
     fn truncated_or_empty_summary_never_emits_compaction_item() {
-        let incomplete = render_stream(validate(parsed("partial", "max_tokens")), "gpt-5.6-sol");
+        let incomplete = render_stream(validated(parsed("partial", "max_tokens")), "gpt-5.6-sol");
         let incomplete =
             futures::executor::block_on(to_bytes(incomplete.into_body(), 1024 * 1024)).unwrap();
         let incomplete = String::from_utf8(incomplete.to_vec()).unwrap();
         assert!(incomplete.contains("event: response.incomplete"));
         assert!(!incomplete.contains("\"type\":\"compaction\""));
 
-        let failed = render_stream(validate(parsed("   ", "end_turn")), "gpt-5.6-sol");
+        let failed = render_stream(validated(parsed("   ", "end_turn")), "gpt-5.6-sol");
         let failed =
             futures::executor::block_on(to_bytes(failed.into_body(), 1024 * 1024)).unwrap();
         let failed = String::from_utf8(failed.to_vec()).unwrap();
@@ -694,9 +1097,29 @@ mod tests {
     }
 
     #[test]
+    fn upstream_tool_call_never_becomes_a_compaction_item() {
+        let mut response = parsed("", "tool_use");
+        response.tool_calls.push(json!({
+            "id": "call_dummy",
+            "type": "function",
+            "function": {
+                "name": "kiro_compaction_history_tool",
+                "arguments": "{}"
+            }
+        }));
+        let response = render_stream(validated(response), "gpt-5.6-sol");
+        let body =
+            futures::executor::block_on(to_bytes(response.into_body(), 1024 * 1024)).unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains("event: response.failed"));
+        assert!(body.contains("upstream returned a tool call"));
+        assert!(!body.contains("\"type\":\"compaction\""));
+    }
+
+    #[test]
     fn context_overflow_is_not_reported_as_max_output_tokens() {
         let response = render_stream(
-            validate(parsed("partial", CONTEXT_WINDOW_EXCEEDED)),
+            validated(parsed("partial", CONTEXT_WINDOW_EXCEEDED)),
             "gpt-5.6-sol",
         );
         let body =
@@ -714,7 +1137,7 @@ mod tests {
     fn retry_truncation_preserves_tool_item_pairing_and_summary_turn() {
         let large_output = format!(
             "BEGIN:{}:END",
-            "x".repeat(TOOL_OUTPUT_RETRY_LIMIT_BYTES + 1000)
+            "x".repeat(TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES + 1000)
         );
         let mut request = compact_request(json!([
             { "type": "message", "role": "user", "content": "run it" },
@@ -734,7 +1157,7 @@ mod tests {
         ]));
         request.input.as_array_mut().unwrap().pop();
 
-        let stats = truncate_large_tool_outputs(&mut request.input);
+        let stats = bound_tool_outputs_for_retry(&mut request.input);
         assert_eq!(stats.items, 1);
         assert!(stats.removed_bytes > 0);
         let items = request.input.as_array().unwrap();
@@ -742,35 +1165,28 @@ mod tests {
         assert_eq!(output_item["type"], "function_call_output");
         assert_eq!(output_item["call_id"], "call_large");
         let output = output_item["output"].as_str().unwrap();
-        assert!(output.len() <= TOOL_OUTPUT_RETRY_LIMIT_BYTES);
+        assert!(output.len() <= TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES);
         assert!(output.starts_with("BEGIN:"));
         assert!(output.ends_with(":END"));
         assert!(output.contains("tool output truncated for compaction retry"));
         assert_eq!(items[3]["content"], "small history stays intact");
 
         let mut anthropic = responses_to_anthropic(request, None).unwrap().0;
-        append_summary_request(&mut anthropic);
-        let converted = convert_request(&anthropic).unwrap();
-        assert_eq!(
-            converted
-                .conversation_state
-                .current_message
-                .user_input_message
-                .content,
-            SUMMARY_REQUEST
+        prepare_summary_turn(&mut anthropic).unwrap();
+        let converted = convert_compact(&anthropic).unwrap();
+        let current = &converted
+            .conversation_state
+            .current_message
+            .user_input_message;
+        assert!(current.content.contains("small history stays intact"));
+        assert!(current.content.contains(SUMMARY_REQUEST));
+        assert!(
+            current
+                .user_input_message_context
+                .tool_results
+                .iter()
+                .any(|result| result.tool_use_id == "call_large")
         );
-        assert!(converted.conversation_state.history.iter().any(|message| {
-            matches!(
-                message,
-                crate::kiro::model::requests::conversation::Message::User(user)
-                    if user
-                        .user_input_message
-                        .user_input_message_context
-                        .tool_results
-                        .iter()
-                        .any(|result| result.tool_use_id == "call_large")
-            )
-        }));
     }
 
     #[test]
@@ -779,6 +1195,109 @@ mod tests {
         let truncated = truncate_middle(&text, 1000);
         assert!(truncated.len() <= 1000);
         assert!(truncated.contains("tool output truncated for compaction retry"));
+    }
+
+    #[test]
+    fn retry_budget_bounds_many_individually_small_outputs_and_keeps_newest() {
+        let newest = format!("NEWEST:{}", "n".repeat(9_990));
+        let mut input = Value::Array(
+            (0..4)
+                .map(|index| {
+                    json!({
+                        "type": "function_call_output",
+                        "call_id": format!("call_{index}"),
+                        "output": if index == 3 {
+                            newest.clone()
+                        } else {
+                            format!("OLD_{index}:{}", "o".repeat(9_993))
+                        }
+                    })
+                })
+                .collect(),
+        );
+
+        let stats = bound_tool_outputs_for_retry(&mut input);
+        assert!(stats.items > 0);
+        assert!(stats.original_bytes > TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES);
+        assert!(stats.retained_bytes <= TOOL_OUTPUT_RETRY_TOTAL_BUDGET_BYTES);
+        let items = input.as_array().unwrap();
+        assert_eq!(items[3]["output"].as_str(), Some(newest.as_str()));
+        assert!(
+            items[0]["output"]
+                .as_str()
+                .unwrap()
+                .contains("tool output truncated for compaction retry")
+        );
+    }
+
+    #[test]
+    fn retry_usage_accumulates_tokens_and_credit_metadata() {
+        let mut first = parsed("partial", CONTEXT_WINDOW_EXCEEDED);
+        first.credit_usage = Some(0.25);
+        first.credit_unit = Some("credit".to_string());
+        first.credit_unit_plural = Some("credits".to_string());
+        let mut second = parsed("summary", "end_turn");
+        second.prompt_tokens = 20;
+        second.cached_tokens = 3;
+        second.completion_tokens = 6;
+        second.credit_usage = Some(0.5);
+        second.credit_unit = Some("credit".to_string());
+        second.credit_unit_plural = Some("credits".to_string());
+
+        let mut usage = CompactionUsage::default();
+        usage.add(&first);
+        usage.add(&second);
+        let usage = usage.into_json();
+        assert_eq!(usage["input_tokens"], 30);
+        assert_eq!(usage["input_tokens_details"]["cached_tokens"], 5);
+        assert_eq!(usage["output_tokens"], 10);
+        assert_eq!(usage["total_tokens"], 40);
+        assert_eq!(usage["credit_usage"], 0.75);
+        assert_eq!(usage["credit_unit"], "credit");
+        assert_eq!(usage["credit_unit_plural"], "credits");
+    }
+
+    #[test]
+    fn generate_wrapper_keeps_the_existing_conversion_behavior() {
+        let request = MessagesRequest {
+            model: "gpt-5.6-sol".to_string(),
+            max_tokens: 1024,
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: json!([{ "type": "text", "text": "hello" }]),
+            }],
+            stream: false,
+            system: None,
+            tools: None,
+            tool_choice: None,
+            metadata: None,
+            thinking: None,
+            output_config: None,
+        };
+        let wrapper = super::super::super::converter::convert_request_with_mode(
+            &request,
+            crate::model::config::ToolCompatibilityMode::ClaudeCode,
+        )
+        .unwrap();
+        let explicit = convert_request_with_purpose(
+            &request,
+            crate::model::config::ToolCompatibilityMode::ClaudeCode,
+            ConversionPurpose::Generate,
+        )
+        .unwrap();
+        let normalize = |state| {
+            let mut value = serde_json::to_value(state).unwrap();
+            let object = value.as_object_mut().unwrap();
+            object.remove("conversationId");
+            object.remove("agentContinuationId");
+            value
+        };
+        assert_eq!(
+            normalize(wrapper.conversation_state),
+            normalize(explicit.conversation_state)
+        );
+        assert_eq!(wrapper.tool_name_map, explicit.tool_name_map);
+        assert_eq!(wrapper.known_tool_names, explicit.known_tool_names);
     }
 
     #[test]

--- a/src/anthropic/websearch_loop.rs
+++ b/src/anthropic/websearch_loop.rs
@@ -403,6 +403,10 @@ async fn run_round(
                 ConversionError::EmptyMessages => {
                     ("invalid_request_error", "message list is empty".to_string())
                 }
+                ConversionError::InvalidMessageSequence(reason) => (
+                    "invalid_request_error",
+                    format!("invalid message sequence: {}", reason),
+                ),
                 ConversionError::UnsupportedToolMapping(reason) => (
                     "invalid_request_error",
                     format!("unsupported tool mapping: {}", reason),

--- a/src/kiro/error.rs
+++ b/src/kiro/error.rs
@@ -7,6 +7,13 @@ pub struct UpstreamRateLimitError {
     retry_after: Option<String>,
 }
 
+/// Kiro rejected the serialized conversation because it exceeded the model's
+/// context limit. Keeping this typed at the provider boundary lets compact
+/// retry once without reverse-engineering an HTTP error response.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("upstream context window exceeded")]
+pub struct UpstreamContextOverflowError;
+
 impl UpstreamRateLimitError {
     pub(crate) fn new(retry_after: Option<String>) -> Self {
         Self {

--- a/src/kiro/provider.rs
+++ b/src/kiro/provider.rs
@@ -14,7 +14,7 @@ use tokio::time::sleep;
 use crate::admin::trace_db::{TraceAttempt, TraceSink, outcome, truncate_snippet};
 use crate::http_client::{ProxyConfig, build_client};
 use crate::kiro::endpoint::{KiroEndpoint, RequestContext};
-use crate::kiro::error::UpstreamRateLimitError;
+use crate::kiro::error::{UpstreamContextOverflowError, UpstreamRateLimitError};
 use crate::kiro::machine_id;
 use crate::kiro::model::credentials::KiroCredentials;
 use crate::kiro::token_manager::MultiTokenManager;
@@ -911,6 +911,9 @@ impl KiroProvider {
                     sink, attempt, ctx.id, endpoint_name, Some(400),
                     outcome::BAD_REQUEST, Some(&body), attempt_start,
                 );
+                if body.contains("CONTENT_LENGTH_EXCEEDS_THRESHOLD") {
+                    return Err(UpstreamContextOverflowError.into());
+                }
                 anyhow::bail!("{} API 请求失败: {} {}", api_type, status, body);
             }
 


### PR DESCRIPTION
## 问题背景

Codex 在以下场景会发起 remote compaction：

- 用户手动执行 `/compact`；
- 上下文达到阈值后自动 compact。

这类请求会在 Responses input 末尾携带 `compaction_trigger`，并要求服务端返回且只返回一个 `compaction` output item。

kiro-rs 原有 Responses 兼容层没有实现该协议，compact 请求会进入普通生成路径，最终返回普通 assistant message。Codex 因此无法取得 compaction item，并报告：

```text
remote compaction v2 expected exactly one compaction output item, got 0 from 1 output items
```

在上下文较长或包含工具调用历史时，也可能表现为 compact 请求返回 tool call、上下文窗口溢出或响应未完整结束。

## 原因分析

Kiro 不原生支持 OpenAI Responses 的 `compaction_trigger` 和 `compaction` item。

要兼容 Codex，需要在 kiro-rs 内完成协议适配：

1. 识别 Codex 的 remote compaction 请求；
2. 将完整会话历史转换成合法的 Kiro 摘要请求；
3. 将 Kiro 返回的摘要封装成 Codex 要求的单个 `compaction` item；
4. 区分成功摘要、工具调用、输出截断和上下文溢出；
5. 保证手动和自动 compact 使用相同路径。

## 修改内容

### Remote compaction 路由

- 仅将 input 末尾唯一的 `compaction_trigger` 识别为 remote compaction。
- 手动 `/compact` 和自动 compact 使用同一处理路径。
- legacy checkpoint marker 和普通 Responses 请求继续使用原有生成路径。

### Kiro 摘要请求转换

- 为现有转换器增加内部 `Generate` 和 `Compact` 两种用途。
- 根据转换后的会话末尾角色构造合法的 Kiro current message。
- 完整保留 assistant 消息以及结构化的 `tool_use` / `tool_result` 历史。
- 保留工具调用 ID、参数和结果之间的配对关系。
- 对无法形成合法工具调用链的历史返回明确的转换错误。
- 历史工具统一映射为 compaction 专用 dummy tool，避免摘要阶段调用真实工具。

### Compaction 响应

- 成功时返回且只返回一个 `compaction` output item。
- 空摘要或上游返回 tool call 时返回明确的 compaction failure。
- `max_tokens` 等未完整响应返回 `incomplete`，不会将截断内容作为有效摘要。
- 同时支持流式和非流式 Responses 输出。

### 上下文溢出处理

- 在 provider 边界保留 Kiro 上下文溢出的错误类型。
- HTTP `CONTENT_LENGTH_EXCEEDS_THRESHOLD` 和生成阶段的 `model_context_window_exceeded` 使用统一处理逻辑。
- 第一次请求始终使用完整历史。
- 仅在确认上下文溢出后执行一次有界重试。
- 重试时对工具结果使用 25,000 字节总预算，优先保留较新的内容，同时保持工具调用结构和 ID 不变。
- 两次尝试的 token usage 和 credit usage 会合并统计。

## 兼容性

- 普通 `/v1/messages` 请求不受影响。
- 普通 `/v1/responses` 请求继续使用 `Generate` 模式。
- compact 模式由内部根据 `compaction_trigger` 选择，客户端不能直接伪造转换用途。
- 手动和自动 compact 共享相同实现。

## 验证

覆盖以下场景：

- 手动和自动 remote compaction 请求识别；
- legacy checkpoint marker 保持普通消息行为；
- assistant、user 和 tool result 结尾的会话；
- 完整工具调用历史及未完成工具调用；
- 空摘要、截断响应和上游 tool call；
- HTTP 与生成阶段的上下文溢出；
- 多个工具结果的总预算截断；
- UTF-8 安全截断；
- 重试 usage 累计；
- Generate 模式行为保持不变。

```text
cargo test --quiet
710 passed; 0 failed
```