### PR TITLE
fix(tool_call): resolve bare namespaced tool calls

### DIFF
--- a/src/anthropic/responses.rs
+++ b/src/anthropic/responses.rs
@@ -110,6 +110,29 @@ fn flat_tool_name(namespace: Option<&str>, name: &str) -> String {
     }
 }
 
+/// 将上游返回的工具名映射回请求里的声明。
+///
+/// Kiro 偶尔会把 namespaced 工具的展平名（如 `functions__exec`）返回为原名
+/// `exec`。精确匹配始终优先；仅当原名在本次请求中唯一时才接受裸名，避免在
+/// 多个 namespace 声明同名工具时猜错目标。
+fn resolve_declared_tool<'a>(
+    kinds: &'a ToolKindMap,
+    upstream_name: &str,
+) -> Option<(&'a DeclaredTool, bool)> {
+    if let Some(declared) = kinds.get(upstream_name) {
+        return Some((declared, false));
+    }
+
+    let mut matches = kinds
+        .values()
+        .filter(|declared| declared.name == upstream_name);
+    let declared = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some((declared, true))
+}
+
 // ============================ 请求类型 ============================
 
 #[derive(Debug, Deserialize)]
@@ -916,7 +939,14 @@ fn build_view(p: &ParsedResponse, kinds: &ToolKindMap) -> ResponsesView {
             .and_then(|v| v.as_str())
             .unwrap_or("{}")
             .to_string();
-        let decl = kinds.get(flat_name.as_str());
+        let resolution = resolve_declared_tool(kinds, flat_name.as_str());
+        if matches!(resolution, Some((_, true))) {
+            tracing::debug!(
+                upstream_tool_name = %flat_name,
+                "responses: resolved bare upstream tool name to a unique declaration"
+            );
+        }
+        let decl = resolution.map(|(declared, _)| declared);
         // 展平名还原：namespace 工具应答时用原名 + namespace 字段
         let (name, namespace) = match decl {
             Some(d) => (d.name.clone(), d.namespace.clone()),
@@ -1523,7 +1553,27 @@ impl ResponsesStreamContext {
             arguments = "{}".to_string();
         }
         let output_index = self.allocate_output_index();
-        let decl = self.tool_kinds.get(&flat_name);
+        let resolution = resolve_declared_tool(&self.tool_kinds, &flat_name);
+        let decl = resolution.map(|(declared, _)| declared);
+        match decl {
+            Some(declared) if matches!(resolution, Some((_, true))) => tracing::debug!(
+                upstream_tool_name = %flat_name,
+                declared_tool_name = %declared.name,
+                namespace = ?declared.namespace,
+                kind = ?declared.kind,
+                "responses: resolved bare upstream tool name to a unique declaration"
+            ),
+            Some(_) => {}
+            None => {
+                let mut known_tools = self.tool_kinds.keys().cloned().collect::<Vec<_>>();
+                known_tools.sort();
+                tracing::warn!(
+                    upstream_tool_name = %flat_name,
+                    known_tools = ?known_tools,
+                    "responses: upstream tool call was not present in the request registry"
+                );
+            }
+        }
         let (name, namespace, kind) = match decl {
             Some(d) => (d.name.clone(), d.namespace.clone(), d.kind),
             None => (flat_name, None, DeclaredToolKind::Function),
@@ -2203,6 +2253,22 @@ mod tests {
             .collect()
     }
 
+    fn namespaced_kind(
+        flat_name: &str,
+        name: &str,
+        namespace: &str,
+        kind: DeclaredToolKind,
+    ) -> ToolKindMap {
+        HashMap::from([(
+            flat_name.to_string(),
+            DeclaredTool {
+                kind,
+                name: name.to_string(),
+                namespace: Some(namespace.to_string()),
+            },
+        )])
+    }
+
     fn system_texts(req: &MessagesRequest) -> Vec<String> {
         req.system
             .as_ref()
@@ -2700,6 +2766,61 @@ mod tests {
     }
 
     #[test]
+    fn build_view_resolves_unique_bare_name_to_namespaced_custom_tool() {
+        let kinds = namespaced_kind(
+            "functions__exec",
+            "exec",
+            "functions",
+            DeclaredToolKind::Custom,
+        );
+        let p = parsed_with_tool_calls(vec![json!({
+            "id": "toolu_1",
+            "type": "function",
+            "function": { "name": "exec", "arguments": "{\"input\":\"pwd\"}" },
+        })]);
+
+        let view = build_view(&p, &kinds);
+        let item = view
+            .output
+            .iter()
+            .find(|item| item["type"] == "custom_tool_call")
+            .expect("the unique declared custom tool must be restored");
+        assert_eq!(item["name"], "exec");
+        assert_eq!(item["namespace"], "functions");
+        assert_eq!(item["input"], "pwd");
+    }
+
+    #[test]
+    fn declared_tool_resolution_prefers_exact_and_rejects_ambiguous_bare_names() {
+        let mut kinds = namespaced_kind(
+            "functions__exec",
+            "exec",
+            "functions",
+            DeclaredToolKind::Custom,
+        );
+        kinds.insert(
+            "exec".into(),
+            DeclaredTool {
+                kind: DeclaredToolKind::Function,
+                name: "exec".into(),
+                namespace: None,
+            },
+        );
+        let (exact, used_bare_fallback) = resolve_declared_tool(&kinds, "exec").unwrap();
+        assert_eq!(exact.kind, DeclaredToolKind::Function);
+        assert!(!used_bare_fallback);
+
+        kinds.remove("exec");
+        kinds.extend(namespaced_kind(
+            "other__exec",
+            "exec",
+            "other",
+            DeclaredToolKind::Custom,
+        ));
+        assert!(resolve_declared_tool(&kinds, "exec").is_none());
+    }
+
+    #[test]
     fn build_view_emits_function_call_for_function_and_unknown_kinds() {
         let kinds = kinds_of(&[("shell", DeclaredToolKind::Function)]);
         let p = parsed_with_tool_calls(vec![
@@ -2906,6 +3027,51 @@ mod tests {
         assert!(completed.contains("\"namespace\":\"collaboration\""));
         assert!(completed.contains("\"call_id\":\"toolu_1\""));
         assert!(!completed.contains("\"done_key\""));
+    }
+
+    #[test]
+    fn streaming_tool_resolves_unique_bare_name_to_namespaced_custom_tool() {
+        let kinds = namespaced_kind(
+            "functions__exec",
+            "exec",
+            "functions",
+            DeclaredToolKind::Custom,
+        );
+        let mut context = ResponsesStreamContext::new(
+            "gpt-5.6-sol".into(),
+            kinds,
+            ResponsesResponseConfig::default(),
+        );
+        context.initial_events();
+        feed_event(
+            &mut context,
+            "content_block_start",
+            json!({
+                "type": "content_block_start", "index": 1,
+                "content_block": {
+                    "type": "tool_use", "id": "toolu_1", "name": "exec", "input": {}
+                },
+            }),
+        );
+        feed_event(
+            &mut context,
+            "content_block_delta",
+            json!({
+                "type": "content_block_delta", "index": 1,
+                "delta": { "type": "input_json_delta", "partial_json": "{\"input\":\"pwd\"}" },
+            }),
+        );
+
+        let completed = feed_event(
+            &mut context,
+            "content_block_stop",
+            json!({ "type": "content_block_stop", "index": 1 }),
+        );
+        assert!(completed.contains("response.custom_tool_call_input.done"));
+        assert!(completed.contains("\"name\":\"exec\""));
+        assert!(completed.contains("\"namespace\":\"functions\""));
+        assert!(completed.contains("\"input\":\"pwd\""));
+        assert!(!completed.contains("response.function_call_arguments.done"));
     }
 
     #[test]


### PR DESCRIPTION
## 问题现象

  使用 Codex 执行 `/review` 或其他需要调用工具的任务时，可能出现：

  - `/review` 长时间停留在等待状态；
  - Codex 重复尝试调用同一个工具，但无法继续；
  - 工具调用直接显示 `aborted`；
  - 后续再次要求执行简单命令，工具仍可能无法恢复。

  该问题并非工具进程本身执行失败，而是部分 namespaced tool 的调用响应没有被正确还原，导致 Codex 无法识别和分发工具调用。

  ## 原因分析

  Codex 可以通过 namespace 声明工具，例如：

  ```text
  namespace: functions
  tool: exec
  type: custom
  ```

  kiro-rs 转发给 Anthropic/Kiro 时，需要将名称展平为：

  ```text
  functions__exec
  ```

  但 Kiro 偶尔会在响应中返回原始裸名：

  ```text
  exec
  ```

  此前响应转换只使用展平名 `functions__exec` 进行精确查找。收到裸名 `exec` 后，kiro-rs 无法找到原始声明，因而将其当成未知的普通 function tool，返回：

  ```json
  {
    "type": "function_call",
    "name": "exec"
  }
  ```

  Codex 实际声明并期待的是：

  ```json
  {
    "type": "custom_tool_call",
    "name": "exec",
    "namespace": "functions"
  }
  ```

  返回结果因此丢失了 namespace，并且工具类型从 `custom_tool_call` 错误变成了 `function_call`。

  Codex 无法将这个响应对应到原始工具声明，工具调用会被中止。Agent 随后可能再次尝试执行同一工具，因此表面上表现为 `/review` 一直等待、重复尝试，或者工具持续显
  示 `aborted`。

  ## 修改内容

  增加统一的工具声明解析规则：

  1. 始终优先匹配上游返回的精确名称。
  2. 精确匹配失败时，按声明中的原始工具名查找。
  3. 仅当裸名在当前请求中唯一时，恢复对应的 namespace 和工具类型。
  4. 多个 namespace 存在同名工具时不进行猜测，避免错误路由。
  5. 流式和非流式 Responses 输出使用相同的解析逻辑。

  修复后，上游返回裸名 `exec` 时，可以恢复为：

  ```json
  {
    "type": "custom_tool_call",
    "name": "exec",
    "namespace": "functions",
    "input": "pwd"
  }
  ```

  ## 修复边界

  该修改只处理“已声明 namespaced tool，但上游返回唯一裸名”的情况。

  - 普通非 namespace 工具行为不变；
  - 精确名称匹配仍具有最高优先级；
  - 裸名存在歧义时不会猜测目标；
  - 未声明的工具仍按原有兼容逻辑处理。

  ## 验证

  覆盖以下场景：

  - 唯一裸名恢复为 namespaced custom tool；
  - 精确名称优先于裸名 fallback；
  - 同名 namespace 存在歧义时拒绝猜测；
  - 流式和非流式响应使用一致的恢复规则；
  - 普通 function tool 行为保持不变。

  ```text
  cargo test --quiet
  693 passed; 0 failed
  ```